### PR TITLE
Add server-to-client sampling and resource update notifications

### DIFF
--- a/src/barrel_mcp.erl
+++ b/src/barrel_mcp.erl
@@ -91,6 +91,14 @@
     find/1
 ]).
 
+%% Server-to-client primitives (sampling + resource notifications).
+-export([
+    sampling_create_message/3,
+    list_sessions_with_sampling/0,
+    notify_resource_updated/1,
+    notify_resource_updated/2
+]).
+
 %%====================================================================
 %% Tool API
 %%====================================================================
@@ -591,3 +599,46 @@ all() ->
 -spec find(Name :: binary()) -> {ok, map()} | error.
 find(Name) ->
     barrel_mcp_registry:find(tool, Name).
+
+%%====================================================================
+%% Server -> Client primitives
+%%====================================================================
+
+%% @doc Send `sampling/createMessage' to the client behind a session.
+%% Requires the client to have declared sampling capability in its
+%% `initialize' request and an active SSE stream. Blocks until the
+%% client responds or `timeout_ms' (default 30s) elapses.
+-spec sampling_create_message(binary(), map(), map()) ->
+    {ok, Result :: map(), Usage :: map()}
+  | {error, timeout | not_supported | no_sse | not_found | term()}.
+sampling_create_message(SessionId, Params, Opts) ->
+    barrel_mcp_session:sampling_create_message(SessionId, Params, Opts).
+
+%% @doc Return the ids of currently connected sessions whose client
+%% declared sampling capability.
+-spec list_sessions_with_sampling() -> [binary()].
+list_sessions_with_sampling() ->
+    barrel_mcp_session:list_sampling_capable().
+
+%% @doc Notify all subscribers of a resource that it has changed.
+%% The notification body is a JSON-RPC notification with no params; the
+%% client is expected to issue a `resources/read' to fetch the new state.
+-spec notify_resource_updated(binary()) -> ok.
+notify_resource_updated(Uri) ->
+    notify_resource_updated(Uri, #{}).
+
+-spec notify_resource_updated(binary(), map()) -> ok.
+notify_resource_updated(Uri, Extra) when is_binary(Uri) ->
+    Subscribers = barrel_mcp_session:subscribers_for(Uri),
+    Notification = #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"method">> => <<"notifications/resources/updated">>,
+        <<"params">> => maps:merge(#{<<"uri">> => Uri}, Extra)
+    },
+    lists:foreach(fun(SessionId) ->
+        case barrel_mcp_session:get_sse_pid(SessionId) of
+            {ok, Pid} -> Pid ! {sse_send_message, Notification};
+            _ -> ok
+        end
+    end, Subscribers),
+    ok.

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -140,10 +140,22 @@ info({sse_event, EventId, Data}, Req, State) ->
     send_sse_event(Req, EventId, Data),
     {ok, Req, State};
 
+info({sse_send_message, Message}, Req, State) ->
+    %% Server-initiated message (e.g. sampling/createMessage request or a
+    %% notifications/resources/updated notification). Format as an SSE
+    %% event with a fresh id.
+    send_sse_event(Req, generate_event_id(), Message),
+    {ok, Req, State};
+
 info(_Info, Req, State) ->
     {ok, Req, State}.
 
-terminate(_Reason, _Req, _State) ->
+terminate(_Reason, _Req, State) ->
+    case maps:find(sse_session, State) of
+        {ok, SessionId} when is_binary(SessionId) ->
+            catch barrel_mcp_session:set_sse_pid(SessionId, undefined);
+        _ -> ok
+    end,
     ok.
 
 %%====================================================================
@@ -192,16 +204,34 @@ handle_post_authenticated(Req0, State) ->
     {ok, Body, Req1} = cowboy_req:read_body(Req0),
 
     case barrel_mcp_protocol:decode(Body) of
+        {ok, #{<<"id">> := RespId} = Request}
+                when is_map_key(<<"result">>, Request);
+                     is_map_key(<<"error">>, Request) ->
+            %% Inbound is a JSON-RPC RESPONSE (not a request) for an
+            %% earlier server-initiated call (e.g. sampling/createMessage).
+            %% Route to the waiting caller; reply 204.
+            _ = barrel_mcp_session:deliver_response(RespId, Request),
+            ResponseHeaders = add_session_header(cors_headers(), SessionId),
+            Req2 = cowboy_req:reply(204, ResponseHeaders, <<>>, Req1),
+            {ok, Req2, State1};
         {ok, Request} ->
             %% Add auth info to request context
             AuthInfo = maps:get(auth_info, State1, undefined),
+            ProtocolState = case SessionId of
+                undefined -> #{};
+                _ -> #{session_id => SessionId}
+            end,
+            ProtocolState1 = case AuthInfo of
+                undefined -> ProtocolState;
+                _ -> ProtocolState#{auth_info => AuthInfo}
+            end,
             RequestWithAuth = case AuthInfo of
                 undefined -> Request;
                 _ -> Request#{<<"_auth">> => AuthInfo}
             end,
 
             %% Handle the MCP request
-            case barrel_mcp_protocol:handle(RequestWithAuth) of
+            case barrel_mcp_protocol:handle(RequestWithAuth, ProtocolState1) of
                 no_response ->
                     %% Notification - return 204 No Content
                     ResponseHeaders = add_session_header(cors_headers(), SessionId),
@@ -264,6 +294,10 @@ handle_get_sse(Req0, State) ->
                             }, SessionId),
                             ResponseHeaders1 = maps:merge(ResponseHeaders, cors_headers()),
                             Req = cowboy_req:stream_reply(200, ResponseHeaders1, Req0),
