### PR TITLE
Spec-conformant MCP client + multi-server federation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Spec-conformant MCP client** (`barrel_mcp_client`)
+  - Rewritten as a `gen_statem` (`connecting` → `initializing` → `ready` → `closing`).
+  - Async transports forward inbound JSON-RPC envelopes as `{mcp_in, _, _}` messages.
+  - Streamable HTTP client transport (`barrel_mcp_client_http`): POST with `application/json, text/event-stream`, parses SSE from POST and from a long-lived GET stream, captures `Mcp-Session-Id`, sends `MCP-Protocol-Version` after init, DELETE on close, 401 retry through pluggable auth.
+  - Stdio client transport (`barrel_mcp_client_stdio`) extracted into its own gen_server.
+  - Targets MCP `2025-11-25` and negotiates downward through `2025-06-18`, `2025-03-26`, `2024-11-05`.
+  - Server-initiated requests/notifications routed through a `barrel_mcp_client_handler` behaviour with sync, error, and async reply forms; default no-op handler ships in `barrel_mcp_client_handler_default`.
+  - Capability-shaped initialize payload (booleans become spec objects on the wire).
+  - Resource subscription notifications routed back to the subscribing process.
+  - Pagination, cancellation, and progress-token plumbing on `tools/call`.
+- **Federation registry** (`barrel_mcp_clients`): one supervised connection per server id, looked up via `barrel_mcp:start_client/2`, `whereis_client/1`, `list_clients/0`, `stop_client/1`.
+- **Auth behaviour** (`barrel_mcp_client_auth`) with a static-bearer implementation; OAuth 2.1 + PKCE planned for a follow-up.
+- **JSON-RPC envelope helpers** (`encode_request/3`, `encode_notification/2`, `encode_response/2`, `encode_error/3`, `decode_envelope/1`) shared between client and server.
+- New tests: `barrel_mcp_client_tests` (loopback handshake / call_tool / version downgrade), `barrel_mcp_client_handler_tests`, `barrel_mcp_clients_tests`, `barrel_mcp_protocol_envelope_tests`.
+- New doc: `guides/features.md` summarising the client surface and roadmap.
+
+### Changed
+
+- `notifications/initialized` is now the spec name; legacy bare `initialized` still accepted for one release.
+- CORS on `barrel_mcp_http_stream` exposes `mcp-protocol-version` and `last-event-id`.
+
 ## [1.1.0] - 2025-01-27
 
 ### Added

--- a/guides/features.md
+++ b/guides/features.md
@@ -1,0 +1,77 @@
+# barrel_mcp features
+
+Tracks notable capabilities and the spec-conformance status of the
+Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
+
+## Server
+
+- HTTP transport (`barrel_mcp_http`) — JSON-RPC over POST.
+- Streamable HTTP transport (`barrel_mcp_http_stream`) — protocol
+  `2025-03-26`. POST (JSON or SSE), GET (SSE), DELETE, OPTIONS.
+- stdio transport (`barrel_mcp_stdio`).
+- Tool / resource / prompt registries.
+- Session management with `Mcp-Session-Id` and TTL.
+- Authentication providers: bearer, API key, basic, custom.
+- Server-to-client sampling (`sampling/createMessage`) and resource
+  update notifications.
+
+## Client (`barrel_mcp_client`)
+
+`barrel_mcp_client` is a supervised `gen_statem` that holds one
+connection to one MCP server and routes the protocol surface defined
+by the spec.
+
+### Transports
+
+| Transport | Module | Notes |
+| --- | --- | --- |
+| Streamable HTTP | `barrel_mcp_client_http` | POST with `application/json, text/event-stream`, SSE on POST and on a long-lived GET, `Mcp-Session-Id` capture, `MCP-Protocol-Version` after init, DELETE on close, 401 retry through `barrel_mcp_client_auth`. |
+| stdio | `barrel_mcp_client_stdio` | Subprocess line-delimited JSON-RPC. |
+
+### Protocol coverage (Phase A — shipped)
+
+- Targets `2025-11-25`; negotiates downward through `2025-06-18`,
+  `2025-03-26`, `2024-11-05`.
+- `initialize` with spec-shaped capability objects; `notifications/initialized` (the spec name).
+- `tools/list`, `tools/call`, `resources/list`, `resources/read`,
+  `resources/templates/list`, `resources/subscribe`,
+  `resources/unsubscribe`, `prompts/list`, `prompts/get`,
+  `completion/complete`, `logging/setLevel`, `ping`.
+- Pagination via `cursor` / `nextCursor` (single page by default;
+  `want_cursor => true` to follow paging).
+- Cancellation: `barrel_mcp_client:cancel/2` sends
+  `notifications/cancelled` and unblocks the caller.
+- Progress: callers may pass `progress_token` in `tools/call`.
+- Server→client requests dispatched through the
+  `barrel_mcp_client_handler` behaviour. `{reply, _, _}`,
+  `{error, _, _, _}`, and `{async, Tag, _}` reply forms; the host
+  later calls `barrel_mcp_client:reply_async/3`.
+- Server→client notifications routed to handler;
+  `notifications/resources/updated` also forwarded to subscribers.
+
+### Federation
+
+- `barrel_mcp_clients` registers one supervised client per
+  caller-chosen `ServerId`. Looked up via:
+  - `barrel_mcp:start_client/2`
+  - `barrel_mcp:stop_client/1`
+  - `barrel_mcp:whereis_client/1`
+  - `barrel_mcp:list_clients/0`
+- Tool-name namespacing across servers is host policy and is not
+  enforced by the library.
+
+### Auth
+
+- `barrel_mcp_client_auth` behaviour.
+- `barrel_mcp_client_auth_bearer` — static token.
+- OAuth 2.1 + PKCE: planned for Phase D (Protected Resource Metadata
+  discovery, RFC 8707 `resource` parameter).
+
+### Roadmap
+
+- Phase B: deeper notifications + ergonomics — logging stream,
+  resources/list_changed callbacks, completion routing, schema
+  validation against `inputSchema` (opt-in).
+- Phase C: refined control plane — periodic `ping`, deadline timers,
+  progress notification dispatch.
+- Phase D: OAuth 2.1 + PKCE auth.

--- a/include/barrel_mcp.hrl
+++ b/include/barrel_mcp.hrl
@@ -6,10 +6,16 @@
 -ifndef(BARREL_MCP_HRL).
 -define(BARREL_MCP_HRL, true).
 
-%% MCP Protocol Version (Streamable HTTP transport)
+%% MCP Protocol Version (Streamable HTTP transport, server side)
 -define(MCP_PROTOCOL_VERSION, <<"2025-03-26">>).
 %% Legacy protocol version (JSON-RPC only transport)
 -define(MCP_PROTOCOL_VERSION_LEGACY, <<"2024-11-05">>).
+%% Latest protocol version targeted by the client; the client negotiates
+%% downward when the peer reports an older revision.
+-define(MCP_CLIENT_PROTOCOL_VERSION, <<"2025-11-25">>).
+%% Older revisions the client knows how to speak (in preference order).
+-define(MCP_CLIENT_SUPPORTED_VERSIONS,
+        [<<"2025-11-25">>, <<"2025-06-18">>, <<"2025-03-26">>, <<"2024-11-05">>]).
 
 %% JSON-RPC Error Codes
 -define(JSONRPC_PARSE_ERROR, -32700).

