### PR TITLE
Pagination walker, *_all helpers, and JSON Schema validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `notifications/initialized` is now the spec name; legacy bare `initialized` still accepted for one release.
 - CORS on `barrel_mcp_http_stream` exposes `mcp-protocol-version` and `last-event-id`.
 
+### Added (ergonomics)
+
+- `barrel_mcp_pagination:walk/1,2`: cursor walker shared by every `*/list` paged helper, with a configurable max-pages guard.
+- `barrel_mcp_client:list_tools_all/1`, `list_resources_all/1`, `list_resource_templates_all/1`, `list_prompts_all/1`: walk every page and return the union.
+- `barrel_mcp_schema:validate/2`: minimal JSON Schema validator covering type/properties/required/enum/items/oneOf/anyOf/allOf/min-max-length/pattern/min-max-items/uniqueItems/min-max/exclusive bounds. Returns `ok` or `{error, [{Path, Reason}]}`. Hosts use it to pre-flight LLM-generated tool args before calling the server.
+
 ## [1.1.0] - 2025-01-27
 
 ### Added

--- a/guides/features.md
+++ b/guides/features.md
@@ -37,8 +37,11 @@ by the spec.
   `resources/templates/list`, `resources/subscribe`,
   `resources/unsubscribe`, `prompts/list`, `prompts/get`,
   `completion/complete`, `logging/setLevel`, `ping`.
-- Pagination via `cursor` / `nextCursor` (single page by default;
-  `want_cursor => true` to follow paging).
+- Pagination via `cursor` / `nextCursor`. Single page by default
+  (`want_cursor => true` to follow paging by hand). The sugar helpers
+  `list_tools_all/1`, `list_resources_all/1`,
+  `list_resource_templates_all/1`, `list_prompts_all/1` walk every
+  page via `barrel_mcp_pagination:walk/1`.
 - Cancellation: `barrel_mcp_client:cancel/2` sends
   `notifications/cancelled` and unblocks the caller.
 - Progress: callers may pass `progress_token` in `tools/call`.
@@ -63,15 +66,27 @@ by the spec.
 ### Auth
 
 - `barrel_mcp_client_auth` behaviour.
-- `barrel_mcp_client_auth_bearer` — static token.
-- OAuth 2.1 + PKCE: planned for Phase D (Protected Resource Metadata
-  discovery, RFC 8707 `resource` parameter).
+- `barrel_mcp_client_auth_bearer`: static token.
+- OAuth 2.1 + PKCE: planned (Protected Resource Metadata discovery,
+  RFC 8707 `resource` parameter).
+
+### Schema validation (`barrel_mcp_schema`)
+
+Pure-Erlang JSON Schema subset validator hosts can use to pre-flight
+LLM-generated tool args before calling the server. Covers `type`,
+`properties`, `required`, `enum`, `items`, `oneOf`/`anyOf`/`allOf`,
+`additionalProperties: false`, string `minLength`/`maxLength`/`pattern`,
+number bounds, and array `minItems`/`maxItems`/`uniqueItems`.
+
+```
+case barrel_mcp_schema:validate(Args, ToolInputSchema) of
+    ok -> barrel_mcp_client:call_tool(Pid, Name, Args);
+    {error, Errors} -> reject(Errors)
+end.
+```
 
 ### Roadmap
 
-- Phase B: deeper notifications + ergonomics — logging stream,
-  resources/list_changed callbacks, completion routing, schema
-  validation against `inputSchema` (opt-in).
-- Phase C: refined control plane — periodic `ping`, deadline timers,
-  progress notification dispatch.
-- Phase D: OAuth 2.1 + PKCE auth.
+- Periodic `ping` cadence and deadline timers for outstanding
+  requests.
+- OAuth 2.1 + PKCE auth.

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -45,14 +45,18 @@
     close/1,
     %% Tools
     list_tools/1, list_tools/2,
+    list_tools_all/1,
     call_tool/3, call_tool/4,
     %% Resources
     list_resources/1, list_resources/2,
+    list_resources_all/1,
     list_resource_templates/1, list_resource_templates/2,