+                            %% Register this process as the session's SSE
+                            %% pid so server-to-client primitives (sampling,
+                            %% notifications) can deliver messages here.
+                            _ = barrel_mcp_session:set_sse_pid(SessionId, self()),
                             %% Enter loop mode to handle SSE events
                             {cowboy_loop, Req, State#{sse_session => SessionId}};
                         {error, not_found} ->

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -82,9 +82,17 @@ notification_response() ->
 %% Request Handlers
 %%====================================================================
 
-handle_request(<<"initialize">>, _Params, Id, _State) ->
+handle_request(<<"initialize">>, Params, Id, State) ->
     ServerName = application:get_env(barrel_mcp, server_name, <<"barrel">>),
     ServerVersion = application:get_env(barrel_mcp, server_version, <<"1.0.0">>),
+    %% Persist client capabilities (notably `sampling') so the server can
+    %% later issue server-to-client requests via barrel_mcp_session.
+    case maps:find(session_id, State) of
+        {ok, SessionId} when is_binary(SessionId) ->
+            ClientCaps = maps:get(<<"capabilities">>, Params, #{}),
+            _ = barrel_mcp_session:set_client_capabilities(SessionId, ClientCaps);
+        _ -> ok
+    end,
     success_response(Id, #{
         <<"protocolVersion">> => ?MCP_PROTOCOL_VERSION,
         <<"capabilities">> => #{
@@ -158,6 +166,28 @@ handle_request(<<"resources/read">>, Params, Id, _State) ->
 handle_request(<<"resources/templates/list">>, _Params, Id, _State) ->
     %% Return empty list for now - templates can be added later
     success_response(Id, #{<<"resourceTemplates">> => []});
+
+handle_request(<<"resources/subscribe">>, Params, Id, State) ->
+    Uri = maps:get(<<"uri">>, Params, <<>>),
+    case maps:find(session_id, State) of
+        {ok, SessionId} when is_binary(SessionId), Uri =/= <<>> ->
+            barrel_mcp_session:subscribe_resource(SessionId, Uri),
+            success_response(Id, #{});
+        _ ->
+            error_response(Id, ?JSONRPC_INVALID_PARAMS,
+                           <<"Subscribe requires a session and a uri">>)
+    end;
+
+handle_request(<<"resources/unsubscribe">>, Params, Id, State) ->
+    Uri = maps:get(<<"uri">>, Params, <<>>),
+    case maps:find(session_id, State) of
+        {ok, SessionId} when is_binary(SessionId), Uri =/= <<>> ->
+            barrel_mcp_session:unsubscribe_resource(SessionId, Uri),
+            success_response(Id, #{});
+        _ ->
+            error_response(Id, ?JSONRPC_INVALID_PARAMS,
+                           <<"Unsubscribe requires a session and a uri">>)
+    end;
 
 %% Prompts
 handle_request(<<"prompts/list">>, _Params, Id, _State) ->

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -87,10 +87,10 @@ handle_request(<<"initialize">>, Params, Id, State) ->
     ServerVersion = application:get_env(barrel_mcp, server_version, <<"1.0.0">>),
     %% Persist client capabilities (notably `sampling') so the server can
     %% later issue server-to-client requests via barrel_mcp_session.
-    case maps:find(session_id, State) of
+    _ = case maps:find(session_id, State) of
         {ok, SessionId} when is_binary(SessionId) ->
             ClientCaps = maps:get(<<"capabilities">>, Params, #{}),
-            _ = barrel_mcp_session:set_client_capabilities(SessionId, ClientCaps);
+            barrel_mcp_session:set_client_capabilities(SessionId, ClientCaps);
         _ -> ok
     end,
     success_response(Id, #{

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -203,20 +203,20 @@ get_sse_pid(SessionId) ->
 -spec subscribe_resource(binary(), binary()) -> ok.
 subscribe_resource(SessionId, Uri)
         when is_binary(SessionId), is_binary(Uri) ->
-    ensure_subs_table(),
+    _ = ensure_subs_table(),
     true = ets:insert(?SUBSCRIPTIONS_TABLE, {{SessionId, Uri}}),
     ok.
 
 -spec unsubscribe_resource(binary(), binary()) -> ok.
 unsubscribe_resource(SessionId, Uri) ->
-    ensure_subs_table(),
+    _ = ensure_subs_table(),
     true = ets:delete(?SUBSCRIPTIONS_TABLE, {SessionId, Uri}),
     ok.
 
 %% @doc Return all session ids that subscribed to a URI.
 -spec subscribers_for(binary()) -> [binary()].
 subscribers_for(Uri) when is_binary(Uri) ->
-    ensure_subs_table(),
+    _ = ensure_subs_table(),
     %% match-spec to find all {SessionId, Uri} for the given Uri
     Pattern = {{'$1', Uri}},
     Match = [{Pattern, [], ['$1']}],
@@ -244,10 +244,10 @@ sampling_create_message(SessionId, Params, Opts) ->
 -spec deliver_response(binary() | integer(), map()) -> ok | {error, unknown_id}.
 deliver_response(Id, Response) ->
     Key = id_to_binary(Id),
-    ensure_pending_table(),
+    _ = ensure_pending_table(),
     case ets:lookup(?PENDING_TABLE, Key) of
         [{_, #pending{caller = Caller, caller_ref = Ref}}] ->
-            ets:delete(?PENDING_TABLE, Key),
+            true = ets:delete(?PENDING_TABLE, Key),
             Caller ! {sampling_response, Ref, Response},
             ok;
         [] ->
@@ -274,11 +274,11 @@ cleanup_expired(TTL) ->
 
 init([]) ->
     %% Create ETS tables if they don't exist
-    ensure_session_table(),
-    ensure_subs_table(),
-    ensure_pending_table(),
+    _ = ensure_session_table(),
+    _ = ensure_subs_table(),
+    _ = ensure_pending_table(),
     %% Schedule periodic cleanup
-    erlang:send_after(?CLEANUP_INTERVAL, self(), cleanup),
+    _ = erlang:send_after(?CLEANUP_INTERVAL, self(), cleanup),
     {ok, #{}}.
 
 handle_call(_Request, _From, State) ->
@@ -375,8 +375,8 @@ do_sampling(SessionId, SsePid, Params, Opts) ->
         caller_ref = Ref,
         expires_at = erlang:system_time(millisecond) + Timeout
     },
-    ensure_pending_table(),
-    ets:insert(?PENDING_TABLE, {RequestId, Pending}),
+    _ = ensure_pending_table(),
+    true = ets:insert(?PENDING_TABLE, {RequestId, Pending}),
     Request = #{
         <<"jsonrpc">> => <<"2.0">>,
         <<"id">> => RequestId,
@@ -391,7 +391,7 @@ do_sampling(SessionId, SsePid, Params, Opts) ->
         {sampling_response, Ref, #{<<"error">> := Err}} ->
             {error, {client_error, Err}}
     after Timeout ->
-        ets:delete(?PENDING_TABLE, RequestId),
+        true = ets:delete(?PENDING_TABLE, RequestId),
         {error, timeout}
     end.
 

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -21,22 +21,49 @@
     delete/1,
     generate_id/0,
     list/0,
-    cleanup_expired/1
+    cleanup_expired/1,
+    %% Capability tracking (set during MCP `initialize').
+    set_client_capabilities/2,
+    has_sampling/1,
+    list_sampling_capable/0,
+    %% sse_pid management.
+    set_sse_pid/2,
+    get_sse_pid/1,
+    %% Resource subscription tracking (server-side, used to emit
+    %% notifications/resources/updated when an exposed resource changes).
+    subscribe_resource/2,
+    unsubscribe_resource/2,
+    subscribers_for/1,
+    %% Server -> client request via the session's SSE channel.
+    sampling_create_message/3,
+    deliver_response/2
 ]).
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(SESSION_TABLE, barrel_mcp_sessions).
+-define(SUBSCRIPTIONS_TABLE, barrel_mcp_resource_subs).
+-define(PENDING_TABLE, barrel_mcp_pending_requests).
 -define(CLEANUP_INTERVAL, 60000). %% 1 minute
+-define(DEFAULT_SAMPLING_TIMEOUT, 30000).
 
 -record(mcp_session, {
     id :: binary(),
     created_at :: integer(),
     last_activity :: integer(),
     client_info :: map(),
+    client_capabilities :: map(),
     protocol_version :: binary(),
     sse_pid :: pid() | undefined  %% Process handling SSE stream
+}).
+
+-record(pending, {
+    id :: binary(),
+    session_id :: binary(),
+    caller :: pid(),
+    caller_ref :: reference(),
+    expires_at :: integer()
 }).
 
 %%====================================================================
@@ -62,6 +89,7 @@ create(Opts) ->
         created_at = Now,
         last_activity = Now,
         client_info = maps:get(client_info, Opts, #{}),
+        client_capabilities = maps:get(client_capabilities, Opts, #{}),
         protocol_version = maps:get(protocol_version, Opts, <<"2025-03-26">>),
         sse_pid = undefined
     },
@@ -118,6 +146,114 @@ list() ->
         [session_to_map(Session) | Acc]
     end, [], ?SESSION_TABLE).
 
+%% @doc Set the client_capabilities map for a session. Called from the
+%% protocol handler after parsing the `initialize' request.
+-spec set_client_capabilities(binary(), map()) -> ok | {error, not_found}.
+set_client_capabilities(SessionId, Capabilities) when is_map(Capabilities) ->
+    case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, Session}] ->
+            Updated = Session#mcp_session{client_capabilities = Capabilities},
+            true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
+            ok;
+        [] ->
+            {error, not_found}
+    end.
+
+%% @doc Whether a session declared sampling capability in its initialize
+%% request.
+-spec has_sampling(binary()) -> boolean().
+has_sampling(SessionId) ->
+    case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, #mcp_session{client_capabilities = Caps}}] ->
+            maps:is_key(<<"sampling">>, Caps);
+        [] ->
+            false
+    end.
+
+%% @doc List session ids whose client declared sampling capability.
+-spec list_sampling_capable() -> [binary()].
+list_sampling_capable() ->
+    ets:foldl(fun({Id, #mcp_session{client_capabilities = Caps}}, Acc) ->
+        case maps:is_key(<<"sampling">>, Caps) of
+            true -> [Id | Acc];
+            false -> Acc
+        end
+    end, [], ?SESSION_TABLE).
+
+%% @doc Set the SSE process pid for a session.
+-spec set_sse_pid(binary(), pid() | undefined) -> ok | {error, not_found}.
+set_sse_pid(SessionId, Pid) ->
+    case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, Session}] ->
+            Updated = Session#mcp_session{sse_pid = Pid},
+            true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
+            ok;
+        [] -> {error, not_found}
+    end.
+
+-spec get_sse_pid(binary()) -> {ok, pid()} | {error, not_found | no_sse}.
+get_sse_pid(SessionId) ->
+    case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, #mcp_session{sse_pid = undefined}}] -> {error, no_sse};
+        [{_, #mcp_session{sse_pid = Pid}}] when is_pid(Pid) -> {ok, Pid};
+        [] -> {error, not_found}
+    end.
+
+%% @doc Subscribe a session to resource updates for a given URI.
+-spec subscribe_resource(binary(), binary()) -> ok.
+subscribe_resource(SessionId, Uri)
+        when is_binary(SessionId), is_binary(Uri) ->
+    ensure_subs_table(),
+    true = ets:insert(?SUBSCRIPTIONS_TABLE, {{SessionId, Uri}}),
+    ok.
+
+-spec unsubscribe_resource(binary(), binary()) -> ok.
+unsubscribe_resource(SessionId, Uri) ->
+    ensure_subs_table(),
+    true = ets:delete(?SUBSCRIPTIONS_TABLE, {SessionId, Uri}),
+    ok.
+
+%% @doc Return all session ids that subscribed to a URI.
+-spec subscribers_for(binary()) -> [binary()].
+subscribers_for(Uri) when is_binary(Uri) ->
+    ensure_subs_table(),
+    %% match-spec to find all {SessionId, Uri} for the given Uri
+    Pattern = {{'$1', Uri}},
+    Match = [{Pattern, [], ['$1']}],
+    ets:select(?SUBSCRIPTIONS_TABLE, Match).
+
+%% @doc Send `sampling/createMessage' to the client behind a session and
+%% wait for the response. The session must (a) exist, (b) have an active
+%% sse_pid, and (c) have declared sampling capability in initialize.
+-spec sampling_create_message(binary(), map(), map()) ->
+    {ok, map(), map()}
+  | {error, timeout | not_supported | no_sse | not_found | term()}.
+sampling_create_message(SessionId, Params, Opts) ->
+    case has_sampling(SessionId) of
+        false -> {error, not_supported};
+        true ->
+            case get_sse_pid(SessionId) of
+                {error, _} = E -> E;
+                {ok, Pid} -> do_sampling(SessionId, Pid, Params, Opts)
+            end
+    end.
+
+%% @doc Deliver a JSON-RPC response from the client back to the waiting
+%% caller. Called by the HTTP handler when an inbound POST contains a
+%% `result' or `error' for a server-initiated id.
+-spec deliver_response(binary() | integer(), map()) -> ok | {error, unknown_id}.
+deliver_response(Id, Response) ->
+    Key = id_to_binary(Id),
+    ensure_pending_table(),
+    case ets:lookup(?PENDING_TABLE, Key) of
+        [{_, #pending{caller = Caller, caller_ref = Ref}}] ->
+            ets:delete(?PENDING_TABLE, Key),
+            Caller ! {sampling_response, Ref, Response},
+            ok;
+        [] ->
+            {error, unknown_id}
+    end.
+
 %% @doc Cleanup sessions older than TTL milliseconds.
 -spec cleanup_expired(pos_integer()) -> non_neg_integer().
 cleanup_expired(TTL) ->
@@ -137,19 +273,10 @@ cleanup_expired(TTL) ->
 %%====================================================================
 
 init([]) ->
-    %% Create ETS table if it doesn't exist
-    _ = case ets:whereis(?SESSION_TABLE) of
-        undefined ->
-            ets:new(?SESSION_TABLE, [
-                named_table,
-                public,
-                set,
-                {read_concurrency, true},
-                {write_concurrency, true}
-            ]);
-        _ ->
-            ok
-    end,
+    %% Create ETS tables if they don't exist
+    ensure_session_table(),
+    ensure_subs_table(),
+    ensure_pending_table(),
     %% Schedule periodic cleanup
     erlang:send_after(?CLEANUP_INTERVAL, self(), cleanup),
     {ok, #{}}.
@@ -188,6 +315,7 @@ session_to_map(#mcp_session{
     created_at = CreatedAt,
     last_activity = LastActivity,
     client_info = ClientInfo,
+    client_capabilities = Caps,
     protocol_version = ProtocolVersion,
     sse_pid = SsePid
 }) ->
@@ -196,6 +324,80 @@ session_to_map(#mcp_session{
         created_at => CreatedAt,
         last_activity => LastActivity,
         client_info => ClientInfo,
+        client_capabilities => Caps,
         protocol_version => ProtocolVersion,
         sse_pid => SsePid
     }.
+
+%% ============================================================================
+%% Internal helpers (table init + sampling implementation)
+%% ============================================================================
+
+ensure_session_table() ->
+    case ets:whereis(?SESSION_TABLE) of
+        undefined ->
+            ets:new(?SESSION_TABLE, [
+                named_table, public, set,
+                {read_concurrency, true},
+                {write_concurrency, true}
+            ]);
+        _ -> ok
+    end.
+
+ensure_subs_table() ->
+    case ets:whereis(?SUBSCRIPTIONS_TABLE) of
+        undefined ->
+            ets:new(?SUBSCRIPTIONS_TABLE, [
+                named_table, public, set,
+                {read_concurrency, true}
+            ]);
+        _ -> ok
+    end.
+
+ensure_pending_table() ->
+    case ets:whereis(?PENDING_TABLE) of
+        undefined ->
+            ets:new(?PENDING_TABLE, [
+                named_table, public, set,
+                {read_concurrency, true}
+            ]);
+        _ -> ok
+    end.
+
+do_sampling(SessionId, SsePid, Params, Opts) ->
+    Timeout = maps:get(timeout_ms, Opts, ?DEFAULT_SAMPLING_TIMEOUT),
+    RequestId = generate_request_id(),
+    Ref = make_ref(),
+    Pending = #pending{
+        id = RequestId,
+        session_id = SessionId,
+        caller = self(),
+        caller_ref = Ref,
+        expires_at = erlang:system_time(millisecond) + Timeout
+    },
+    ensure_pending_table(),
+    ets:insert(?PENDING_TABLE, {RequestId, Pending}),
+    Request = #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => RequestId,
+        <<"method">> => <<"sampling/createMessage">>,
+        <<"params">> => Params
+    },
+    SsePid ! {sse_send_message, Request},
+    receive
+        {sampling_response, Ref, #{<<"result">> := Result} = R} ->
+            Usage = maps:get(<<"usage">>, Result, maps:get(usage, R, #{})),
+            {ok, Result, Usage};
+        {sampling_response, Ref, #{<<"error">> := Err}} ->
+            {error, {client_error, Err}}
+    after Timeout ->
+        ets:delete(?PENDING_TABLE, RequestId),
+        {error, timeout}
+    end.
+
+generate_request_id() ->
+    <<"sampling-", (integer_to_binary(erlang:unique_integer([positive])))/binary>>.
+
+id_to_binary(Id) when is_binary(Id) -> Id;
+id_to_binary(Id) when is_integer(Id) -> integer_to_binary(Id);
+id_to_binary(Id) -> iolist_to_binary(io_lib:format("~p", [Id])).

--- a/test/barrel_mcp_sampling_tests.erl
+++ b/test/barrel_mcp_sampling_tests.erl
@@ -1,0 +1,194 @@
+%% @doc Tests for the new server-to-client primitives:
+%%   - client capability tracking
+%%   - resource subscriptions and notifications
+%%   - sampling/createMessage round-trip
+-module(barrel_mcp_sampling_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% ============================================================================
+%% Capability tracking
+%% ============================================================================
+
+capability_tracking_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"set + has_sampling", fun test_has_sampling/0},
+            {"list sampling-capable sessions",
+             fun test_list_sampling_capable/0}
+        ]
+    end}.
+
+test_has_sampling() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ?assertNot(barrel_mcp_session:has_sampling(S1)),
+    ok = barrel_mcp_session:set_client_capabilities(S1, #{
+        <<"sampling">> => #{}
+    }),
+    ?assert(barrel_mcp_session:has_sampling(S1)).
+
+test_list_sampling_capable() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    {ok, S2} = barrel_mcp_session:create(#{}),
+    ok = barrel_mcp_session:set_client_capabilities(
+        S2, #{<<"sampling">> => #{}}),
+    Capable = barrel_mcp_session:list_sampling_capable(),
+    ?assertNot(lists:member(S1, Capable)),
+    ?assert(lists:member(S2, Capable)).
+
+%% ============================================================================
+%% Resource subscriptions
+%% ============================================================================
+
+resource_subscriptions_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"subscribe + subscribers_for",
+             fun test_subscribe/0},
+            {"notify_resource_updated reaches subscriber",
+             fun test_notify_resource_updated/0}
+        ]
+    end}.
+
+test_subscribe() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    Uri = <<"live://alerts/active">>,
+    ok = barrel_mcp_session:subscribe_resource(S1, Uri),
+    Subs = barrel_mcp_session:subscribers_for(Uri),
+    ?assert(lists:member(S1, Subs)),
+    ok = barrel_mcp_session:unsubscribe_resource(S1, Uri),
+    ?assertNot(lists:member(S1,
+                            barrel_mcp_session:subscribers_for(Uri))).
+
+test_notify_resource_updated() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    Self = self(),
+    Pid = spawn(fun() -> capture_loop(Self) end),
+    ok = barrel_mcp_session:set_sse_pid(S1, Pid),
+    Uri = <<"live://alerts/active">>,
+    ok = barrel_mcp_session:subscribe_resource(S1, Uri),
+    ok = barrel_mcp:notify_resource_updated(Uri),
+    receive
+        {captured, {sse_send_message, Msg}} ->
+            ?assertEqual(<<"notifications/resources/updated">>,
+                         maps:get(<<"method">>, Msg)),
+            ?assertEqual(Uri,
+                         maps:get(<<"uri">>,
+                                  maps:get(<<"params">>, Msg)))
+    after 1000 -> ?assert(false)
+    end,
+    exit(Pid, kill).
+
+%% ============================================================================
+%% sampling_create_message round-trip
+%% ============================================================================
+
+sampling_round_trip_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"declines without sampling capability",
+             fun test_sampling_not_supported/0},
+            {"declines without an SSE pid",
+             fun test_sampling_no_sse/0},
+            {"happy path: response routed to caller",
+             fun test_sampling_round_trip/0},
+            {"timeout when no response arrives",
+             fun test_sampling_timeout/0}
+        ]
+    end}.
+
+test_sampling_not_supported() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    %% capability not set
+    ?assertEqual({error, not_supported},
+                 barrel_mcp:sampling_create_message(S1, #{}, #{})).
+
+test_sampling_no_sse() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ok = barrel_mcp_session:set_client_capabilities(
+        S1, #{<<"sampling">> => #{}}),
+    %% no sse_pid
+    ?assertEqual({error, no_sse},
+                 barrel_mcp:sampling_create_message(S1, #{}, #{})).
+
+test_sampling_round_trip() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ok = barrel_mcp_session:set_client_capabilities(
+        S1, #{<<"sampling">> => #{}}),
+    Self = self(),
+    Pid = spawn(fun() -> sampling_responder(Self) end),
+    ok = barrel_mcp_session:set_sse_pid(S1, Pid),
+    spawn(fun() ->
+        %% Forward the inbound message back as a response, then deliver.
+        Self ! {result, barrel_mcp:sampling_create_message(
+            S1, #{<<"messages">> => []}, #{timeout_ms => 2000})}
+    end),
+    %% The fake responder forwards the request to us.
+    Request = receive
+        {got_message, Msg} -> Msg
+    after 1000 -> ?assert(false), undefined
+    end,
+    Id = maps:get(<<"id">>, Request),
+    ?assertEqual(<<"sampling/createMessage">>,
+                 maps:get(<<"method">>, Request)),
+    %% Deliver a fake response
+    ok = barrel_mcp_session:deliver_response(Id, #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => Id,
+        <<"result">> => #{
+            <<"content">> => #{<<"type">> => <<"text">>, <<"text">> => <<"hi">>},
+            <<"usage">> => #{<<"input_tokens">> => 10}
+        }
+    }),
+    receive
+        {result, {ok, Result, Usage}} ->
+            ?assertEqual(<<"hi">>,
+                         maps:get(<<"text">>,
+                                  maps:get(<<"content">>, Result))),
+            ?assertEqual(10, maps:get(<<"input_tokens">>, Usage))
+    after 2000 ->
+        ?assert(false)
+    end,
+    exit(Pid, kill).
+
+test_sampling_timeout() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ok = barrel_mcp_session:set_client_capabilities(
+        S1, #{<<"sampling">> => #{}}),
+    Pid = spawn(fun() -> idle_loop() end),
+    ok = barrel_mcp_session:set_sse_pid(S1, Pid),
+    ?assertEqual({error, timeout},
+                 barrel_mcp:sampling_create_message(
+                     S1, #{}, #{timeout_ms => 100})),
+    exit(Pid, kill).
+
+%% ============================================================================
+%% Helpers
+%% ============================================================================
+
+setup() ->
+    %% Restart application to get a clean ETS state.
+    catch application:stop(barrel_mcp),
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    ok.
+
+teardown(_) ->
+    application:stop(barrel_mcp).
+
+capture_loop(Reporter) ->
+    receive
+        Msg ->
+            Reporter ! {captured, Msg},
+            capture_loop(Reporter)
+    end.
+
+sampling_responder(Reporter) ->
+    receive
+        {sse_send_message, Msg} ->
+            Reporter ! {got_message, Msg},
+            sampling_responder(Reporter);
+        _ -> sampling_responder(Reporter)
+    end.
+
+idle_loop() ->
+    receive _ -> idle_loop() end.


### PR DESCRIPTION
## Summary

Three additive primitives for server-initiated work on connected MCP clients:

- **Capability tracking** — `initialize` now stores the client's `capabilities` map in the session; surfaced through `barrel_mcp_session:has_sampling/1` and `list_sampling_capable/0`.
- **Resource subscriptions** — `resources/subscribe` / `resources/unsubscribe` persist a `(session, uri)` entry. New public API `barrel_mcp:notify_resource_updated/1,2` fans out `notifications/resources/updated` over subscribed SSE streams.
- **Server-initiated sampling** — `barrel_mcp:sampling_create_message/3` sends `sampling/createMessage` through the session's SSE pid and awaits the matching response with a configurable timeout. Inbound POSTs containing `result` / `error` (no `method`) are routed to the waiting caller.

Existing users see no behaviour change; the additions are gated on the client declaring sampling capability and an active SSE stream.

## Files

- `src/barrel_mcp.erl` — public API surface
- `src/barrel_mcp_session.erl` — capability + subscription + pending-request state, sampling round-trip
- `src/barrel_mcp_protocol.erl` — initialize stores capabilities; resources/subscribe + resources/unsubscribe handlers
- `src/barrel_mcp_http_stream.erl` — SSE pid registration, `sse_send_message` info handler, response routing
- `test/barrel_mcp_sampling_tests.erl` — 8 new tests covering capability tracking, subscription fan-out, sampling round-trip, timeout, and error paths