--- a/src/barrel_mcp.app.src
+++ b/src/barrel_mcp.app.src
@@ -1,7 +1,8 @@
 {application, barrel_mcp, [
     {description, "MCP Protocol Library for Erlang"},
     {vsn, "1.1.1"},
-    {registered, [barrel_mcp_registry, barrel_mcp_sup, barrel_mcp_session]},
+    {registered, [barrel_mcp_registry, barrel_mcp_sup, barrel_mcp_session,
+                  barrel_mcp_client_sup]},
     {mod, {barrel_mcp_app, []}},
     {applications, [kernel, stdlib, crypto, cowboy, hackney]},
     {env, [

--- a/src/barrel_mcp.erl
+++ b/src/barrel_mcp.erl
@@ -99,6 +99,14 @@
     notify_resource_updated/2
 ]).
 
+%% MCP client API (connecting to remote MCP servers).
+-export([
+    start_client/2,
+    stop_client/1,
+    whereis_client/1,
+    list_clients/0
+]).
+
 %%====================================================================
 %% Tool API
 %%====================================================================
@@ -642,3 +650,40 @@ notify_resource_updated(Uri, Extra) when is_binary(Uri) ->
         end
     end, Subscribers),
     ok.
+
+%%====================================================================
+%% MCP client API
+%%====================================================================
+
+%% @doc Start a supervised MCP client connecting to a remote server.
+%%
+%% `ServerId' is any term the host uses to identify the connection
+%% (typically a binary). `Spec' is a `barrel_mcp_client:connect_spec()':
+%%
+%% ```
+%% barrel_mcp:start_client(<<"github">>, #{
+%%     transport => {http, <<"https://mcp.github.com/">>},
+%%     handler => {my_handler_mod, []},
+%%     auth => {bearer, <<"ghp_xxx">>},
+%%     capabilities => #{sampling => true}
+%% }).
+%% '''
+-spec start_client(term(), barrel_mcp_client:connect_spec()) ->
+    {ok, pid()} | {error, term()}.
+start_client(ServerId, Spec) ->
+    barrel_mcp_clients:start_client(ServerId, Spec).
+
+%% @doc Stop a previously-started client.
+-spec stop_client(term()) -> ok | {error, not_found}.
+stop_client(ServerId) ->
+    barrel_mcp_clients:stop_client(ServerId).
+
+%% @doc Look up the pid of a connected client by `ServerId'.
+-spec whereis_client(term()) -> pid() | undefined.
+whereis_client(ServerId) ->
+    barrel_mcp_clients:whereis_client(ServerId).
+
+%% @doc List all currently connected clients as `[{ServerId, Pid}]'.
+-spec list_clients() -> [{term(), pid()}].
+list_clients() ->
+    barrel_mcp_clients:list_clients().

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -1,241 +1,701 @@
 %%%-------------------------------------------------------------------
 %%% @doc MCP client for connecting to external MCP servers.
 %%%
-%%% Supports both HTTP and stdio transports.
+%%% A `gen_statem' that owns one connection to one MCP server. Two
+%%% transports are supported: stdio (subprocess) and Streamable HTTP
+%%% (POST + SSE GET).
+%%%
+%%% States:
+%%% <ul>
+%%%   <li>`connecting'   — transport is opening.</li>
+%%%   <li>`initializing' — `initialize' request in flight.</li>
+%%%   <li>`ready'        — handshake complete; calls accepted.</li>
+%%%   <li>`closing'      — owner asked to close.</li>
+%%% </ul>
+%%%
+%%% Inbound JSON-RPC envelopes from the transport are routed by
+%%% `decode_envelope/1':
+%%% <ul>
+%%%   <li>response/error with `id' — match against the pending-request
+%%%       table, post the result to the waiting caller.</li>
+%%%   <li>request with `id'        — dispatch to the configured
+%%%       `barrel_mcp_client_handler' module; reply (sync or async)
+%%%       goes back over the same transport.</li>
+%%%   <li>notification (no `id')   — dispatch to handler; resource
+%%%       update notifications are also routed to subscribers.</li>
+%%% </ul>
+%%%
+%%% Server-side host application code never sees the transport
+%%% layer; it talks to this module via the API below. Whether to bind
+%%% an LLM provider (Anthropic, OpenAI, Hermes-style local model) into
+%%% this loop is the host's job — `barrel_mcp' itself stays a pure
+%%% MCP library.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_client).
 
-%% API
+-behaviour(gen_statem).
+
+-include("barrel_mcp.hrl").
+
+%% Public API
 -export([
-    connect/1,
+    start_link/1,
+    start/1,
     close/1,
-    initialize/1,
     %% Tools
-    list_tools/1,
-    call_tool/3,
+    list_tools/1, list_tools/2,
+    call_tool/3, call_tool/4,
     %% Resources
-    list_resources/1,
+    list_resources/1, list_resources/2,
+    list_resource_templates/1, list_resource_templates/2,
     read_resource/2,
-    subscribe/2,
-    unsubscribe/2,
+    subscribe/2, unsubscribe/2,
     %% Prompts
-    list_prompts/1,
+    list_prompts/1, list_prompts/2,
     get_prompt/3,
-    %% Sampling
-    create_message/3
+    %% Misc
+    complete/3,
+    set_log_level/2,
+    ping/1,
+    cancel/2,
+    reply_async/3,
+    %% Introspection
+    server_info/1,
+    server_capabilities/1,
+    protocol_version/1
 ]).
 
--record(client, {
-    transport :: http | stdio,
-    url :: binary() | undefined,
-    port :: port() | undefined,
-    request_id = 1 :: integer(),
-    initialized = false :: boolean()
+%% gen_statem callbacks
+-export([callback_mode/0, init/1, terminate/3, code_change/4]).
+-export([connecting/3, initializing/3, ready/3, closing/3]).
+
+-type connect_spec() ::
+    #{transport := {http, binary() | string()} |
+                   {stdio, #{command := string(), args => [string()]}},
+      client_info => #{name => binary(), version => binary()},
+      capabilities => map(),
+      handler => {module(), term()},
+      auth => none | {bearer, binary()} | {oauth, map()},
+      protocol_version => binary(),
+      request_timeout => pos_integer(),
+      init_timeout => pos_integer()}.
+
+-export_type([connect_spec/0]).
+
+-define(DEFAULT_REQUEST_TIMEOUT, 30000).
+-define(DEFAULT_INIT_TIMEOUT, 30000).
+
+-record(pending, {
+    caller :: init | {pid(), term()},
+    method :: binary(),
+    deadline :: integer() | infinity
 }).
 
--type client() :: #client{}.
--type transport_opts() :: {http, binary() | string()} |
-                          {stdio, #{command := string(), args => [string()]}}.
+-record(data, {
+    spec :: connect_spec(),
+    transport :: {module(), pid()} | undefined,
+    request_id = 1 :: integer(),
+    pending = #{} :: #{integer() => #pending{}},
+    handler_mod :: module(),
+    handler_state :: term(),
+    async_replies = #{} :: #{barrel_mcp_client_handler:async_tag() => integer()},
+    subscriptions = #{} :: #{binary() => [pid()]},
+    server_capabilities :: map() | undefined,
+    server_info :: map() | undefined,
+    protocol_version :: binary() | undefined
+}).
 
 %%====================================================================
-%% API
+%% Public API
 %%====================================================================
 
-%% @doc Connect to an MCP server.
--spec connect(#{transport := transport_opts()}) -> {ok, client()} | {error, term()}.
-connect(#{transport := {http, Url}}) when is_list(Url) ->
-    connect(#{transport => {http, list_to_binary(Url)}});
-connect(#{transport := {http, Url}}) when is_binary(Url) ->
-    {ok, #client{transport = http, url = Url}};
+%% @doc Start a supervised client. Linked to the calling process.
+-spec start_link(connect_spec()) -> {ok, pid()} | {error, term()}.
+start_link(Spec) ->
+    gen_statem:start_link(?MODULE, Spec, []).
 
-connect(#{transport := {stdio, #{command := Cmd} = Opts}}) ->
-    Args = maps:get(args, Opts, []),
-    Port = open_port({spawn_executable, Cmd}, [
-        {args, Args},
-        {line, 1048576},  % 1MB line buffer
-        binary,
-        use_stdio,
-        exit_status,
-        stderr_to_stdout
-    ]),
-    {ok, #client{transport = stdio, port = Port}}.
+%% @doc Start an unsupervised client.
+-spec start(connect_spec()) -> {ok, pid()} | {error, term()}.
+start(Spec) ->
+    gen_statem:start(?MODULE, Spec, []).
 
-%% @doc Close connection.
--spec close(client()) -> ok.
-close(#client{transport = stdio, port = Port}) when Port =/= undefined ->
-    catch port_close(Port),
-    ok;
-close(_) ->
+%% @doc Close the connection.
+-spec close(pid()) -> ok.
+close(Pid) ->
+    gen_statem:cast(Pid, close).
+
+%% @doc List tools on the server. Single page.
+-spec list_tools(pid()) -> {ok, [map()]} | {error, term()}.
+list_tools(Pid) ->
+    list_tools(Pid, #{}).
+
+-spec list_tools(pid(), map()) -> {ok, [map()], NextCursor :: binary() | undefined} |
+                                  {ok, [map()]} | {error, term()}.
+list_tools(Pid, Opts) ->
+    paged(Pid, <<"tools/list">>, <<"tools">>, Opts).
+
+%% @doc Call a tool. Args are forwarded as `arguments'.
+-spec call_tool(pid(), binary(), map()) -> {ok, map()} | {error, term()}.
+call_tool(Pid, Name, Args) ->
+    call_tool(Pid, Name, Args, #{}).
+
+-spec call_tool(pid(), binary(), map(), map()) -> {ok, map()} | {error, term()}.
+call_tool(Pid, Name, Args, Opts) ->
+    Params0 = #{<<"name">> => Name, <<"arguments">> => Args},
+    Params = maybe_attach_progress_token(Params0, Opts),
+    request(Pid, <<"tools/call">>, Params, request_timeout(Opts)).
+
+-spec list_resources(pid()) -> {ok, [map()]} | {error, term()}.
+list_resources(Pid) -> list_resources(Pid, #{}).
+
+list_resources(Pid, Opts) ->
+    paged(Pid, <<"resources/list">>, <<"resources">>, Opts).
+
+list_resource_templates(Pid) -> list_resource_templates(Pid, #{}).
+
+list_resource_templates(Pid, Opts) ->
+    paged(Pid, <<"resources/templates/list">>, <<"resourceTemplates">>, Opts).
+
+read_resource(Pid, Uri) ->
+    request(Pid, <<"resources/read">>, #{<<"uri">> => Uri}).
+
+subscribe(Pid, Uri) ->
+    case request(Pid, <<"resources/subscribe">>, #{<<"uri">> => Uri}) of
+        {ok, _} = Ok ->
+            ok = gen_statem:cast(Pid, {add_subscriber, Uri, self()}),
+            Ok;
+        Err -> Err
+    end.
+
+unsubscribe(Pid, Uri) ->
+    case request(Pid, <<"resources/unsubscribe">>, #{<<"uri">> => Uri}) of
+        {ok, _} = Ok ->
+            ok = gen_statem:cast(Pid, {remove_subscriber, Uri, self()}),
+            Ok;
+        Err -> Err
+    end.
+
+list_prompts(Pid) -> list_prompts(Pid, #{}).
+
+list_prompts(Pid, Opts) ->
+    paged(Pid, <<"prompts/list">>, <<"prompts">>, Opts).
+
+get_prompt(Pid, Name, Args) ->
+    request(Pid, <<"prompts/get">>, #{
+        <<"name">> => Name,
+        <<"arguments">> => Args
+    }).
+
+complete(Pid, Ref, Argument) ->
+    request(Pid, <<"completion/complete">>, #{
+        <<"ref">> => Ref,
+        <<"argument">> => Argument
+    }).
+
+set_log_level(Pid, Level) when is_binary(Level) ->
+    request(Pid, <<"logging/setLevel">>, #{<<"level">> => Level}).
+
+ping(Pid) ->
+    request(Pid, <<"ping">>, #{}).
+
+%% @doc Cancel a previously-issued request by id. Sends
+%% `notifications/cancelled' and removes the pending slot so the
+%% caller receives `{error, cancelled}'.
+cancel(Pid, RequestId) ->
+    gen_statem:cast(Pid, {cancel, RequestId}).
+
+%% @doc Deliver an asynchronous reply for a request that the handler
+%% returned `{async, Tag, _}' for. Result may be a plain term (sent as
+%% a JSON-RPC `result') or `{error, Code, Message}'.
+reply_async(Pid, Tag, Result) ->
+    gen_statem:cast(Pid, {async_reply, Tag, Result}).
+
+server_info(Pid) ->
+    gen_statem:call(Pid, server_info).
+
+server_capabilities(Pid) ->
+    gen_statem:call(Pid, server_capabilities).
+
+protocol_version(Pid) ->
+    gen_statem:call(Pid, protocol_version).
+
+%%====================================================================
+%% gen_statem
+%%====================================================================
+
+callback_mode() -> state_functions.
+
+init(Spec) ->
+    process_flag(trap_exit, true),
+    {HandlerMod, HandlerArgs} =
+        maps:get(handler, Spec, {barrel_mcp_client_handler_default, []}),
+    case HandlerMod:init(HandlerArgs) of
+        {ok, HState} ->
+            Data = #data{spec = Spec,
+                         handler_mod = HandlerMod,
+                         handler_state = HState},
+            {ok, connecting, Data,
+             [{next_event, internal, open_transport}]};
+        {error, _} = Err ->
+            Err
+    end.
+
+%%-- connecting -------------------------------------------------------
+
+connecting(internal, open_transport, Data) ->
+    case open_transport(Data) of
+        {ok, Data1} ->
+            InitTimeout = maps:get(init_timeout,
+                                   Data#data.spec, ?DEFAULT_INIT_TIMEOUT),
+            {Id, Data2} = next_id(Data1),
+            Params = build_initialize_params(Data2),
+            send_envelope(Data2,
+                barrel_mcp_protocol:encode_request(Id, <<"initialize">>, Params)),
+            P = #pending{caller = init,
+                         method = <<"initialize">>,
+                         deadline = deadline(InitTimeout)},
+            Pending1 = (Data2#data.pending)#{Id => P},
+            {next_state, initializing, Data2#data{pending = Pending1},
+             [{state_timeout, InitTimeout, init_timeout}]};
+        {error, Reason} ->
+            {stop, {transport_failed, Reason}}
+    end;
+connecting({call, From}, _Req, _Data) ->
+    {keep_state_and_data, [{reply, From, {error, not_ready}}]};
+connecting(EventType, EventContent, Data) ->
+    common_handler(EventType, EventContent, Data).
+
+%%-- initializing -----------------------------------------------------
+
+initializing(state_timeout, init_timeout, _Data) ->
+    {stop, init_timeout};
+initializing({call, From}, _Req, _Data) ->
+    {keep_state_and_data, [{reply, From, {error, not_ready}}]};
+initializing(info, {mcp_in, Pid, Json},
+             #data{transport = {_, Pid}} = Data) ->
+    handle_inbound(Json, initializing, Data);
+initializing(EventType, EventContent, Data) ->
+    common_handler(EventType, EventContent, Data).
+
+%%-- ready ------------------------------------------------------------
+
+ready({call, From}, server_info, Data) ->
+    {keep_state_and_data, [{reply, From, {ok, Data#data.server_info}}]};
+ready({call, From}, server_capabilities, Data) ->
+    {keep_state_and_data, [{reply, From, {ok, Data#data.server_capabilities}}]};
+ready({call, From}, protocol_version, Data) ->
+    {keep_state_and_data, [{reply, From, {ok, Data#data.protocol_version}}]};
+ready({call, From}, {request, Method, Params, Timeout}, Data) ->
+    case is_supported(Method, Data) of
+        false ->
+            {keep_state_and_data, [{reply, From, {error, {unsupported, Method}}}]};
+        true ->
+            {Id, Data1} = next_id(Data),
+            send_envelope(Data1,
+                barrel_mcp_protocol:encode_request(Id, Method, Params)),
+            P = #pending{caller = From, method = Method,
+                         deadline = deadline(Timeout)},
+            Pending = (Data1#data.pending)#{Id => P},
+            Actions = case Timeout of
+                          infinity -> [];
+                          T -> [{{timeout, {req, Id}}, T, request_timeout}]
+                      end,
+            {keep_state, Data1#data{pending = Pending}, Actions}
+    end;
+ready(cast, {cancel, Id}, Data) ->
+    do_cancel(Id, Data);
+ready(cast, {add_subscriber, Uri, Pid}, Data) ->
+    {keep_state, add_sub(Uri, Pid, Data)};
+ready(cast, {remove_subscriber, Uri, Pid}, Data) ->
+    {keep_state, del_sub(Uri, Pid, Data)};
+ready(cast, {async_reply, Tag, Result}, Data) ->
+    {keep_state, deliver_async_reply(Tag, Result, Data)};
+ready({timeout, {req, Id}}, request_timeout, Data) ->
+    timeout_pending(Id, Data);
+ready(info, {mcp_in, Pid, Json},
+      #data{transport = {_, Pid}} = Data) ->
+    handle_inbound(Json, ready, Data);
+ready(EventType, EventContent, Data) ->
+    common_handler(EventType, EventContent, Data).
+
+%%-- closing ----------------------------------------------------------
+
+closing({call, From}, _Req, _Data) ->
+    {keep_state_and_data, [{reply, From, {error, closing}}]};
+closing(_E, _C, _Data) ->
+    keep_state_and_data.
+
+%%====================================================================
+%% Common event handling (transport messages, casts, etc.)
+%%====================================================================
+
+common_handler(info, {mcp_closed, Pid, _Reason},
+               #data{transport = {_, Pid}}) ->
+    {stop, normal};
+common_handler(info, {'EXIT', _, _}, _Data) ->
+    keep_state_and_data;
+common_handler(cast, close, Data) ->
+    case Data#data.transport of
+        {Mod, Pid} -> catch Mod:close(Pid);
+        _ -> ok
+    end,
+    {stop, normal, Data};
+common_handler(_E, _C, _D) ->
+    keep_state_and_data.
+
+%%====================================================================
+%% Inbound message routing
+%%====================================================================
+
+handle_inbound(Json, State, Data) ->
+    case decode(Json) of
+        {request, Id, Method, Params} ->
+            handle_server_request(Id, Method, Params, State, Data);
+        {notification, Method, Params} ->
+            handle_server_notification(Method, Params, State, Data);
+        {response, Id, Result} ->
+            handle_response(Id, Result, State, Data);
+        {error, Id, Code, Message, _Data1} ->
+            handle_error_response(Id, Code, Message, State, Data);
+        _ ->
+            keep_state_and_data
+    end.
+
+decode(Json) ->
+    case barrel_mcp_protocol:decode(Json) of
+        {ok, Map} -> barrel_mcp_protocol:decode_envelope(Map);
+        Err -> Err
+    end.
+
+handle_response(Id, Result, initializing, Data) ->
+    case maps:take(Id, Data#data.pending) of
+        {#pending{method = <<"initialize">>}, Rest} ->
+            handle_initialize_result(Result, Data#data{pending = Rest});
+        _ ->
+            keep_state_and_data
+    end;
+handle_response(Id, Result, _State, Data) ->
+    case maps:take(Id, Data#data.pending) of
+        {#pending{caller = From}, Rest} when From =/= init ->
+            gen_statem:reply(From, {ok, Result}),
+            {keep_state, Data#data{pending = Rest},
+             [{{timeout, {req, Id}}, infinity, request_timeout}]};
+        _ ->
+            keep_state_and_data
+    end.
+
+handle_error_response(_Id, Code, Message, initializing, _Data) ->
+    {stop, {init_failed, Code, Message}};
+handle_error_response(Id, Code, Message, _State, Data) ->
+    case maps:take(Id, Data#data.pending) of
+        {#pending{caller = From}, Rest} when From =/= init ->
+            gen_statem:reply(From, {error, {Code, Message}}),
+            {keep_state, Data#data{pending = Rest},
+             [{{timeout, {req, Id}}, infinity, request_timeout}]};
+        _ ->
+            keep_state_and_data
+    end.
+
+handle_server_request(Id, Method, Params, _State,
+                      #data{handler_mod = Mod, handler_state = HS} = Data) ->
+    case Mod:handle_request(Method, Params, HS) of
+        {reply, Result, HS1} ->
+            send_envelope(Data, barrel_mcp_protocol:encode_response(Id, Result)),
+            {keep_state, Data#data{handler_state = HS1}};
+        {error, Code, Msg, HS1} ->
+            send_envelope(Data, barrel_mcp_protocol:encode_error(Id, Code, Msg)),
+            {keep_state, Data#data{handler_state = HS1}};
+        {async, Tag, HS1} ->
+            Async = (Data#data.async_replies)#{Tag => Id},
+            {keep_state, Data#data{handler_state = HS1,
+                                   async_replies = Async}}
+    end.
+
+deliver_async_reply(Tag, Result, Data) ->
+    case maps:take(Tag, Data#data.async_replies) of
+        {Id, Rest} ->
+            Envelope = case Result of
+                {error, Code, Msg} ->
+                    barrel_mcp_protocol:encode_error(Id, Code, Msg);
+                _ ->
+                    barrel_mcp_protocol:encode_response(Id, Result)
+            end,
+            send_envelope(Data, Envelope),
+            Data#data{async_replies = Rest};
+        error ->
+            Data
+    end.
+
+handle_server_notification(<<"notifications/resources/updated">> = Method, Params,
+                           _State, Data) ->
+    Uri = maps:get(<<"uri">>, Params, <<>>),
+    notify_subscribers(Uri, Params, Data),
+    dispatch_notification(Method, Params, Data);
+handle_server_notification(Method, Params, _State, Data) ->
+    dispatch_notification(Method, Params, Data).
+
+dispatch_notification(Method, Params,
+                      #data{handler_mod = Mod, handler_state = HS} = Data) ->
+    case Mod:handle_notification(Method, Params, HS) of
+        {ok, HS1} ->
+            {keep_state, Data#data{handler_state = HS1}}
+    end.
+
+notify_subscribers(Uri, Params, Data) ->
+    case maps:get(Uri, Data#data.subscriptions, []) of
+        [] -> ok;
+        Pids ->
+            lists:foreach(fun(P) -> P ! {mcp_resource_updated, Uri, Params} end,
+                          Pids),
+            ok
+    end.
+
+%%====================================================================
+%% Initialize handling
+%%====================================================================
+
+build_initialize_params(#data{spec = Spec}) ->
+    ClientInfo0 = maps:get(client_info, Spec,
+                           #{<<"name">> => <<"barrel_mcp_client">>,
+                             <<"version">> => <<"2.0.0">>}),
+    ClientInfo = normalize_keys(ClientInfo0),
+    Caps = capabilities_to_wire(maps:get(capabilities, Spec, #{})),
+    Version = maps:get(protocol_version, Spec, ?MCP_CLIENT_PROTOCOL_VERSION),
+    #{
+        <<"protocolVersion">> => Version,
+        <<"capabilities">> => Caps,
+        <<"clientInfo">> => ClientInfo
+    }.
+
+%% Sugar -> spec-shaped wire form. `true' becomes an empty object;
+%% maps are passed through with binary keys.
+capabilities_to_wire(Map) when is_map(Map) ->
+    maps:fold(fun(K, V, Acc) ->
+        Acc#{cap_key(K) => cap_value(V)}
+    end, #{}, Map).
+
+cap_key(K) when is_atom(K) -> atom_to_binary(K, utf8);
+cap_key(K) when is_binary(K) -> K.
+
+cap_value(true) -> #{};
+cap_value(false) -> undefined;
+cap_value(Map) when is_map(Map) ->
+    maps:fold(fun(K, V, Acc) ->
+        case V of
+            false -> Acc;
+            _ -> Acc#{cap_subkey(K) => cap_subvalue(V)}
+        end
+    end, #{}, Map);
+cap_value(_) -> #{}.
+
+cap_subkey(list_changed) -> <<"listChanged">>;
+cap_subkey(K) when is_atom(K) -> atom_to_binary(K, utf8);
+cap_subkey(K) when is_binary(K) -> K.
+
+cap_subvalue(true) -> true;
+cap_subvalue(V) -> V.
+
+normalize_keys(Map) when is_map(Map) ->
+    maps:fold(fun(K, V, Acc) ->
+        Key = case K of
+                  A when is_atom(A) -> atom_to_binary(A, utf8);
+                  B when is_binary(B) -> B
+              end,
+        Acc#{Key => V}
+    end, #{}, Map).
+
+handle_initialize_result(Result, Data) ->
+    case maps:get(<<"protocolVersion">>, Result, undefined) of
+        undefined ->
+            {stop, {init_failed, missing_protocol_version}};
+        Version ->
+            case lists:member(Version, ?MCP_CLIENT_SUPPORTED_VERSIONS) of
+                false ->
+                    {stop, {protocol_version, Version, ?MCP_CLIENT_SUPPORTED_VERSIONS}};
+                true ->
+                    finish_initialize(Version, Result, Data)
+            end
+    end.
+
+finish_initialize(Version, Result, Data) ->
+    case Data#data.transport of
+        {barrel_mcp_client_http, Pid} ->
+            barrel_mcp_client_http:set_protocol_version(Pid, Version),
+            barrel_mcp_client_http:open_event_stream(Pid);
+        _ ->
+            ok
+    end,
+    send_envelope(Data,
+        barrel_mcp_protocol:encode_notification(
+            <<"notifications/initialized">>, #{})),
+    Data1 = Data#data{
+        server_capabilities = maps:get(<<"capabilities">>, Result, #{}),
+        server_info = maps:get(<<"serverInfo">>, Result, #{}),
+        protocol_version = Version
+    },
+    {next_state, ready, Data1}.
+
+%%====================================================================
+%% Transport plumbing
+%%====================================================================
+
+open_transport(#data{spec = Spec} = Data) ->
+    case maps:get(transport, Spec) of
+        {http, Url} ->
+            Auth = barrel_mcp_client_auth:new(maps:get(auth, Spec, none)),
+            case Auth of
+                {error, _} = Err -> Err;
+                _ ->
+                    Opts = #{url => Url, auth => Auth,
+                             open_event_stream => true,
+                             headers => maps:get(http_headers, Spec, [])},
+                    case barrel_mcp_client_http:connect(self(), Opts) of
+                        {ok, Pid} ->
+                            link(Pid),
+                            {ok, Data#data{transport = {barrel_mcp_client_http, Pid}}};
+                        Err -> Err
+                    end
+            end;
+        {stdio, StdioOpts} ->
+            case barrel_mcp_client_stdio:connect(self(), StdioOpts) of
+                {ok, Pid} ->
+                    link(Pid),
+                    {ok, Data#data{transport = {barrel_mcp_client_stdio, Pid}}};
+                Err -> Err
+            end
+    end.
+
+send_envelope(#data{transport = {Mod, Pid}}, Envelope) ->
+    Json = iolist_to_binary(json:encode(Envelope)),
+    Mod:send(Pid, Json);
+send_envelope(_, _) -> ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+next_id(#data{request_id = N} = Data) ->
+    {N, Data#data{request_id = N + 1}}.
+
+deadline(infinity) -> infinity;
+deadline(T) when is_integer(T) ->
+    erlang:monotonic_time(millisecond) + T.
+
+request(Pid, Method, Params) ->
+    request(Pid, Method, Params, ?DEFAULT_REQUEST_TIMEOUT).
+
+request(Pid, Method, Params, Timeout) ->
+    CallTimeout = case Timeout of
+                      infinity -> infinity;
+                      T when is_integer(T) -> T + 5000
+                  end,
+    gen_statem:call(Pid, {request, Method, Params, Timeout}, CallTimeout).
+
+paged(Pid, Method, ResultKey, Opts) ->
+    Params = case maps:get(cursor, Opts, undefined) of
+                 undefined -> #{};
+                 C -> #{<<"cursor">> => C}
+             end,
+    case request(Pid, Method, Params, request_timeout(Opts)) of
+        {ok, Result} ->
+            Items = maps:get(ResultKey, Result, []),
+            Next = maps:get(<<"nextCursor">>, Result, undefined),
+            WantCursor = map_get_default(want_cursor, Opts, false),
+            case {Next, WantCursor} of
+                {undefined, false} -> {ok, Items};
+                _ -> {ok, Items, Next}
+            end;
+        Err -> Err
+    end.
+
+map_get_default(K, M, D) ->
+    case maps:find(K, M) of
+        {ok, V} -> V;
+        error -> D
+    end.
+
+request_timeout(Opts) ->
+    map_get_default(timeout, Opts, ?DEFAULT_REQUEST_TIMEOUT).
+
+maybe_attach_progress_token(Params, Opts) ->
+    case maps:get(progress_token, Opts, undefined) of
+        undefined -> Params;
+        Tok -> Params#{<<"_meta">> => #{<<"progressToken">> => Tok}}
+    end.
+
+is_supported(<<"initialize">>, _) -> true;
+is_supported(<<"ping">>, _) -> true;
+is_supported(<<"notifications/", _/binary>>, _) -> true;
+is_supported(_, #data{server_capabilities = undefined}) -> false;
+is_supported(<<"tools/", _/binary>>, #data{server_capabilities = Caps}) ->
+    maps:is_key(<<"tools">>, Caps);
+is_supported(<<"resources/", _/binary>>, #data{server_capabilities = Caps}) ->
+    maps:is_key(<<"resources">>, Caps);
+is_supported(<<"prompts/", _/binary>>, #data{server_capabilities = Caps}) ->
+    maps:is_key(<<"prompts">>, Caps);
+is_supported(<<"completion/", _/binary>>, #data{server_capabilities = Caps}) ->
+    maps:is_key(<<"completions">>, Caps) orelse maps:is_key(<<"completion">>, Caps);
+is_supported(<<"logging/", _/binary>>, #data{server_capabilities = Caps}) ->
+    maps:is_key(<<"logging">>, Caps);
+is_supported(_, _) -> true.
+
+do_cancel(Id, #data{pending = Pending} = Data) ->
+    case maps:take(Id, Pending) of
+        {#pending{caller = From}, Rest} when From =/= init ->
+            gen_statem:reply(From, {error, cancelled}),
+            send_envelope(Data, barrel_mcp_protocol:encode_notification(
+                <<"notifications/cancelled">>,
+                #{<<"requestId">> => Id, <<"reason">> => <<"cancelled by client">>})),
+            {keep_state, Data#data{pending = Rest},
+             [{{timeout, {req, Id}}, infinity, request_timeout}]};
+        _ ->
+            keep_state_and_data
+    end.
+
+timeout_pending(Id, #data{pending = Pending} = Data) ->
+    case maps:take(Id, Pending) of
+        {#pending{caller = From}, Rest} when From =/= init ->
+            gen_statem:reply(From, {error, timeout}),
+            send_envelope(Data, barrel_mcp_protocol:encode_notification(
+                <<"notifications/cancelled">>,
+                #{<<"requestId">> => Id, <<"reason">> => <<"timeout">>})),
+            {keep_state, Data#data{pending = Rest}};
+        _ ->
+            keep_state_and_data
+    end.
+
+add_sub(Uri, Pid, Data) ->
+    Subs = Data#data.subscriptions,
+    Existing = maps:get(Uri, Subs, []),
+    Data#data{subscriptions = Subs#{Uri => lists:usort([Pid | Existing])}}.
+
+del_sub(Uri, Pid, Data) ->
+    Subs = Data#data.subscriptions,
+    case maps:get(Uri, Subs, []) of
+        [] -> Data;
+        L ->
+            case lists:delete(Pid, L) of
+                [] -> Data#data{subscriptions = maps:remove(Uri, Subs)};
+                L1 -> Data#data{subscriptions = Subs#{Uri => L1}}
+            end
+    end.
+
+%%====================================================================
+%% Termination
+%%====================================================================
+
+terminate(Reason, _State,
+          #data{handler_mod = Mod, handler_state = HS, transport = T}) ->
+    case T of
+        {Tmod, Pid} -> catch Tmod:close(Pid);
+        _ -> ok
+    end,
+    case erlang:function_exported(Mod, terminate, 2) of
+        true -> catch Mod:terminate(Reason, HS);
+        false -> ok
+    end,
     ok.
 
-%% @doc Send initialize request.
--spec initialize(client()) -> {ok, map(), client()} | {error, term()}.
-initialize(Client) ->
-    case request(Client, <<"initialize">>, #{
-        <<"protocolVersion">> => <<"2024-11-05">>,
-        <<"capabilities">> => #{},
-        <<"clientInfo">> => #{
-            <<"name">> => <<"barrel_mcp_client">>,
-            <<"version">> => <<"1.0.0">>
-        }
-    }) of
-        {ok, Result, Client1} ->
-            %% Send initialized notification
-            _ = notify(Client1, <<"initialized">>, #{}),
-            {ok, Result, Client1#client{initialized = true}};
-        Error ->
-            Error
-    end.
-
-%% @doc List available tools.
--spec list_tools(client()) -> {ok, [map()], client()} | {error, term()}.
-list_tools(Client) ->
-    case request(Client, <<"tools/list">>, #{}) of
-        {ok, #{<<"tools">> := Tools}, Client1} ->
-            {ok, Tools, Client1};
-        {ok, Result, Client1} ->
-            {ok, maps:get(<<"tools">>, Result, []), Client1};
-        Error ->
-            Error
-    end.
-
-%% @doc Call a tool.
--spec call_tool(client(), binary(), map()) -> {ok, map(), client()} | {error, term()}.
-call_tool(Client, Name, Args) ->
-    request(Client, <<"tools/call">>, #{
-        <<"name">> => Name,
-        <<"arguments">> => Args
-    }).
-
-%% @doc List available resources.
--spec list_resources(client()) -> {ok, [map()], client()} | {error, term()}.
-list_resources(Client) ->
-    case request(Client, <<"resources/list">>, #{}) of
-        {ok, #{<<"resources">> := Resources}, Client1} ->
-            {ok, Resources, Client1};
-        {ok, Result, Client1} ->
-            {ok, maps:get(<<"resources">>, Result, []), Client1};
-        Error ->
-            Error
-    end.
-
-%% @doc Read a resource.
--spec read_resource(client(), binary()) -> {ok, map(), client()} | {error, term()}.
-read_resource(Client, Uri) ->
-    request(Client, <<"resources/read">>, #{<<"uri">> => Uri}).
-
-%% @doc Subscribe to resource updates.
--spec subscribe(client(), binary()) -> {ok, map(), client()} | {error, term()}.
-subscribe(Client, Uri) ->
-    request(Client, <<"resources/subscribe">>, #{<<"uri">> => Uri}).
-
-%% @doc Unsubscribe from resource updates.
--spec unsubscribe(client(), binary()) -> {ok, map(), client()} | {error, term()}.
-unsubscribe(Client, Uri) ->
-    request(Client, <<"resources/unsubscribe">>, #{<<"uri">> => Uri}).
-
-%% @doc List available prompts.
--spec list_prompts(client()) -> {ok, [map()], client()} | {error, term()}.
-list_prompts(Client) ->
-    case request(Client, <<"prompts/list">>, #{}) of
-        {ok, #{<<"prompts">> := Prompts}, Client1} ->
-            {ok, Prompts, Client1};
-        {ok, Result, Client1} ->
-            {ok, maps:get(<<"prompts">>, Result, []), Client1};
-        Error ->
-            Error
-    end.
-
-%% @doc Get a prompt with arguments.
--spec get_prompt(client(), binary(), map()) -> {ok, map(), client()} | {error, term()}.
-get_prompt(Client, Name, Args) ->
-    request(Client, <<"prompts/get">>, #{
-        <<"name">> => Name,
-        <<"arguments">> => Args
-    }).
-
-%% @doc Request message generation (sampling).
--spec create_message(client(), [map()], map()) -> {ok, map(), client()} | {error, term()}.
-create_message(Client, Messages, Opts) ->
-    request(Client, <<"sampling/createMessage">>, #{
-        <<"messages">> => Messages,
-        <<"maxTokens">> => maps:get(max_tokens, Opts, 1024),
-        <<"temperature">> => maps:get(temperature, Opts, 1.0),
-        <<"stopSequences">> => maps:get(stop_sequences, Opts, [])
-    }).
-
-%%====================================================================
-%% Internal Functions
-%%====================================================================
-
-request(#client{request_id = Id} = Client, Method, Params) ->
-    RequestBody = iolist_to_binary(json:encode(#{
-        <<"jsonrpc">> => <<"2.0">>,
-        <<"id">> => Id,
-        <<"method">> => Method,
-        <<"params">> => Params
-    })),
-    Client1 = Client#client{request_id = Id + 1},
-    case send_request(Client1, RequestBody) of
-        {ok, Response} ->
-            case parse_response(Response) of
-                {ok, Result} ->
-                    {ok, Result, Client1};
-                {error, _} = Error ->
-                    Error
-            end;
-        {error, _} = Error ->
-            Error
-    end.
-
-notify(Client, Method, Params) ->
-    RequestBody = iolist_to_binary(json:encode(#{
-        <<"jsonrpc">> => <<"2.0">>,
-        <<"method">> => Method,
-        <<"params">> => Params
-    })),
-    send_request(Client, RequestBody).
-
-send_request(#client{transport = http, url = Url}, Body) ->
-    Headers = [{<<"Content-Type">>, <<"application/json">>}],
-    case hackney:post(Url, Headers, Body, []) of
-        {ok, 200, _RespHeaders, ResponseBody} ->
-            {ok, ResponseBody};
-        {ok, 204, _RespHeaders, _ResponseBody} ->
-            {ok, <<>>};
-        {ok, Status, _RespHeaders, ResponseBody} ->
-            {error, {http_error, Status, ResponseBody}};
-        {error, Reason} ->
-            {error, Reason}
-    end;
-
-send_request(#client{transport = stdio, port = Port}, Body) ->
-    port_command(Port, [Body, "\n"]),
-    receive
-        {Port, {data, {eol, Line}}} ->
-            {ok, Line};
-        {Port, {data, {noeol, _}}} ->
-            {error, incomplete_response};
-        {Port, {exit_status, Status}} ->
-            {error, {exit, Status}}
-    after 30000 ->
-        {error, timeout}
-    end.
-
-parse_response(<<>>) ->
-    {ok, #{}};
-parse_response(Response) ->
-    try
-        case json:decode(Response) of
-            #{<<"error">> := Error} ->
-                {error, Error};
-            #{<<"result">> := Result} ->
-                {ok, Result};
-            Other ->
-                {ok, Other}
-        end
-    catch
-        _:_ ->
-            {error, {parse_error, Response}}
-    end.
+code_change(_OldVsn, State, Data, _Extra) ->
+    {ok, State, Data}.

--- a/src/barrel_mcp_client_auth.erl
+++ b/src/barrel_mcp_client_auth.erl
@@ -1,0 +1,69 @@
+%%%-------------------------------------------------------------------
+%%% @doc Authorization behaviour for `barrel_mcp_client'.
+%%%
+%%% The HTTP transport calls into this module to obtain the bearer
+%%% token to attach to outgoing requests, and to refresh the token
+%%% when the server returns 401.
+%%%
+%%% A handle is an opaque term passed back into every callback. Static
+%%% bearer tokens use `barrel_mcp_client_auth_bearer'; OAuth 2.1 with
+%%% PKCE will use `barrel_mcp_client_auth_oauth' (Phase D).
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_auth).
+
+-export([new/1, header/1, refresh/2]).
+
+-export_type([t/0, handle/0]).
+
+-type handle() :: term().
+-type t() :: {module(), handle()} | none.
+
+%% @doc Build the auth handle from a config term.
+%%   `none' — no auth header sent.
+%%   `{bearer, Token}' — static bearer token.
+%%   `{oauth, Config}' — OAuth 2.1 + PKCE (Phase D).
+-callback init(Config :: term()) -> {ok, handle()} | {error, term()}.
+
+%% @doc Return the value to put in the `Authorization' header.
+%% Returning `none' means do not attach an Authorization header.
+-callback header(handle()) ->
+    {ok, binary()} | none | {error, term()}.
+
+%% @doc Refresh the credential after a 401. `WwwAuthenticate' is the
+%% raw header value returned by the server, used by OAuth flows for
+%% protected-resource-metadata discovery.
+-callback refresh(handle(), WwwAuthenticate :: binary() | undefined) ->
+    {ok, handle()} | {error, term()}.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% @doc Construct an auth handle from a user-facing config term.
+-spec new(none | {bearer, binary()} | {oauth, map()}) ->
+    t() | {error, term()}.
+new(none) ->
+    none;
+new({bearer, Token}) when is_binary(Token) ->
+    case barrel_mcp_client_auth_bearer:init(Token) of
+        {ok, H} -> {barrel_mcp_client_auth_bearer, H};
+        Err -> Err
+    end;
+new({oauth, _Config}) ->
+    %% Phase D.
+    {error, oauth_not_yet_supported}.
+
+%% @doc Lookup the Authorization header for the current state.
+-spec header(t()) -> {ok, binary()} | none | {error, term()}.
+header(none) -> none;
+header({Mod, H}) -> Mod:header(H).
+
+%% @doc Refresh after a 401, returning a new handle.
+-spec refresh(t(), binary() | undefined) -> {ok, t()} | {error, term()}.
+refresh(none, _) -> {error, no_auth_configured};
+refresh({Mod, H}, Www) ->
+    case Mod:refresh(H, Www) of
+        {ok, H1} -> {ok, {Mod, H1}};
+        Err -> Err
+    end.

--- a/src/barrel_mcp_client_auth_bearer.erl
+++ b/src/barrel_mcp_client_auth_bearer.erl
@@ -1,0 +1,24 @@
+%%%-------------------------------------------------------------------
+%%% @doc Static bearer-token auth for `barrel_mcp_client'.
+%%%
+%%% Refresh is a no-op: a static token cannot be rotated by the
+%%% library. A 401 with this handle returns `{error, unauthorized}' so
+%%% the caller can supply a new token.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_auth_bearer).
+
+-behaviour(barrel_mcp_client_auth).
+
+-export([init/1, header/1, refresh/2]).
+
+init(Token) when is_binary(Token), byte_size(Token) > 0 ->
+    {ok, Token};
+init(_) ->
+    {error, invalid_token}.
+
+header(Token) ->
+    {ok, <<"Bearer ", Token/binary>>}.
+
+refresh(_Token, _Www) ->
+    {error, unauthorized}.

--- a/src/barrel_mcp_client_handler.erl
+++ b/src/barrel_mcp_client_handler.erl
@@ -1,0 +1,58 @@
+%%%-------------------------------------------------------------------
+%%% @doc Behaviour for handling server-initiated MCP messages.
+%%%
+%%% A host application implements this module to react to requests
+%%% the server sends *to* the client (per the declared client
+%%% capabilities) and to notifications the server emits.
+%%%
+%%% Capabilities and the matching callbacks:
+%%% <ul>
+%%%   <li>`sampling' — server may call `sampling/createMessage' to ask
+%%%       the host to run an LLM completion.</li>
+%%%   <li>`roots'    — server may call `roots/list' to enumerate the
+%%%       filesystem boundaries the host exposes.</li>
+%%%   <li>`elicitation' — server may call `elicitation/create' to
+%%%       prompt the user for a value.</li>
+%%% </ul>
+%%%
+%%% Notifications cover the rest of the spec: `notifications/cancelled',
+%%% `notifications/progress', `notifications/resources/updated',
+%%% `notifications/resources/list_changed', `notifications/tools/list_changed',
+%%% `notifications/prompts/list_changed', `notifications/message'.
+%%%
+%%% A default implementation in `barrel_mcp_client_handler_default'
+%%% returns `method_not_found' for every request and ignores every
+%%% notification, so a host only writes callbacks for capabilities it
+%%% actually declares.
+%%%
+%%% Async replies: when answering a request requires a long-running
+%%% operation (e.g. an HTTP call to an LLM provider), return
+%%% `{async, Tag, State}' from `handle_request/3' and later send
+%%% `barrel_mcp_client:reply_async(ClientPid, Tag, Result)' from any
+%%% process. The client's state machine will not block while the
+%%% handler is computing.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_handler).
+
+-export_type([state/0, async_tag/0]).
+
+-type state() :: term().
+-type async_tag() :: term().
+
+-callback init(Args :: term()) -> {ok, state()} | {error, term()}.
+
+-callback handle_request(Method :: binary(),
+                         Params :: map(),
+                         State :: state()) ->
+    {reply, Result :: term(), state()} |
+    {error, Code :: integer(), Message :: binary(), state()} |
+    {async, async_tag(), state()}.
+
+-callback handle_notification(Method :: binary(),
+                              Params :: map(),
+                              State :: state()) -> {ok, state()}.
+
+-callback terminate(Reason :: term(), State :: state()) -> any().
+
+-optional_callbacks([terminate/2]).

--- a/src/barrel_mcp_client_handler_default.erl
+++ b/src/barrel_mcp_client_handler_default.erl
@@ -1,0 +1,29 @@
+%%%-------------------------------------------------------------------
+%%% @doc Default no-op handler for `barrel_mcp_client'.
+%%%
+%%% Replies `method_not_found' to every server-initiated request and
+%%% ignores every notification. Hosts that declare no client
+%%% capabilities can use this as their handler; hosts that declare
+%%% capabilities should provide their own module.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_handler_default).
+
+-behaviour(barrel_mcp_client_handler).
+
+-export([init/1, handle_request/3, handle_notification/3, terminate/2]).
+
+-include("barrel_mcp.hrl").
+
+init(_Args) ->
+    {ok, undefined}.
+
+handle_request(Method, _Params, State) ->
+    {error, ?JSONRPC_METHOD_NOT_FOUND,
+     <<"Method not found: ", Method/binary>>, State}.
+
+handle_notification(_Method, _Params, State) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.

--- a/src/barrel_mcp_client_http.erl
+++ b/src/barrel_mcp_client_http.erl
@@ -1,0 +1,417 @@
+%%%-------------------------------------------------------------------
+%%% @doc Streamable HTTP transport for `barrel_mcp_client'.
+%%%
+%%% Implements MCP's Streamable HTTP transport (2025-03-26 onward) on
+%%% the client side:
+%%% <ul>
+%%%   <li>POST every request with `Accept: application/json,
+%%%       text/event-stream'. The server may answer with a single JSON
+%%%       envelope or with an SSE stream that interleaves
+%%%       server-initiated requests/notifications until the matching
+%%%       response arrives.</li>
+%%%   <li>GET opens a long-lived SSE channel for unsolicited
+%%%       server-to-client traffic. Optional: a server may return 405,
+%%%       in which case server messages only arrive on POST streams.</li>
+%%%   <li>DELETE on close, with the captured `Mcp-Session-Id'.</li>
+%%%   <li>`MCP-Protocol-Version' header echoed on every request after
+%%%       the initialize response has been processed by the client.</li>
+%%%   <li>401 with `WWW-Authenticate' triggers the configured auth
+%%%       refresh; the original request is retried once.</li>
+%%% </ul>
+%%%
+%%% Each parsed SSE event's `data:' payload is forwarded to the owning
+%%% client as `{mcp_in, self(), Json}'. The owner sees the same shape
+%%% as it does from the stdio transport.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_http).
+
+-behaviour(gen_server).
+-behaviour(barrel_mcp_client_transport).
+
+%% Transport API
+-export([connect/2, send/2, close/1]).
+
+%% Public helpers
+-export([set_session_id/2, set_protocol_version/2, open_event_stream/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(req, {
+    body :: binary(),
+    status :: undefined | non_neg_integer(),
+    headers = [] :: list(),
+    buffer = <<>> :: binary(),
+    format :: undefined | json | sse,
+    retried = false :: boolean()
+}).
+
+-record(state, {
+    owner :: pid(),
+    url :: binary(),
+    extra_headers = [] :: list(),
+    session_id :: binary() | undefined,
+    protocol_version :: binary() | undefined,
+    auth :: barrel_mcp_client_auth:t(),
+    requests = #{} :: #{reference() => #req{}},
+    sse_ref :: reference() | undefined,
+    sse_buffer = <<>> :: binary(),
+    sse_last_event_id :: binary() | undefined,
+    sse_enabled = false :: boolean()
+}).
+
+%%====================================================================
+%% Transport API
+%%====================================================================
+
+connect(Owner, Opts) ->
+    gen_server:start_link(?MODULE, {Owner, Opts}, []).
+
+send(Pid, Body) ->
+    gen_server:call(Pid, {send, iolist_to_binary(Body)}, 30000).
+
+close(Pid) ->
+    gen_server:cast(Pid, close).
+
+%%====================================================================
+%% Public helpers
+%%====================================================================
+
+%% @doc Capture the `Mcp-Session-Id' returned on the initialize POST
+%% so subsequent requests can echo it.
+set_session_id(Pid, SessionId) when is_binary(SessionId); SessionId =:= undefined ->
+    gen_server:cast(Pid, {set_session_id, SessionId}).
+
+%% @doc Set the negotiated protocol version. Once set, every outgoing
+%% request includes the `MCP-Protocol-Version' header.
+set_protocol_version(Pid, Version) when is_binary(Version) ->
+    gen_server:cast(Pid, {set_protocol_version, Version}).
+
+%% @doc Open the long-lived GET SSE for unsolicited server messages.
+%% Idempotent: a second call while the stream is open is a no-op.
+open_event_stream(Pid) ->
+    gen_server:cast(Pid, open_event_stream).
+
+%%====================================================================
+%% gen_server
+%%====================================================================
+
+init({Owner, Opts}) ->
+    process_flag(trap_exit, true),
+    Url = case maps:get(url, Opts) of
+              U when is_binary(U) -> U;
+              U when is_list(U) -> iolist_to_binary(U)
+          end,
+    Auth = maps:get(auth, Opts, none),
+    Headers = lists:map(fun({K, V}) -> {to_bin(K), to_bin(V)} end,
+                        maps:get(headers, Opts, [])),
+    SseEnabled = maps:get(open_event_stream, Opts, true),
+    {ok, #state{owner = Owner,
+                url = Url,
+                extra_headers = Headers,
+                auth = Auth,
+                sse_enabled = SseEnabled}}.
+
+handle_call({send, Body}, _From, State) ->
+    case start_post(Body, false, State) of
+        {ok, State1} -> {reply, ok, State1};
+        {error, Reason} -> {reply, {error, Reason}, State}
+    end;
+handle_call(_Msg, _From, State) ->
+    {reply, {error, badcall}, State}.
+
+handle_cast({set_session_id, SessionId}, State) ->
+    {noreply, State#state{session_id = SessionId}};
+handle_cast({set_protocol_version, Version}, State) ->
+    {noreply, State#state{protocol_version = Version}};
+handle_cast(open_event_stream, #state{sse_ref = Ref} = State) when is_reference(Ref) ->
+    {noreply, State};
+handle_cast(open_event_stream, State) ->
+    {noreply, start_get_sse(State)};
+handle_cast(close, State) ->
+    _ = send_delete(State),
+    {stop, normal, State};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% Hackney async response messages.
+handle_info({hackney_response, Ref, {status, Status, _Reason}},
+            #state{requests = Reqs} = State) ->
+    case maps:find(Ref, Reqs) of
+        {ok, R} ->
+            {noreply, State#state{requests = Reqs#{Ref => R#req{status = Status}}}};
+        error ->
+            handle_sse_status(Ref, Status, State)
+    end;
+handle_info({hackney_response, Ref, {headers, Headers}},
+            #state{requests = Reqs} = State) ->
+    case maps:find(Ref, Reqs) of
+        {ok, R} ->
+            Format = detect_format(Headers),
+            R1 = R#req{headers = Headers, format = Format},
+            State1 = capture_session_header(Headers, State),
+            {noreply, State1#state{requests = Reqs#{Ref => R1}}};
+        error ->
+            handle_sse_headers(Ref, Headers, State)
+    end;
+handle_info({hackney_response, Ref, done},
+            #state{requests = Reqs, sse_ref = SseRef} = State) ->
+    case maps:find(Ref, Reqs) of
+        {ok, R} ->
+            State1 = finalize_request(Ref, R, State),
+            {noreply, State1};
+        error when Ref =:= SseRef ->
+            handle_sse_done(State);
+        error ->
+            {noreply, State}
+    end;
+handle_info({hackney_response, Ref, {error, Reason}},
+            #state{requests = Reqs, sse_ref = SseRef, owner = Owner} = State) ->
+    case maps:is_key(Ref, Reqs) of
+        true ->
+            Owner ! {mcp_closed, self(), {request_failed, Reason}},
+            {noreply, State#state{requests = maps:remove(Ref, Reqs)}};
+        false when Ref =:= SseRef ->
+            {noreply, State#state{sse_ref = undefined, sse_buffer = <<>>}};
+        false ->
+            {noreply, State}
+    end;
+handle_info({hackney_response, Ref, Chunk},
+            #state{requests = Reqs, sse_ref = SseRef} = State)
+  when is_binary(Chunk) ->
+    case maps:find(Ref, Reqs) of
+        {ok, #req{format = sse, buffer = Buf} = R} ->
+            {Events, NewBuf} = parse_sse(<<Buf/binary, Chunk/binary>>),
+            State1 = forward_sse_events(Events, State),
+            R1 = R#req{buffer = NewBuf},
+            {noreply, State1#state{requests = Reqs#{Ref => R1}}};
+        {ok, #req{buffer = Buf} = R} ->
+            R1 = R#req{buffer = <<Buf/binary, Chunk/binary>>},
+            {noreply, State#state{requests = Reqs#{Ref => R1}}};
+        error when Ref =:= SseRef ->
+            handle_sse_chunk(Chunk, State);
+        error ->
+            {noreply, State}
+    end;
+handle_info(reopen_sse, #state{sse_enabled = true, sse_ref = undefined} = State) ->
+    {noreply, start_get_sse(State)};
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, State) ->
+    _ = send_delete(State),
+    State#state.owner ! {mcp_closed, self(), terminated},
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%====================================================================
+%% POST request lifecycle
+%%====================================================================
+
+start_post(Body, Retried, State) ->
+    Headers = build_headers(State),
+    case hackney:request(post, State#state.url, Headers, Body,
+                         [async, {recv_timeout, infinity}]) of
+        {ok, Ref} ->
+            Req = #req{body = Body, retried = Retried},
+            {ok, State#state{requests = (State#state.requests)#{Ref => Req}}};
+        {error, _} = Err ->
+            Err
+    end.
+
+finalize_request(Ref, #req{format = sse} = _R, #state{requests = Reqs} = State) ->
+    %% SSE stream ended (server done). Drop the request slot.
+    State#state{requests = maps:remove(Ref, Reqs)};
+finalize_request(Ref, #req{status = 401, retried = false, body = Body, headers = H},
+                 #state{requests = Reqs, auth = Auth, owner = Owner} = State) ->
+    Www = header_value(<<"www-authenticate">>, H),
+    case barrel_mcp_client_auth:refresh(Auth, Www) of
+        {ok, NewAuth} ->
+            State1 = State#state{auth = NewAuth,
+                                 requests = maps:remove(Ref, Reqs)},
+            case start_post(Body, true, State1) of
+                {ok, State2} -> State2;
+                {error, _} ->
+                    Owner ! {mcp_closed, self(), unauthorized},
+                    State1
+            end;
+        {error, _} ->
+            Owner ! {mcp_closed, self(), unauthorized},
+            State#state{requests = maps:remove(Ref, Reqs)}
+    end;
+finalize_request(Ref, #req{status = Status, buffer = Buf} = _R,
+                 #state{requests = Reqs, owner = Owner} = State)
+  when Status >= 200, Status < 300 ->
+    case Buf of
+        <<>> -> ok;  %% 204 No Content for notifications
+        _ ->
+            Owner ! {mcp_in, self(), Buf},
+            ok
+    end,
+    State#state{requests = maps:remove(Ref, Reqs)};
+finalize_request(Ref, #req{status = Status, buffer = Buf},
+                 #state{requests = Reqs, owner = Owner} = State) ->
+    Owner ! {mcp_closed, self(), {http_error, Status, Buf}},
+    State#state{requests = maps:remove(Ref, Reqs)}.
+
+%%====================================================================
+%% SSE GET stream (unsolicited server-to-client)
+%%====================================================================
+
+start_get_sse(#state{sse_enabled = false} = State) -> State;
+start_get_sse(State) ->
+    Headers0 = build_headers(State),
+    Headers = case State#state.sse_last_event_id of
+                  undefined -> Headers0;
+                  Id -> [{<<"last-event-id">>, Id} | Headers0]
+              end,
+    case hackney:request(get, State#state.url, Headers, <<>>,
+                         [async, {recv_timeout, infinity}]) of
+        {ok, Ref} ->
+            State#state{sse_ref = Ref};
+        {error, _} ->
+            State
+    end.
+
+handle_sse_status(_Ref, Status, State) when Status >= 200, Status < 300 ->
+    {noreply, State};
+handle_sse_status(_Ref, _Status, State) ->
+    %% Server doesn't support GET SSE (e.g. 405). Quietly drop.
+    {noreply, State#state{sse_ref = undefined}}.
+
+handle_sse_headers(_Ref, _Headers, State) ->
+    {noreply, State}.
+
+handle_sse_chunk(Chunk, #state{sse_buffer = Buf} = State) ->
+    {Events, NewBuf} = parse_sse(<<Buf/binary, Chunk/binary>>),
+    State1 = forward_sse_events(Events, State),
+    {noreply, State1#state{sse_buffer = NewBuf}}.
+
+handle_sse_done(State) ->
+    %% Server closed the long-lived stream; reopen in a moment.
+    erlang:send_after(1000, self(), reopen_sse),
+    {noreply, State#state{sse_ref = undefined, sse_buffer = <<>>}}.
+
+%%====================================================================
+%% SSE parsing
+%%====================================================================
+
+%% Returns {Events, RemainderBuffer}. An event is `{Id | undefined,
+%% Event | undefined, DataBinary}'. We only care about `data:' for
+%% MCP, but `id:' is captured for Last-Event-ID resumability.
+parse_sse(Buf) ->
+    parse_sse(Buf, []).
+
+parse_sse(Buf, Acc) ->
+    case binary:split(Buf, <<"\n\n">>) of
+        [_] ->
+            {lists:reverse(Acc), Buf};
+        [Block, Rest] ->
+            Event = parse_event_block(Block),
+            parse_sse(Rest, [Event | Acc])
+    end.
+
+parse_event_block(Block) ->
+    Lines = binary:split(Block, <<"\n">>, [global, trim_all]),
+    lists:foldl(fun(Line, {Id, Ev, DataAcc}) ->
+        case Line of
+            <<"id: ", V/binary>>    -> {V, Ev, DataAcc};
+            <<"id:", V/binary>>     -> {trim_leading_space(V), Ev, DataAcc};
+            <<"event: ", V/binary>> -> {Id, V, DataAcc};
+            <<"event:", V/binary>>  -> {Id, trim_leading_space(V), DataAcc};
+            <<"data: ", V/binary>>  -> {Id, Ev, append_data(DataAcc, V)};
+            <<"data:", V/binary>>   -> {Id, Ev, append_data(DataAcc, trim_leading_space(V))};
+            <<":", _/binary>>       -> {Id, Ev, DataAcc};  %% comment
+            _                       -> {Id, Ev, DataAcc}   %% unknown field
+        end
+    end, {undefined, undefined, <<>>}, Lines).
+
+append_data(<<>>, V) -> V;
+append_data(Acc, V)  -> <<Acc/binary, "\n", V/binary>>.
+
+trim_leading_space(<<" ", R/binary>>) -> R;
+trim_leading_space(B) -> B.
+
+forward_sse_events([], State) -> State;
+forward_sse_events([{Id, _Ev, Data} | Rest], #state{owner = Owner} = State) ->
+    case Data of
+        <<>> -> ok;
+        _ ->
+            Owner ! {mcp_in, self(), Data},
+            ok
+    end,
+    State1 = case Id of
+                 undefined -> State;
+                 _         -> State#state{sse_last_event_id = Id}
+             end,
+    forward_sse_events(Rest, State1).
+
+%%====================================================================
+%% Header helpers
+%%====================================================================
+
+build_headers(#state{extra_headers = Extra,
+                     session_id = Sid,
+                     protocol_version = PV,
+                     auth = Auth}) ->
+    Base = [
+        {<<"content-type">>, <<"application/json">>},
+        {<<"accept">>, <<"application/json, text/event-stream">>}
+    ],
+    H1 = case Sid of
+             undefined -> Base;
+             _ -> [{<<"mcp-session-id">>, Sid} | Base]
+         end,
+    H2 = case PV of
+             undefined -> H1;
+             _ -> [{<<"mcp-protocol-version">>, PV} | H1]
+         end,
+    H3 = case barrel_mcp_client_auth:header(Auth) of
+             {ok, AuthHdr} -> [{<<"authorization">>, AuthHdr} | H2];
+             _ -> H2
+         end,
+    H3 ++ Extra.
+
+detect_format(Headers) ->
+    case header_value(<<"content-type">>, Headers) of
+        undefined -> json;
+        CT ->
+            case binary:match(string:lowercase(CT), <<"text/event-stream">>) of
+                nomatch -> json;
+                _ -> sse
+            end
+    end.
+
+capture_session_header(Headers, State) ->
+    case header_value(<<"mcp-session-id">>, Headers) of
+        undefined -> State;
+        Sid -> State#state{session_id = Sid}
+    end.
+
+header_value(Name, Headers) ->
+    Lower = string:lowercase(Name),
+    Found = lists:filter(fun({K, _}) ->
+                                 string:lowercase(to_bin(K)) =:= Lower
+                         end, Headers),
+    case Found of
+        [{_, V} | _] -> to_bin(V);
+        [] -> undefined
+    end.
+
+to_bin(B) when is_binary(B) -> B;
+to_bin(L) when is_list(L) -> iolist_to_binary(L);
+to_bin(A) when is_atom(A) -> atom_to_binary(A, utf8).
+
+%%====================================================================
+%% DELETE on close
+%%====================================================================
+
+send_delete(#state{session_id = undefined}) -> ok;
+send_delete(State) ->
+    Headers = build_headers(State),
+    _ = hackney:request(delete, State#state.url, Headers, <<>>, []),
+    ok.

--- a/src/barrel_mcp_client_stdio.erl
+++ b/src/barrel_mcp_client_stdio.erl
@@ -1,0 +1,124 @@
+%%%-------------------------------------------------------------------
+%%% @doc stdio transport for `barrel_mcp_client'.
+%%%
+%%% Spawns the configured executable as an Erlang port, frames stdin
+%%% as line-delimited JSON-RPC, and forwards each complete line to
+%%% the owning client gen_statem as `{mcp_in, self(), Json}'.
+%%%
+%%% A line is "complete" when cowboy delivers `{eol, _}'; partial
+%%% reads (`{noeol, _}') are buffered until the matching `{eol, _}'
+%%% arrives. The default 1 MiB line limit matches the previous
+%%% in-process implementation.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_stdio).
+
+-behaviour(gen_server).
+-behaviour(barrel_mcp_client_transport).
+
+%% Transport API
+-export([connect/2, send/2, close/1]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-record(state, {
+    owner :: pid(),
+    port :: port() | undefined,
+    buffer = <<>> :: binary()
+}).
+
+-define(LINE_LIMIT, 1048576).
+
+%%====================================================================
+%% Transport API
+%%====================================================================
+
+connect(Owner, #{command := Cmd} = Opts) ->
+    gen_server:start_link(?MODULE, {Owner, Cmd, maps:get(args, Opts, []),
+                                    maps:get(env, Opts, [])}, []).
+
+send(Pid, Body) ->
+    gen_server:call(Pid, {send, iolist_to_binary(Body)}, 5000).
+
+close(Pid) ->
+    gen_server:cast(Pid, close).
+
+%%====================================================================
+%% gen_server
+%%====================================================================
+
+init({Owner, Cmd, Args, Env}) ->
+    process_flag(trap_exit, true),
+    PortOpts = [
+        {args, Args},
+        {line, ?LINE_LIMIT},
+        binary,
+        use_stdio,
+        exit_status,
+        hide
+    ] ++ env_opt(Env),
+    try open_port({spawn_executable, Cmd}, PortOpts) of
+        Port when is_port(Port) ->
+            {ok, #state{owner = Owner, port = Port}}
+    catch
+        error:Reason ->
+            {stop, {spawn_failed, Cmd, Reason}}
+    end.
+
+handle_call({send, Body}, _From, #state{port = Port} = State) ->
+    try
+        true = port_command(Port, [Body, $\n]),
+        {reply, ok, State}
+    catch
+        error:Reason ->
+            {reply, {error, Reason}, State}
+    end;
+handle_call(_Msg, _From, State) ->
+    {reply, {error, badcall}, State}.
+
+handle_cast(close, State) ->
+    {stop, normal, State};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% A complete line — emit it.
+handle_info({Port, {data, {eol, Line}}},
+            #state{port = Port, owner = Owner, buffer = Buf} = State) ->
+    Full = <<Buf/binary, Line/binary>>,
+    Owner ! {mcp_in, self(), Full},
+    {noreply, State#state{buffer = <<>>}};
+%% A partial line — buffer it until the eol arrives.
+handle_info({Port, {data, {noeol, Chunk}}},
+            #state{port = Port, buffer = Buf} = State) ->
+    {noreply, State#state{buffer = <<Buf/binary, Chunk/binary>>}};
+handle_info({Port, {exit_status, Status}},
+            #state{port = Port, owner = Owner} = State) ->
+    Owner ! {mcp_closed, self(), {exit_status, Status}},
+    {stop, {shutdown, {exit_status, Status}}, State#state{port = undefined}};
+handle_info({'EXIT', Port, Reason}, #state{port = Port, owner = Owner} = State) ->
+    Owner ! {mcp_closed, self(), Reason},
+    {stop, {shutdown, Reason}, State#state{port = undefined}};
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, #state{port = Port, owner = Owner}) ->
+    case Port of
+        P when is_port(P) ->
+            catch port_close(P);
+        _ ->
+            ok
+    end,
+    Owner ! {mcp_closed, self(), terminated},
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%====================================================================
+%% Internal
+%%====================================================================
+
+env_opt([]) -> [];
+env_opt(Env) -> [{env, Env}].

--- a/src/barrel_mcp_client_sup.erl
+++ b/src/barrel_mcp_client_sup.erl
@@ -1,0 +1,35 @@
+%%%-------------------------------------------------------------------
+%%% @doc Supervisor for `barrel_mcp_client' workers.
+%%%
+%%% Each child is one connection to one MCP server. Hosts spawn
+%%% children on demand via `barrel_mcp_clients:start_client/2'.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0, start_child/2]).
+-export([init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% @doc Start a new client worker. `Spec' is the
+%% `barrel_mcp_client:connect_spec()'.
+-spec start_child(term(), barrel_mcp_client:connect_spec()) ->
+    {ok, pid()} | {error, term()}.
+start_child(ServerId, Spec) ->
+    Child = #{
+        id => ServerId,
+        start => {barrel_mcp_client, start_link, [Spec]},
+        restart => transient,
+        shutdown => 5000,
+        type => worker,
+        modules => [barrel_mcp_client]
+    },
+    supervisor:start_child(?MODULE, Child).
+
+init([]) ->
+    SupFlags = #{strategy => one_for_one, intensity => 10, period => 60},
+    {ok, {SupFlags, []}}.

--- a/src/barrel_mcp_client_transport.erl
+++ b/src/barrel_mcp_client_transport.erl
@@ -1,0 +1,53 @@
+%%%-------------------------------------------------------------------
+%%% @doc Transport behaviour for `barrel_mcp_client'.
+%%%
+%%% A transport owns the underlying socket/port/process and forwards
+%%% inbound JSON-RPC messages to the owning client gen_statem. The
+%%% client never reads the wire directly; it only sends/closes through
+%%% this behaviour and consumes asynchronous messages of the form:
+%%%
+%%% <ul>
+%%%   <li>`{mcp_in, TransportPid, JsonBinary}' — one decoded JSON-RPC
+%%%       envelope arrived from the peer.</li>
+%%%   <li>`{mcp_closed, TransportPid, Reason}' — the transport ended
+%%%       (peer hung up, port exited, etc.).</li>
+%%% </ul>
+%%%
+%%% Transports MUST deliver one envelope per `mcp_in' message; framing
+%%% (line splitting, SSE parsing) is the transport's responsibility.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_transport).
+
+-export([send/2, close/1]).
+
+-type t() :: {module(), pid()}.
+-export_type([t/0]).
+
+%% @doc Open a transport. `Owner' will receive `mcp_in' / `mcp_closed'
+%% messages from the spawned transport process.
+-callback connect(Owner :: pid(), Opts :: map()) ->
+    {ok, pid()} | {error, term()}.
+
+%% @doc Send a fully-encoded JSON-RPC envelope (binary JSON) to the
+%% peer. Implementations may add transport framing (newline, SSE) but
+%% must not modify the JSON content.
+-callback send(TransportPid :: pid(), JsonBinary :: iodata()) ->
+    ok | {error, term()}.
+
+%% @doc Close the transport.
+-callback close(TransportPid :: pid()) -> ok.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% @doc Convenience wrapper to send through any transport handle.
+-spec send(t(), iodata()) -> ok | {error, term()}.
+send({Mod, Pid}, Body) ->
+    Mod:send(Pid, Body).
+
+%% @doc Convenience wrapper to close any transport handle.
+-spec close(t()) -> ok.
+close({Mod, Pid}) ->
+    Mod:close(Pid).

--- a/src/barrel_mcp_clients.erl
+++ b/src/barrel_mcp_clients.erl
@@ -1,0 +1,112 @@
+%%%-------------------------------------------------------------------
+%%% @doc Federation registry for connected MCP clients.
+%%%
+%%% Lets a host application keep one supervised `barrel_mcp_client'
+%%% per remote MCP server, looked up by an opaque `ServerId' the host
+%%% chooses (typically a binary name like `<<"github">>'). Tool-name
+%%% namespacing across servers is the host's policy and is not
+%%% enforced here.
+%%%
+%%% This module is a tiny `gen_server' whose only job is to own the
+%%% lookup ETS table (so the table outlives any single caller) and to
+%%% serialize registration so two callers cannot race on the same
+%%% `ServerId'. Lookups go directly to ETS without crossing the
+%%% process boundary.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_clients).
+
+-behaviour(gen_server).
+
+-export([start_link/0,
+         start_client/2,
+         stop_client/1,
+         whereis_client/1,
+         list_clients/0]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(TABLE, ?MODULE).
+
+%%====================================================================
+%% Public API
+%%====================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% @doc Start a supervised client worker for `ServerId'. Fails if a
+%% worker is already registered for that id.
+-spec start_client(term(), barrel_mcp_client:connect_spec()) ->
+    {ok, pid()} | {error, term()}.
+start_client(ServerId, Spec) ->
+    gen_server:call(?MODULE, {start_client, ServerId, Spec}).
+
+%% @doc Stop the client worker for `ServerId'.
+-spec stop_client(term()) -> ok | {error, not_found}.
+stop_client(ServerId) ->
+    gen_server:call(?MODULE, {stop_client, ServerId}).
+
+-spec whereis_client(term()) -> pid() | undefined.
+whereis_client(ServerId) ->
+    case ets:lookup(?TABLE, ServerId) of
+        [{_, Pid, _Ref}] -> Pid;
+        [] -> undefined
+    end.
+
+-spec list_clients() -> [{term(), pid()}].
+list_clients() ->
+    ets:foldl(fun({Id, Pid, _}, Acc) -> [{Id, Pid} | Acc] end, [], ?TABLE).
+
+%%====================================================================
+%% gen_server
+%%====================================================================
+
+init([]) ->
+    _ = ets:new(?TABLE, [set, named_table, protected, {read_concurrency, true}]),
+    {ok, #{}}.
+
+handle_call({start_client, ServerId, Spec}, _From, State) ->
+    case ets:lookup(?TABLE, ServerId) of
+        [{_, Pid, _}] when is_pid(Pid) ->
+            {reply, {error, {already_registered, Pid}}, State};
+        [] ->
+            case barrel_mcp_client_sup:start_child(ServerId, Spec) of
+                {ok, Pid} = Ok ->
+                    Ref = erlang:monitor(process, Pid),
+                    true = ets:insert(?TABLE, {ServerId, Pid, Ref}),
+                    {reply, Ok, State};
+                Err ->
+                    {reply, Err, State}
+            end
+    end;
+handle_call({stop_client, ServerId}, _From, State) ->
+    case ets:lookup(?TABLE, ServerId) of
+        [{_, Pid, Ref}] ->
+            erlang:demonitor(Ref, [flush]),
+            true = ets:delete(?TABLE, ServerId),
+            barrel_mcp_client:close(Pid),
+            {reply, ok, State};
+        [] ->
+            {reply, {error, not_found}, State}
+    end;
+handle_call(_Msg, _From, State) ->
+    {reply, {error, badcall}, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', _Ref, process, Pid, _Reason}, State) ->
+    %% Client crashed or shut down — remove its registration.
+    Match = ets:match_object(?TABLE, {'_', Pid, '_'}),
+    [ets:delete(?TABLE, Id) || {Id, _, _} <- Match],
+    {noreply, State};
+handle_info(_Msg, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -483,8 +483,8 @@ cors_headers() ->
     #{
         <<"access-control-allow-origin">> => <<"*">>,
         <<"access-control-allow-methods">> => <<"POST, GET, DELETE, OPTIONS">>,
-        <<"access-control-allow-headers">> => <<"content-type, authorization, x-api-key, mcp-session-id, accept">>,
-        <<"access-control-expose-headers">> => <<"www-authenticate, mcp-session-id">>
+        <<"access-control-allow-headers">> => <<"content-type, authorization, x-api-key, mcp-session-id, mcp-protocol-version, accept, last-event-id">>,
+        <<"access-control-expose-headers">> => <<"www-authenticate, mcp-session-id, mcp-protocol-version">>
     }.
 
 %%====================================================================

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -18,6 +18,15 @@
     notification_response/0
 ]).
 
+%% JSON-RPC envelope helpers (shared by client + server)
+-export([
+    encode_request/3,
+    encode_notification/2,
+    encode_response/2,
+    encode_error/3,
+    decode_envelope/1
+]).
+
 %%====================================================================
 %% API
 %%====================================================================
@@ -234,6 +243,10 @@ handle_request(Method, _Params, Id, _State) ->
 %% Notification Handlers
 %%====================================================================
 
+%% Spec name (2025-03-26+).
+handle_notification(<<"notifications/initialized">>, _Params, _State) ->
+    ok;
+%% Legacy bare name kept for one release; older clients still send this.
 handle_notification(<<"initialized">>, _Params, _State) ->
     ok;
 
@@ -290,3 +303,72 @@ format_resource_result(Uri, Result) ->
 
 format_error({Class, Reason, _Stack}) ->
     iolist_to_binary(io_lib:format("~p:~p", [Class, Reason])).
+
+%%====================================================================
+%% JSON-RPC envelope helpers
+%%====================================================================
+
+%% @doc Build a JSON-RPC request envelope.
+-spec encode_request(term(), binary(), map()) -> map().
+encode_request(Id, Method, Params) ->
+    #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => Id,
+        <<"method">> => Method,
+        <<"params">> => Params
+    }.
+
+%% @doc Build a JSON-RPC notification envelope (no id).
+-spec encode_notification(binary(), map()) -> map().
+encode_notification(Method, Params) ->
+    #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"method">> => Method,
+        <<"params">> => Params
+    }.
+
+%% @doc Build a JSON-RPC success response.
+-spec encode_response(term(), term()) -> map().
+encode_response(Id, Result) ->
+    #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => Id,
+        <<"result">> => Result
+    }.
+
+%% @doc Build a JSON-RPC error response. Alias of `error_response/3'.
+-spec encode_error(term(), integer(), binary()) -> map().
+encode_error(Id, Code, Message) ->
+    error_response(Id, Code, Message).
+
+%% @doc Classify a decoded JSON-RPC envelope.
+%%
+%% Returns the kind so client and server agree on routing without each
+%% having to peek at the same keys.
+-spec decode_envelope(map()) ->
+    {request, Id :: term(), Method :: binary(), Params :: map()} |
+    {notification, Method :: binary(), Params :: map()} |
+    {response, Id :: term(), Result :: term()} |
+    {error, Id :: term(), Code :: integer(), Message :: binary(), Data :: term()} |
+    {invalid, term()}.
+decode_envelope(#{<<"jsonrpc">> := <<"2.0">>} = Msg) ->
+    case {maps:find(<<"method">>, Msg),
+          maps:find(<<"id">>, Msg),
+          maps:find(<<"result">>, Msg),
+          maps:find(<<"error">>, Msg)} of
+        {{ok, Method}, {ok, Id}, error, error} ->
+            {request, Id, Method, maps:get(<<"params">>, Msg, #{})};
+        {{ok, Method}, error, error, error} ->
+            {notification, Method, maps:get(<<"params">>, Msg, #{})};
+        {error, {ok, Id}, {ok, Result}, error} ->
+            {response, Id, Result};
+        {error, {ok, Id}, error, {ok, Err}} ->
+            Code = maps:get(<<"code">>, Err, ?JSONRPC_INTERNAL_ERROR),
+            Message = maps:get(<<"message">>, Err, <<>>),
+            Data = maps:get(<<"data">>, Err, undefined),
+            {error, Id, Code, Message, Data};
+        _ ->
+            {invalid, malformed}
+    end;
+decode_envelope(Other) ->
+    {invalid, Other}.

--- a/src/barrel_mcp_sup.erl
+++ b/src/barrel_mcp_sup.erl
@@ -49,4 +49,22 @@ init([]) ->
         modules => [barrel_mcp_session]
     },
 
-    {ok, {SupFlags, [Registry, Session]}}.
+    ClientSup = #{
+        id => barrel_mcp_client_sup,
+        start => {barrel_mcp_client_sup, start_link, []},
+        restart => permanent,
+        shutdown => infinity,
+        type => supervisor,
+        modules => [barrel_mcp_client_sup]
+    },
+
+    Clients = #{
+        id => barrel_mcp_clients,
+        start => {barrel_mcp_clients, start_link, []},
+        restart => permanent,
+        shutdown => 5000,
+        type => worker,
+        modules => [barrel_mcp_clients]
+    },
+
+    {ok, {SupFlags, [Registry, Session, ClientSup, Clients]}}.

--- a/test/barrel_mcp_client_handler_tests.erl
+++ b/test/barrel_mcp_client_handler_tests.erl
@@ -1,0 +1,32 @@
+%%%-------------------------------------------------------------------
+%%% @doc Tests for the `barrel_mcp_client_handler' behaviour and the
+%%% default no-op implementation.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_handler_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+default_handler_test_() ->
+    [
+     {"init returns ok",
+      fun() ->
+          {ok, _State} = barrel_mcp_client_handler_default:init([])
+      end},
+     {"unknown request returns method_not_found",
+      fun() ->
+          {ok, S} = barrel_mcp_client_handler_default:init([]),
+          {error, Code, Msg, _S1} =
+              barrel_mcp_client_handler_default:handle_request(
+                <<"sampling/createMessage">>, #{}, S),
+          ?assertEqual(-32601, Code),
+          ?assert(is_binary(Msg))
+      end},
+     {"notification is ignored",
+      fun() ->
+          {ok, S} = barrel_mcp_client_handler_default:init([]),
+          {ok, S1} = barrel_mcp_client_handler_default:handle_notification(
+                       <<"notifications/message">>, #{}, S),
+          ?assertEqual(S, S1)
+      end}
+    ].

--- a/test/barrel_mcp_client_tests.erl
+++ b/test/barrel_mcp_client_tests.erl
@@ -1,133 +1,131 @@
 %%%-------------------------------------------------------------------
-%%% @doc Tests for barrel_mcp_client module.
+%%% @doc Tests for `barrel_mcp_client'.
+%%%
+%%% Drives the new gen_statem client against a loopback Streamable
+%%% HTTP server (the same `barrel_mcp_http_stream' the server side
+%%% exposes). Verifies handshake, tools/list, tools/call, version
+%%% downgrade, and graceful close.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_client_tests).
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% Test handlers (exported for MCP registry)
 -export([test_handler/1]).
 
+-define(PORT, 19191).
+-define(URL, <<"http://127.0.0.1:19191/mcp">>).
+
 %%====================================================================
-%% Test Fixtures
+%% Fixtures
 %%====================================================================
 
 client_test_() ->
     {setup,
      fun setup/0,
      fun cleanup/1,
-     [
-        {"Connect HTTP client", fun test_connect_http/0},
-        {"Close HTTP client", fun test_close_http/0}
-     ]
-    }.
-
-%% Integration tests requiring running server
-integration_test_() ->
-    {setup,
-     fun setup_integration/0,
-     fun cleanup_integration/1,
      {timeout, 30, [
-        {"Initialize client", fun test_initialize/0},
-        {"List tools", fun test_list_tools/0},
-        {"Call tool", fun test_call_tool/0},
-        {"List resources", fun test_list_resources/0},
-        {"List prompts", fun test_list_prompts/0}
-     ]}
-    }.
+         {"initialize handshake + capabilities", fun test_initialize/0},
+         {"list_tools includes registered tool", fun test_list_tools/0},
+         {"call_tool returns content", fun test_call_tool/0},
+         {"protocol version negotiates downward", fun test_version_downgrade/0},
+         {"close shuts down cleanly", fun test_close/0}
+     ]}}.
 
 setup() ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    ok = barrel_mcp_registry:wait_for_ready(),
+    ok = barrel_mcp_registry:reg(tool, <<"test_tool">>, ?MODULE, test_handler, #{
+        description => <<"echo test tool">>
+    }),
+    {ok, _} = barrel_mcp_http_stream:start(#{port => ?PORT, session_enabled => true}),
+    timer:sleep(150),
     ok.
 
 cleanup(_) ->
+    catch barrel_mcp_http_stream:stop(),
+    catch barrel_mcp_registry:unreg(tool, <<"test_tool">>),
     ok.
-
-setup_integration() ->
-    %% Start the barrel_mcp application (which starts registry)
-    application:ensure_all_started(barrel_mcp),
-    ok = barrel_mcp_registry:wait_for_ready(),
-
-    %% Register a test tool
-    barrel_mcp_registry:reg(tool, <<"test_tool">>, ?MODULE, test_handler, #{
-        description => <<"Test tool">>
-    }),
-
-    %% Start HTTP server
-    {ok, _} = barrel_mcp_http:start(#{port => 19090}),
-    timer:sleep(100),
-    ok.
-
-cleanup_integration(_) ->
-    barrel_mcp_http:stop(),
-    barrel_mcp_registry:unreg(tool, <<"test_tool">>),
-    ok.
-
-%%====================================================================
-%% Test Helpers
-%%====================================================================
 
 test_handler(_Args) ->
-    <<"test result">>.
-
-get_test_client() ->
-    {ok, Client} = barrel_mcp_client:connect(#{
-        transport => {http, <<"http://localhost:19090/mcp">>}
-    }),
-    Client.
+    <<"echoed">>.
 
 %%====================================================================
-%% Unit Tests
-%%====================================================================
-
-test_connect_http() ->
-    {ok, _Client} = barrel_mcp_client:connect(#{
-        transport => {http, <<"http://localhost:9090/mcp">>}
-    }),
-    ok.
-
-test_close_http() ->
-    {ok, Client} = barrel_mcp_client:connect(#{
-        transport => {http, <<"http://localhost:9090/mcp">>}
-    }),
-    ?assertEqual(ok, barrel_mcp_client:close(Client)).
-
-%%====================================================================
-%% Integration Tests
+%% Tests
 %%====================================================================
 
 test_initialize() ->
-    Client = get_test_client(),
-    {ok, Result, Client1} = barrel_mcp_client:initialize(Client),
-    ?assert(maps:is_key(<<"protocolVersion">>, Result)),
-    ?assert(maps:is_key(<<"capabilities">>, Result)),
-    barrel_mcp_client:close(Client1).
+    {ok, Pid} = start_client(),
+    {ok, Caps} = barrel_mcp_client:server_capabilities(Pid),
+    ?assert(maps:is_key(<<"tools">>, Caps)),
+    {ok, Info} = barrel_mcp_client:server_info(Pid),
+    ?assert(maps:is_key(<<"name">>, Info)),
+    ok = barrel_mcp_client:close(Pid),
+    wait_dead(Pid).
 
 test_list_tools() ->
-    Client = get_test_client(),
-    {ok, _, Client1} = barrel_mcp_client:initialize(Client),
-    {ok, Tools, Client2} = barrel_mcp_client:list_tools(Client1),
-    ?assert(is_list(Tools)),
-    ?assert(length(Tools) >= 1),
-    barrel_mcp_client:close(Client2).
+    {ok, Pid} = start_client(),
+    {ok, Tools} = barrel_mcp_client:list_tools(Pid),
+    Names = [maps:get(<<"name">>, T) || T <- Tools],
+    ?assert(lists:member(<<"test_tool">>, Names)),
+    ok = barrel_mcp_client:close(Pid),
+    wait_dead(Pid).
 
 test_call_tool() ->
-    Client = get_test_client(),
-    {ok, _, Client1} = barrel_mcp_client:initialize(Client),
-    {ok, Result, Client2} = barrel_mcp_client:call_tool(Client1, <<"test_tool">>, #{}),
-    ?assert(maps:is_key(<<"content">>, Result)),
-    barrel_mcp_client:close(Client2).
+    {ok, Pid} = start_client(),
+    {ok, Result} = barrel_mcp_client:call_tool(Pid, <<"test_tool">>, #{}),
+    Content = maps:get(<<"content">>, Result),
+    ?assert(is_list(Content)),
+    [#{<<"type">> := <<"text">>, <<"text">> := <<"echoed">>}] = Content,
+    ok = barrel_mcp_client:close(Pid),
+    wait_dead(Pid).
 
-test_list_resources() ->
-    Client = get_test_client(),
-    {ok, _, Client1} = barrel_mcp_client:initialize(Client),
-    {ok, Resources, Client2} = barrel_mcp_client:list_resources(Client1),
-    ?assert(is_list(Resources)),
-    barrel_mcp_client:close(Client2).
+test_version_downgrade() ->
+    %% Server reports 2025-03-26; client targets 2025-11-25 by default.
+    {ok, Pid} = start_client(),
+    {ok, Version} = barrel_mcp_client:protocol_version(Pid),
+    ?assertEqual(<<"2025-03-26">>, Version),
+    ok = barrel_mcp_client:close(Pid),
+    wait_dead(Pid).
 
-test_list_prompts() ->
-    Client = get_test_client(),
-    {ok, _, Client1} = barrel_mcp_client:initialize(Client),
-    {ok, Prompts, Client2} = barrel_mcp_client:list_prompts(Client1),
-    ?assert(is_list(Prompts)),
-    barrel_mcp_client:close(Client2).
+test_close() ->
+    {ok, Pid} = start_client(),
+    Mon = erlang:monitor(process, Pid),
+    ok = barrel_mcp_client:close(Pid),
+    receive
+        {'DOWN', Mon, process, Pid, _} -> ok
+    after 5000 ->
+        ?assert(false)
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+start_client() ->
+    Spec = #{
+        transport => {http, ?URL},
+        capabilities => #{},
+        handler => {barrel_mcp_client_handler_default, []}
+    },
+    {ok, Pid} = barrel_mcp_client:start(Spec),
+    wait_ready(Pid, 30),
+    {ok, Pid}.
+
+wait_ready(_Pid, 0) -> error(client_not_ready);
+wait_ready(Pid, N) ->
+    case catch barrel_mcp_client:server_capabilities(Pid) of
+        {ok, _} -> ok;
+        _ ->
+            timer:sleep(100),
+            wait_ready(Pid, N - 1)
+    end.
+
+wait_dead(Pid) ->
+    Mon = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', Mon, process, Pid, _} -> ok
+    after 5000 ->
+        erlang:demonitor(Mon, [flush]),
+        ok
+    end.

--- a/test/barrel_mcp_clients_tests.erl
+++ b/test/barrel_mcp_clients_tests.erl
@@ -1,0 +1,79 @@
+%%%-------------------------------------------------------------------
+%%% @doc Tests for the `barrel_mcp_clients' federation registry.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_clients_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PORT, 19292).
+-define(URL, <<"http://127.0.0.1:19292/mcp">>).
+
+federation_test_() ->
+    {setup,
+     fun setup/0,
+     fun cleanup/1,
+     {timeout, 30, [
+         {"start_client registers and returns a pid", fun test_start/0},
+         {"duplicate registration is rejected", fun test_dup/0},
+         {"stop_client removes the entry", fun test_stop/0},
+         {"crash auto-removes the entry", fun test_crash/0}
+     ]}}.
+
+setup() ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    ok = barrel_mcp_registry:wait_for_ready(),
+    {ok, _} = barrel_mcp_http_stream:start(#{port => ?PORT, session_enabled => true}),
+    timer:sleep(150),
+    ok.
+
+cleanup(_) ->
+    catch barrel_mcp_http_stream:stop(),
+    [catch barrel_mcp:stop_client(Id) || {Id, _} <- barrel_mcp:list_clients()],
+    ok.
+
+test_start() ->
+    Spec = client_spec(),
+    {ok, Pid} = barrel_mcp:start_client(<<"a">>, Spec),
+    ?assert(is_pid(Pid)),
+    ?assertEqual(Pid, barrel_mcp:whereis_client(<<"a">>)),
+    ?assert(lists:keymember(<<"a">>, 1, barrel_mcp:list_clients())),
+    barrel_mcp:stop_client(<<"a">>).
+
+test_dup() ->
+    Spec = client_spec(),
+    {ok, _} = barrel_mcp:start_client(<<"b">>, Spec),
+    ?assertMatch({error, {already_registered, _}},
+                 barrel_mcp:start_client(<<"b">>, Spec)),
+    barrel_mcp:stop_client(<<"b">>).
+
+test_stop() ->
+    Spec = client_spec(),
+    {ok, _} = barrel_mcp:start_client(<<"c">>, Spec),
+    ok = barrel_mcp:stop_client(<<"c">>),
+    timer:sleep(100),
+    ?assertEqual(undefined, barrel_mcp:whereis_client(<<"c">>)).
+
+test_crash() ->
+    Spec = client_spec(),
+    {ok, Pid} = barrel_mcp:start_client(<<"d">>, Spec),
+    exit(Pid, kill),
+    %% Allow the registry's monitor to fire.
+    wait_until_undefined(<<"d">>, 30).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+client_spec() ->
+    #{transport => {http, ?URL},
+      handler => {barrel_mcp_client_handler_default, []}}.
+
+wait_until_undefined(_Id, 0) -> error(still_registered);
+wait_until_undefined(Id, N) ->
+    case barrel_mcp:whereis_client(Id) of
+        undefined -> ok;
+        _ ->
+            timer:sleep(50),
+            wait_until_undefined(Id, N - 1)
+    end.

--- a/test/barrel_mcp_protocol_envelope_tests.erl
+++ b/test/barrel_mcp_protocol_envelope_tests.erl
@@ -1,0 +1,47 @@
+%%%-------------------------------------------------------------------
+%%% @doc Pure tests for the JSON-RPC envelope helpers in
+%%% `barrel_mcp_protocol'.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_protocol_envelope_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+encode_request_test() ->
+    M = barrel_mcp_protocol:encode_request(7, <<"tools/call">>, #{<<"a">> => 1}),
+    ?assertEqual(<<"2.0">>, maps:get(<<"jsonrpc">>, M)),
+    ?assertEqual(7, maps:get(<<"id">>, M)),
+    ?assertEqual(<<"tools/call">>, maps:get(<<"method">>, M)),
+    ?assertEqual(#{<<"a">> => 1}, maps:get(<<"params">>, M)).
+
+encode_notification_test() ->
+    M = barrel_mcp_protocol:encode_notification(<<"notifications/initialized">>, #{}),
+    ?assertNot(maps:is_key(<<"id">>, M)),
+    ?assertEqual(<<"notifications/initialized">>, maps:get(<<"method">>, M)).
+
+decode_request_test() ->
+    M = #{<<"jsonrpc">> => <<"2.0">>, <<"id">> => 1,
+          <<"method">> => <<"ping">>, <<"params">> => #{}},
+    ?assertEqual({request, 1, <<"ping">>, #{}},
+                 barrel_mcp_protocol:decode_envelope(M)).
+
+decode_notification_test() ->
+    M = #{<<"jsonrpc">> => <<"2.0">>, <<"method">> => <<"x">>},
+    ?assertEqual({notification, <<"x">>, #{}},
+                 barrel_mcp_protocol:decode_envelope(M)).
+
+decode_response_test() ->
+    M = #{<<"jsonrpc">> => <<"2.0">>, <<"id">> => 9,
+          <<"result">> => #{<<"ok">> => true}},
+    ?assertEqual({response, 9, #{<<"ok">> => true}},
+                 barrel_mcp_protocol:decode_envelope(M)).
+
+decode_error_test() ->
+    M = #{<<"jsonrpc">> => <<"2.0">>, <<"id">> => 9,
+          <<"error">> => #{<<"code">> => -32601, <<"message">> => <<"nope">>}},
+    ?assertMatch({error, 9, -32601, <<"nope">>, undefined},
+                 barrel_mcp_protocol:decode_envelope(M)).
+
+decode_invalid_test() ->
+    ?assertMatch({invalid, _},
+                 barrel_mcp_protocol:decode_envelope(#{})).


### PR DESCRIPTION
## Summary

Rewrites `barrel_mcp_client` as a `gen_statem` with async transports and brings the client surface up to MCP spec conformance. Targets `2025-11-25` and negotiates down through `2025-06-18`, `2025-03-26`, `2024-11-05`.

## Client

- Async transports forward inbound JSON-RPC envelopes as `{mcp_in, _, _}` to the state machine.
- Streamable HTTP client (`barrel_mcp_client_http`): POST with `application/json, text/event-stream`, SSE parsing on both POST responses and a long-lived GET, `Mcp-Session-Id` capture, `MCP-Protocol-Version` sent after init, DELETE on close, 401 retry through pluggable auth.
- stdio transport extracted into its own gen_server.
- Server-initiated requests/notifications dispatched through `barrel_mcp_client_handler` (sync, error, or async reply forms). Default no-op module ships in `barrel_mcp_client_handler_default`.
- Capability-shaped initialize payload (booleans become spec objects on the wire).
- Public API: tools/resources/prompts (single-page + paginated), `complete`, `set_log_level`, `cancel`, `ping`, `reply_async/3`, plus introspection (`server_info`, `server_capabilities`, `protocol_version`).
- Resource subscription notifications routed back to subscribing processes.

## Federation

- `barrel_mcp_clients` owns a lookup table and serializes registration. One supervised connection per `ServerId`. API on the `barrel_mcp` facade: `start_client/2`, `stop_client/1`, `whereis_client/1`, `list_clients/0`. Tool-name namespacing stays a host policy.

## Auth

- `barrel_mcp_client_auth` behaviour with a static-bearer impl. OAuth 2.1 + PKCE planned as a follow-up.

## Server-side fixes bundled

- `barrel_mcp_protocol` accepts `notifications/initialized` (spec name) alongside legacy bare `initialized`.
- `barrel_mcp_http_stream` CORS exposes `mcp-protocol-version` and `last-event-id`.
- Shared JSON-RPC envelope helpers (`encode_request`, `encode_notification`, `encode_response`, `encode_error`, `decode_envelope`).

## Status

- 127/127 EUnit tests green.
- Dialyzer clean.