+    list_resource_templates_all/1,
     read_resource/2,
     subscribe/2, unsubscribe/2,
     %% Prompts
     list_prompts/1, list_prompts/2,
+    list_prompts_all/1,
     get_prompt/3,
     %% Misc
     complete/3,
@@ -135,6 +139,11 @@ list_tools(Pid) ->
 list_tools(Pid, Opts) ->
     paged(Pid, <<"tools/list">>, <<"tools">>, Opts).
 
+%% @doc Walk all `tools/list' pages and return the full list.
+-spec list_tools_all(pid()) -> {ok, [map()]} | {error, term()}.
+list_tools_all(Pid) ->
+    walk_all(fun(Cursor) -> list_tools(Pid, page_opts(Cursor)) end).
+
 %% @doc Call a tool. Args are forwarded as `arguments'.
 -spec call_tool(pid(), binary(), map()) -> {ok, map()} | {error, term()}.
 call_tool(Pid, Name, Args) ->
@@ -152,10 +161,20 @@ list_resources(Pid) -> list_resources(Pid, #{}).
 list_resources(Pid, Opts) ->
     paged(Pid, <<"resources/list">>, <<"resources">>, Opts).
 
+%% @doc Walk all `resources/list' pages.
+-spec list_resources_all(pid()) -> {ok, [map()]} | {error, term()}.
+list_resources_all(Pid) ->
+    walk_all(fun(Cursor) -> list_resources(Pid, page_opts(Cursor)) end).
+
 list_resource_templates(Pid) -> list_resource_templates(Pid, #{}).
 
 list_resource_templates(Pid, Opts) ->
     paged(Pid, <<"resources/templates/list">>, <<"resourceTemplates">>, Opts).
+
+%% @doc Walk all `resources/templates/list' pages.
+-spec list_resource_templates_all(pid()) -> {ok, [map()]} | {error, term()}.
+list_resource_templates_all(Pid) ->
+    walk_all(fun(Cursor) -> list_resource_templates(Pid, page_opts(Cursor)) end).
 
 read_resource(Pid, Uri) ->
     request(Pid, <<"resources/read">>, #{<<"uri">> => Uri}).
@@ -180,6 +199,11 @@ list_prompts(Pid) -> list_prompts(Pid, #{}).
 
 list_prompts(Pid, Opts) ->
     paged(Pid, <<"prompts/list">>, <<"prompts">>, Opts).
+
+%% @doc Walk all `prompts/list' pages.
+-spec list_prompts_all(pid()) -> {ok, [map()]} | {error, term()}.
+list_prompts_all(Pid) ->
+    walk_all(fun(Cursor) -> list_prompts(Pid, page_opts(Cursor)) end).
 
 get_prompt(Pid, Name, Args) ->
     request(Pid, <<"prompts/get">>, #{
@@ -591,6 +615,12 @@ request(Pid, Method, Params, Timeout) ->
                       T when is_integer(T) -> T + 5000
                   end,
     gen_statem:call(Pid, {request, Method, Params, Timeout}, CallTimeout).
+
+walk_all(Fetch) ->
+    barrel_mcp_pagination:walk(Fetch).
+
+page_opts(undefined) -> #{want_cursor => true};
+page_opts(Cursor) -> #{cursor => Cursor, want_cursor => true}.
 
 paged(Pid, Method, ResultKey, Opts) ->
     Params = case maps:get(cursor, Opts, undefined) of

--- a/src/barrel_mcp_pagination.erl
+++ b/src/barrel_mcp_pagination.erl
@@ -1,0 +1,58 @@
+%%%-------------------------------------------------------------------
+%%% @doc Cursor-based pagination walker for MCP `*/list' methods.
+%%%
+%%% Every MCP `*/list' response may include a `nextCursor' that the
+%%% client passes back as `cursor' on the next call until the server
+%%% omits it. This module turns that loop into a single function call.
+%%%
+%%% Usage from the client:
+%%%
+%%% ```
+%%% barrel_mcp_pagination:walk(
+%%%     fun(Cursor) -> barrel_mcp_client:list_tools(Pid, #{cursor => Cursor, want_cursor => true}) end).
+%%% '''
+%%%
+%%% Returns `{ok, AllItems}' or `{error, Reason}' on the first error.
+%%% A `MaxPages' guard prevents accidental runaway pagination.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_pagination).
+
+-export([walk/1, walk/2]).
+
+-type fetch_fun() ::
+    fun((undefined | binary()) ->
+        {ok, [term()], undefined | binary()} |
+        {ok, [term()]} |
+        {error, term()}).
+
+-export_type([fetch_fun/0]).
+
+%% @doc Walk pagination starting from no cursor, with a 1000-page cap.
+-spec walk(fetch_fun()) -> {ok, [term()]} | {error, term()}.
+walk(Fetch) ->
+    walk(Fetch, 1000).
+
+%% @doc Walk pagination with an explicit page cap. The cap stops the
+%% loop with `{error, max_pages}' before exhausting memory if a server
+%% never stops returning a cursor.
+-spec walk(fetch_fun(), pos_integer()) ->
+    {ok, [term()]} | {error, term()}.
+walk(Fetch, MaxPages) when is_function(Fetch, 1), MaxPages > 0 ->
+    walk_loop(Fetch, undefined, [], MaxPages).
+
+walk_loop(_Fetch, _Cursor, _Acc, 0) ->
+    {error, max_pages};
+walk_loop(Fetch, Cursor, Acc, Remaining) ->
+    case Fetch(Cursor) of
+        {ok, Items, undefined} ->
+            {ok, lists:append(lists:reverse([Items | Acc]))};
+        {ok, Items} ->
+            {ok, lists:append(lists:reverse([Items | Acc]))};
+        {ok, Items, NextCursor} when is_binary(NextCursor), NextCursor =/= <<>> ->
+            walk_loop(Fetch, NextCursor, [Items | Acc], Remaining - 1);
+        {ok, Items, _} ->
+            {ok, lists:append(lists:reverse([Items | Acc]))};
+        {error, _} = Err ->
+            Err
+    end.

--- a/src/barrel_mcp_schema.erl
+++ b/src/barrel_mcp_schema.erl
@@ -1,0 +1,245 @@
+%%%-------------------------------------------------------------------
+%%% @doc Minimal JSON Schema validator for MCP tool inputs.
+%%%
+%%% Implements the subset of JSON Schema that real MCP tools use, in
+%%% pure Erlang with no extra dependencies. Covers:
+%%%
+%%% <ul>
+%%%   <li>`type': `object', `array', `string', `number', `integer',
+%%%       `boolean', `null', or a list of those for unions.</li>
+%%%   <li>`properties' + `required' for objects.</li>
+%%%   <li>`additionalProperties: false' rejection.</li>
+%%%   <li>`items' for arrays (single schema applied to every item).</li>
+%%%   <li>`enum' for string/number/integer/boolean.</li>
+%%%   <li>`oneOf' / `anyOf' / `allOf' (allOf = each must validate).</li>
+%%%   <li>`minimum'/`maximum'/`exclusiveMinimum'/`exclusiveMaximum'
+%%%       for numbers and integers.</li>
+%%%   <li>`minLength'/`maxLength'/`pattern' for strings.</li>
+%%%   <li>`minItems'/`maxItems'/`uniqueItems' for arrays.</li>
+%%% </ul>
+%%%
+%%% Returns `ok' or `{error, [Error]}' where each error is a tuple
+%%% `{Path, Reason}' (Path is a list of keys / indices from the root,
+%%% Reason an atom or `{atom, Detail}').
+%%%
+%%% Anything outside the supported subset is silently accepted; this
+%%% is a permissive validator by design — its job is to catch obvious
+%%% bugs before sending an LLM-generated arg map to a remote tool, not
+%%% to be a JSON Schema reference implementation.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_schema).
+
+-export([validate/2]).
+
+-type path() :: [binary() | non_neg_integer()].
+-type error() :: {path(), atom() | {atom(), term()}}.
+
+-export_type([error/0]).
+
+%% @doc Validate `Value' against `Schema'. Returns `ok' or
+%% `{error, [Error]}'.
+-spec validate(term(), map()) -> ok | {error, [error()]}.
+validate(Value, Schema) when is_map(Schema) ->
+    case do_validate(Value, Schema, []) of
+        [] -> ok;
+        Errors -> {error, lists:reverse(Errors)}
+    end;
+validate(_, _) ->
+    {error, [{[], invalid_schema}]}.
+
+%%====================================================================
+%% Core dispatch
+%%====================================================================
+
+do_validate(Value, Schema, Path) ->
+    Errs0 = check_type(Value, maps:get(<<"type">>, Schema, undefined), Path),
+    Errs1 = case Errs0 of
+        [_|_] -> Errs0;
+        [] -> check_constraints(Value, Schema, Path)
+    end,
+    Errs1.
+
+check_constraints(Value, Schema, Path) ->
+    lists:foldl(fun(Check, Acc) ->
+        Check(Value, Schema, Path) ++ Acc
+    end, [], [
+        fun check_enum/3,
+        fun check_object/3,
+        fun check_array/3,
+        fun check_string/3,
+        fun check_number/3,
+        fun check_combinators/3
+    ]).
+
+%%====================================================================
+%% Type
+%%====================================================================
+
+check_type(_Value, undefined, _Path) ->
+    [];
+check_type(Value, Types, Path) when is_list(Types) ->
+    case lists:any(fun(T) -> matches_type(Value, T) end, Types) of
+        true -> [];
+        false -> [{Path, {type_mismatch, Types}}]
+    end;
+check_type(Value, Type, Path) when is_binary(Type) ->
+    case matches_type(Value, Type) of
+        true -> [];
+        false -> [{Path, {type_mismatch, Type}}]
+    end.
+
+matches_type(V, <<"object">>)  -> is_map(V);
+matches_type(V, <<"array">>)   -> is_list(V);
+matches_type(V, <<"string">>)  -> is_binary(V);
+matches_type(V, <<"integer">>) -> is_integer(V);
+matches_type(V, <<"number">>)  -> is_integer(V) orelse is_float(V);
+matches_type(V, <<"boolean">>) -> is_boolean(V);
+matches_type(null, <<"null">>) -> true;
+matches_type(_, <<"null">>)    -> false;
+matches_type(_, _) -> true.
+
+%%====================================================================
+%% enum
+%%====================================================================
+
+check_enum(Value, #{<<"enum">> := Allowed}, Path) when is_list(Allowed) ->
+    case lists:member(Value, Allowed) of
+        true -> [];
+        false -> [{Path, {not_in_enum, Allowed}}]
+    end;
+check_enum(_, _, _) -> [].
+
+%%====================================================================
+%% Object
+%%====================================================================
+
+check_object(Value, Schema, Path) when is_map(Value) ->
+    Required = maps:get(<<"required">>, Schema, []),
+    Properties = maps:get(<<"properties">>, Schema, #{}),
+    AdditionalAllowed = maps:get(<<"additionalProperties">>, Schema, true),
+    MissingErrs = [{Path, {missing_required, K}}
+                   || K <- Required, not maps:is_key(K, Value)],
+    PropErrs = lists:flatten(maps:fold(fun(K, V, Acc) ->
+        case maps:find(K, Properties) of
+            {ok, Sub} -> [do_validate(V, Sub, Path ++ [K]) | Acc];
+            error ->
+                case AdditionalAllowed of
+                    false -> [[{Path, {unexpected_property, K}}] | Acc];
+                    _ -> Acc
+                end
+        end
+    end, [], Value)),
+    MissingErrs ++ PropErrs;
+check_object(_, _, _) -> [].
+
+%%====================================================================
+%% Array
+%%====================================================================
+
+check_array(Value, Schema, Path) when is_list(Value) ->
+    LenErrs = length_errors(Value, Schema, Path),
+    UniqErrs = case maps:get(<<"uniqueItems">>, Schema, false) of
+        true ->
+            case length(lists:usort(Value)) =:= length(Value) of
+                true -> [];
+                false -> [{Path, items_not_unique}]
+            end;
+        _ -> []
+    end,
+    ItemErrs = case maps:get(<<"items">>, Schema, undefined) of
+        undefined -> [];
+        Sub when is_map(Sub) ->
+            {Errs, _} = lists:foldl(fun(V, {Acc, I}) ->
+                {do_validate(V, Sub, Path ++ [I]) ++ Acc, I + 1}
+            end, {[], 0}, Value),
+            Errs;
+        _ -> []
+    end,
+    LenErrs ++ UniqErrs ++ ItemErrs;
+check_array(_, _, _) -> [].
+
+length_errors(List, Schema, Path) ->
+    Len = length(List),
+    Min = maps:get(<<"minItems">>, Schema, undefined),
+    Max = maps:get(<<"maxItems">>, Schema, undefined),
+    [ {Path, {too_short, {min, Min}, {got, Len}}}
+      || Min =/= undefined, Len < Min ] ++
+    [ {Path, {too_long, {max, Max}, {got, Len}}}
+      || Max =/= undefined, Len > Max ].
+
+%%====================================================================
+%% String
+%%====================================================================
+
+check_string(Value, Schema, Path) when is_binary(Value) ->
+    MinL = maps:get(<<"minLength">>, Schema, undefined),
+    MaxL = maps:get(<<"maxLength">>, Schema, undefined),
+    Len = byte_size(Value),
+    [{Path, {too_short, {min, MinL}, {got, Len}}}
+     || MinL =/= undefined, Len < MinL] ++
+    [{Path, {too_long, {max, MaxL}, {got, Len}}}
+     || MaxL =/= undefined, Len > MaxL] ++
+    pattern_errors(Value, maps:get(<<"pattern">>, Schema, undefined), Path);
+check_string(_, _, _) -> [].
+
+pattern_errors(_, undefined, _) -> [];
+pattern_errors(Value, Pattern, Path) when is_binary(Pattern) ->
+    case re:run(Value, Pattern, [{capture, none}, unicode]) of
+        match -> [];
+        nomatch -> [{Path, {pattern_mismatch, Pattern}}];
+        {error, _} -> []
+    end.
+
+%%====================================================================
+%% Number
+%%====================================================================
+
+check_number(Value, Schema, Path) when is_integer(Value); is_float(Value) ->
+    Bounds = [
+        {<<"minimum">>, fun(V, B) -> V >= B end, too_small},
+        {<<"maximum">>, fun(V, B) -> V =< B end, too_large},
+        {<<"exclusiveMinimum">>, fun(V, B) -> V > B end, too_small},
+        {<<"exclusiveMaximum">>, fun(V, B) -> V < B end, too_large}
+    ],
+    lists:foldl(fun({Key, Pred, ErrTag}, Acc) ->
+        case maps:get(Key, Schema, undefined) of
+            undefined -> Acc;
+            Bound ->
+                case Pred(Value, Bound) of
+                    true -> Acc;
+                    false -> [{Path, {ErrTag, {Key, Bound}, {got, Value}}} | Acc]
+                end
+        end
+    end, [], Bounds);
+check_number(_, _, _) -> [].
+
+%%====================================================================
+%% allOf / anyOf / oneOf
+%%====================================================================
+
+check_combinators(Value, Schema, Path) ->
+    AllOf = check_all_of(Value, maps:get(<<"allOf">>, Schema, undefined), Path),
+    AnyOf = check_any_of(Value, maps:get(<<"anyOf">>, Schema, undefined), Path),
+    OneOf = check_one_of(Value, maps:get(<<"oneOf">>, Schema, undefined), Path),
+    AllOf ++ AnyOf ++ OneOf.
+
+check_all_of(_, undefined, _) -> [];
+check_all_of(Value, Schemas, Path) when is_list(Schemas) ->
+    lists:flatten([do_validate(Value, S, Path) || S <- Schemas]).
+
+check_any_of(_, undefined, _) -> [];
+check_any_of(Value, Schemas, Path) when is_list(Schemas) ->
+    case lists:any(fun(S) -> do_validate(Value, S, Path) =:= [] end, Schemas) of
+        true -> [];
+        false -> [{Path, no_anyof_match}]
+    end.
+
+check_one_of(_, undefined, _) -> [];
+check_one_of(Value, Schemas, Path) when is_list(Schemas) ->
+    Matches = length([1 || S <- Schemas, do_validate(Value, S, Path) =:= []]),
+    case Matches of
+        1 -> [];
+        0 -> [{Path, no_oneof_match}];
+        N -> [{Path, {multiple_oneof_matches, N}}]
+    end.

--- a/test/barrel_mcp_client_tests.erl
+++ b/test/barrel_mcp_client_tests.erl
@@ -27,6 +27,7 @@ client_test_() ->
      {timeout, 30, [
          {"initialize handshake + capabilities", fun test_initialize/0},
          {"list_tools includes registered tool", fun test_list_tools/0},
+         {"list_tools_all walks pagination", fun test_list_tools_all/0},
          {"call_tool returns content", fun test_call_tool/0},
          {"protocol version negotiates downward", fun test_version_downgrade/0},
          {"close shuts down cleanly", fun test_close/0}
@@ -77,6 +78,16 @@ test_call_tool() ->
     Content = maps:get(<<"content">>, Result),
     ?assert(is_list(Content)),
     [#{<<"type">> := <<"text">>, <<"text">> := <<"echoed">>}] = Content,
+    ok = barrel_mcp_client:close(Pid),
+    wait_dead(Pid).
+
+test_list_tools_all() ->
+    %% Server doesn't paginate today, so list_tools_all should return
+    %% the same set as list_tools in one page.
+    {ok, Pid} = start_client(),
+    {ok, All} = barrel_mcp_client:list_tools_all(Pid),
+    Names = [maps:get(<<"name">>, T) || T <- All],
+    ?assert(lists:member(<<"test_tool">>, Names)),
     ok = barrel_mcp_client:close(Pid),
     wait_dead(Pid).
 

--- a/test/barrel_mcp_pagination_tests.erl
+++ b/test/barrel_mcp_pagination_tests.erl
@@ -1,0 +1,42 @@
+%%%-------------------------------------------------------------------
+%%% @doc Tests for `barrel_mcp_pagination'.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_pagination_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+single_page_test() ->
+    Fetch = fun(undefined) -> {ok, [a, b, c]} end,
+    ?assertEqual({ok, [a, b, c]}, barrel_mcp_pagination:walk(Fetch)).
+
+single_page_with_undefined_cursor_test() ->
+    Fetch = fun(undefined) -> {ok, [a, b], undefined} end,
+    ?assertEqual({ok, [a, b]}, barrel_mcp_pagination:walk(Fetch)).
+
+multi_page_test() ->
+    Pages = #{undefined => {[a, b], <<"c1">>},
+              <<"c1">>  => {[c, d], <<"c2">>},
+              <<"c2">>  => {[e],    undefined}},
+    Fetch = fun(C) ->
+        {Items, Next} = maps:get(C, Pages),
+        {ok, Items, Next}
+    end,
+    ?assertEqual({ok, [a, b, c, d, e]}, barrel_mcp_pagination:walk(Fetch)).
+
+empty_cursor_string_terminates_test() ->
+    Pages = #{undefined => {[a], <<>>}},
+    Fetch = fun(C) ->
+        {Items, Next} = maps:get(C, Pages),
+        {ok, Items, Next}
+    end,
+    ?assertEqual({ok, [a]}, barrel_mcp_pagination:walk(Fetch)).
+
+error_propagates_test() ->
+    Fetch = fun(undefined) -> {error, boom} end,
+    ?assertEqual({error, boom}, barrel_mcp_pagination:walk(Fetch)).
+
+max_pages_guard_test() ->
+    %% Always returns a cursor — would loop forever without the cap.
+    Fetch = fun(_) -> {ok, [x], <<"more">>} end,
+    ?assertEqual({error, max_pages}, barrel_mcp_pagination:walk(Fetch, 3)).

--- a/test/barrel_mcp_schema_tests.erl
+++ b/test/barrel_mcp_schema_tests.erl
@@ -1,0 +1,160 @@
+%%%-------------------------------------------------------------------
+%%% @doc Tests for `barrel_mcp_schema'.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_schema_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% Type
+%%====================================================================
+
+type_string_ok_test() ->
+    ?assertEqual(ok,
+        barrel_mcp_schema:validate(<<"hi">>, #{<<"type">> => <<"string">>})).
+
+type_string_mismatch_test() ->
+    ?assertMatch({error, [{[], {type_mismatch, <<"string">>}}]},
+        barrel_mcp_schema:validate(42, #{<<"type">> => <<"string">>})).
+
+type_union_test() ->
+    S = #{<<"type">> => [<<"string">>, <<"null">>]},
+    ?assertEqual(ok, barrel_mcp_schema:validate(<<"x">>, S)),
+    ?assertEqual(ok, barrel_mcp_schema:validate(null, S)),
+    ?assertMatch({error, _}, barrel_mcp_schema:validate(1, S)).
+
+%%====================================================================
+%% Object
+%%====================================================================
+
+required_property_missing_test() ->
+    S = #{<<"type">> => <<"object">>,
+          <<"required">> => [<<"q">>],
+          <<"properties">> => #{<<"q">> => #{<<"type">> => <<"string">>}}},
+    ?assertMatch({error, [{[], {missing_required, <<"q">>}}]},
+        barrel_mcp_schema:validate(#{}, S)).
+
+required_property_present_test() ->
+    S = #{<<"type">> => <<"object">>,
+          <<"required">> => [<<"q">>],
+          <<"properties">> => #{<<"q">> => #{<<"type">> => <<"string">>}}},
+    ?assertEqual(ok,
+        barrel_mcp_schema:validate(#{<<"q">> => <<"hi">>}, S)).
+
+nested_property_path_test() ->
+    S = #{<<"type">> => <<"object">>,
+          <<"properties">> =>
+            #{<<"a">> => #{<<"type">> => <<"object">>,
+                           <<"properties">> =>
+                             #{<<"b">> => #{<<"type">> => <<"integer">>}}}}},
+    Bad = #{<<"a">> => #{<<"b">> => <<"not int">>}},
+    {error, [{Path, _}]} = barrel_mcp_schema:validate(Bad, S),
+    ?assertEqual([<<"a">>, <<"b">>], Path).
+
+additional_properties_rejected_test() ->
+    S = #{<<"type">> => <<"object">>,
+          <<"properties">> => #{<<"q">> => #{<<"type">> => <<"string">>}},
+          <<"additionalProperties">> => false},
+    ?assertMatch({error, [{_, {unexpected_property, <<"extra">>}}]},
+        barrel_mcp_schema:validate(#{<<"q">> => <<"x">>, <<"extra">> => 1}, S)).
+
+%%====================================================================
+%% Array / items / uniqueItems
+%%====================================================================
+
+array_items_validate_test() ->
+    S = #{<<"type">> => <<"array">>,
+          <<"items">> => #{<<"type">> => <<"integer">>}},
+    ?assertEqual(ok, barrel_mcp_schema:validate([1,2,3], S)),
+    {error, [{Path, _}]} =
+        barrel_mcp_schema:validate([1, <<"oops">>, 3], S),
+    ?assertEqual([1], Path).
+
+unique_items_test() ->
+    S = #{<<"type">> => <<"array">>, <<"uniqueItems">> => true},
+    ?assertEqual(ok, barrel_mcp_schema:validate([1,2,3], S)),
+    ?assertMatch({error, [{[], items_not_unique}]},
+        barrel_mcp_schema:validate([1,1,2], S)).
+
+min_max_items_test() ->
+    S = #{<<"type">> => <<"array">>,
+          <<"minItems">> => 1, <<"maxItems">> => 2},
+    ?assertEqual(ok, barrel_mcp_schema:validate([1], S)),
+    ?assertMatch({error, _}, barrel_mcp_schema:validate([], S)),
+    ?assertMatch({error, _}, barrel_mcp_schema:validate([1,2,3], S)).
+
+%%====================================================================
+%% String / enum / pattern
+%%====================================================================
+
+enum_test() ->
+    S = #{<<"type">> => <<"string">>,
+          <<"enum">> => [<<"a">>, <<"b">>]},
+    ?assertEqual(ok, barrel_mcp_schema:validate(<<"a">>, S)),
+    ?assertMatch({error, [{[], {not_in_enum, _}}]},
+        barrel_mcp_schema:validate(<<"c">>, S)).
+
+string_length_test() ->
+    S = #{<<"type">> => <<"string">>,
+          <<"minLength">> => 2, <<"maxLength">> => 4},
+    ?assertEqual(ok, barrel_mcp_schema:validate(<<"abc">>, S)),
+    ?assertMatch({error, _}, barrel_mcp_schema:validate(<<"a">>, S)),
+    ?assertMatch({error, _}, barrel_mcp_schema:validate(<<"abcde">>, S)).
+
+pattern_match_test() ->
+    S = #{<<"type">> => <<"string">>, <<"pattern">> => <<"^[a-z]+$">>},
+    ?assertEqual(ok, barrel_mcp_schema:validate(<<"hello">>, S)),
+    ?assertMatch({error, [{[], {pattern_mismatch, _}}]},
+        barrel_mcp_schema:validate(<<"Hello">>, S)).
+
+%%====================================================================
+%% Number bounds
+%%====================================================================
+
+minimum_test() ->
+    S = #{<<"type">> => <<"integer">>, <<"minimum">> => 0},
+    ?assertEqual(ok, barrel_mcp_schema:validate(0, S)),
+    ?assertMatch({error, _}, barrel_mcp_schema:validate(-1, S)).
+
+exclusive_maximum_test() ->
+    S = #{<<"type">> => <<"number">>, <<"exclusiveMaximum">> => 1},
+    ?assertEqual(ok, barrel_mcp_schema:validate(0.5, S)),
+    ?assertMatch({error, _}, barrel_mcp_schema:validate(1, S)).
+
+%%====================================================================
+%% allOf / anyOf / oneOf
+%%====================================================================
+
+any_of_test() ->
+    S = #{<<"anyOf">> => [
+        #{<<"type">> => <<"string">>},
+        #{<<"type">> => <<"integer">>}
+    ]},
+    ?assertEqual(ok, barrel_mcp_schema:validate(<<"x">>, S)),
+    ?assertEqual(ok, barrel_mcp_schema:validate(7, S)),
+    ?assertMatch({error, _}, barrel_mcp_schema:validate(true, S)).
+
+one_of_unique_test() ->
+    S = #{<<"oneOf">> => [
+        #{<<"type">> => <<"string">>},
+        #{<<"type">> => <<"integer">>}
+    ]},
+    ?assertEqual(ok, barrel_mcp_schema:validate(<<"x">>, S)).
+
+one_of_no_match_test() ->
+    S = #{<<"oneOf">> => [
+        #{<<"type">> => <<"string">>},
+        #{<<"type">> => <<"integer">>}
+    ]},
+    ?assertMatch({error, [{[], no_oneof_match}]},
+        barrel_mcp_schema:validate(true, S)).
+
+all_of_test() ->
+    S = #{<<"allOf">> => [
+        #{<<"type">> => <<"integer">>},
+        #{<<"minimum">> => 0}
+    ]},
+    ?assertEqual(ok, barrel_mcp_schema:validate(5, S)),
+    ?assertMatch({error, _}, barrel_mcp_schema:validate(-1, S)),
+    ?assertMatch({error, _}, barrel_mcp_schema:validate(<<"x">>, S)).


### PR DESCRIPTION
## Summary

- `barrel_mcp_pagination:walk/1,2` follows `nextCursor` across paged `*/list` responses, with a configurable max-page guard.
- `barrel_mcp_client:list_tools_all/1`, `list_resources_all/1`, `list_resource_templates_all/1`, `list_prompts_all/1` expose the walker as a one-call sugar on the client.
- `barrel_mcp_schema:validate/2` is a pure-Erlang JSON Schema subset validator that hosts can use to pre-flight LLM-generated tool args before calling a remote tool. Covers `type`, `properties`, `required`, `enum`, `items`, `oneOf`/`anyOf`/`allOf`, `additionalProperties: false`, string and number bounds, and array length / uniqueness. Returns `ok` or `{error, [{Path, Reason}]}`.

## Status

- 153/153 EUnit tests green (29 new).
- Dialyzer clean.