### PR TITLE
Progress dispatch and periodic ping cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `barrel_mcp_client:list_tools_all/1`, `list_resources_all/1`, `list_resource_templates_all/1`, `list_prompts_all/1`: walk every page and return the union.
 - `barrel_mcp_schema:validate/2`: minimal JSON Schema validator covering type/properties/required/enum/items/oneOf/anyOf/allOf/min-max-length/pattern/min-max-items/uniqueItems/min-max/exclusive bounds. Returns `ok` or `{error, [{Path, Reason}]}`. Hosts use it to pre-flight LLM-generated tool args before calling the server.
 
+### Added (control plane)
+
+- Progress dispatch: when a caller passes `progress_token` to `call_tool/4`, the client registers the caller pid against that token and routes inbound `notifications/progress` to it as `{mcp_progress, Token, Params}`. The mapping clears automatically when the request settles, is cancelled, or times out.
+- Periodic ping: `ping_interval` (default `infinity`, opt-in) sends `ping` while in `ready`. After `ping_failure_threshold` consecutive failures (default `3`), the connection closes with reason `ping_failed`.
+
 ## [1.1.0] - 2025-01-27
 
 ### Added

--- a/guides/features.md
+++ b/guides/features.md
@@ -44,7 +44,13 @@ by the spec.
   page via `barrel_mcp_pagination:walk/1`.
 - Cancellation: `barrel_mcp_client:cancel/2` sends
   `notifications/cancelled` and unblocks the caller.
-- Progress: callers may pass `progress_token` in `tools/call`.
+- Progress: pass `progress_token` to `call_tool/4` and the caller
+  receives `{mcp_progress, Token, Params}` for every matching
+  `notifications/progress` until the request settles.
+- Periodic ping: opt-in via `ping_interval` (and
+  `ping_failure_threshold`) in the connect spec; the connection is
+  closed with reason `ping_failed` after the configured number of
+  consecutive failures.
 - Server→client requests dispatched through the
   `barrel_mcp_client_handler` behaviour. `{reply, _, _}`,
   `{error, _, _, _}`, and `{async, Tag, _}` reply forms; the host
@@ -87,6 +93,5 @@ end.
 
 ### Roadmap
 
-- Periodic `ping` cadence and deadline timers for outstanding
-  requests.
-- OAuth 2.1 + PKCE auth.
+- OAuth 2.1 + PKCE auth (Protected Resource Metadata discovery,
+  RFC 8707 `resource` parameter).

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -83,17 +83,22 @@
       auth => none | {bearer, binary()} | {oauth, map()},
       protocol_version => binary(),
       request_timeout => pos_integer(),
-      init_timeout => pos_integer()}.
+      init_timeout => pos_integer(),
+      ping_interval => pos_integer() | infinity,
+      ping_failure_threshold => pos_integer()}.
 
 -export_type([connect_spec/0]).
 
 -define(DEFAULT_REQUEST_TIMEOUT, 30000).
 -define(DEFAULT_INIT_TIMEOUT, 30000).
+-define(DEFAULT_PING_TIMEOUT, 5000).
+-define(DEFAULT_PING_FAILURE_THRESHOLD, 3).
 
 -record(pending, {
-    caller :: init | {pid(), term()},
+    caller :: init | ping | {pid(), term()},
     method :: binary(),
-    deadline :: integer() | infinity
+    deadline :: integer() | infinity,
+    progress_token :: binary() | undefined
 }).
 
 -record(data, {
@@ -105,6 +110,8 @@
     handler_state :: term(),
     async_replies = #{} :: #{barrel_mcp_client_handler:async_tag() => integer()},
     subscriptions = #{} :: #{binary() => [pid()]},
+    progress = #{} :: #{binary() => pid()},
+    ping_failures = 0 :: non_neg_integer(),
     server_capabilities :: map() | undefined,
     server_info :: map() | undefined,
     protocol_version :: binary() | undefined
@@ -318,14 +325,21 @@ ready({call, From}, {request, Method, Params, Timeout}, Data) ->
             {Id, Data1} = next_id(Data),
             send_envelope(Data1,
                 barrel_mcp_protocol:encode_request(Id, Method, Params)),
+            ProgressToken = progress_token_from_params(Params),
+            {CallerPid, _Tag} = From,
+            Data2 = case ProgressToken of
+                undefined -> Data1;
+                Tok -> Data1#data{progress = (Data1#data.progress)#{Tok => CallerPid}}
+            end,
             P = #pending{caller = From, method = Method,
-                         deadline = deadline(Timeout)},
-            Pending = (Data1#data.pending)#{Id => P},
+                         deadline = deadline(Timeout),
+                         progress_token = ProgressToken},
+            Pending = (Data2#data.pending)#{Id => P},
             Actions = case Timeout of
                           infinity -> [];
                           T -> [{{timeout, {req, Id}}, T, request_timeout}]
                       end,
-            {keep_state, Data1#data{pending = Pending}, Actions}
+            {keep_state, Data2#data{pending = Pending}, Actions}
     end;
 ready(cast, {cancel, Id}, Data) ->
     do_cancel(Id, Data);
@@ -337,6 +351,9 @@ ready(cast, {async_reply, Tag, Result}, Data) ->
     {keep_state, deliver_async_reply(Tag, Result, Data)};
 ready({timeout, {req, Id}}, request_timeout, Data) ->
     timeout_pending(Id, Data);
+ready(state_timeout, ping_tick, Data) ->
+    {Data1, Actions} = issue_ping(Data),
+    {keep_state, Data1, Actions};
 ready(info, {mcp_in, Pid, Json},
       #data{transport = {_, Pid}} = Data) ->
     handle_inbound(Json, ready, Data);
@@ -401,10 +418,13 @@ handle_response(Id, Result, initializing, Data) ->
     end;
 handle_response(Id, Result, _State, Data) ->
     case maps:take(Id, Data#data.pending) of
-        {#pending{caller = From}, Rest} when From =/= init ->
+        {#pending{caller = ping} = P, Rest} ->
+            Data1 = settle_data(P, Data#data{pending = Rest, ping_failures = 0}),
+            {keep_state, Data1, [drop_req_timeout(Id)]};
+        {#pending{caller = From} = P, Rest} when From =/= init ->
             gen_statem:reply(From, {ok, Result}),
-            {keep_state, Data#data{pending = Rest},
-             [{{timeout, {req, Id}}, infinity, request_timeout}]};
+            Data1 = settle_data(P, Data#data{pending = Rest}),
+            {keep_state, Data1, [drop_req_timeout(Id)]};
         _ ->
             keep_state_and_data
     end.
@@ -413,13 +433,26 @@ handle_error_response(_Id, Code, Message, initializing, _Data) ->
     {stop, {init_failed, Code, Message}};
 handle_error_response(Id, Code, Message, _State, Data) ->
     case maps:take(Id, Data#data.pending) of
-        {#pending{caller = From}, Rest} when From =/= init ->
+        {#pending{caller = ping} = P, Rest} ->
+            Data1 = settle_data(P, bump_ping_failures(Data#data{pending = Rest})),
+            maybe_close_on_ping_failures(Data1, Id);
+        {#pending{caller = From} = P, Rest} when From =/= init ->
             gen_statem:reply(From, {error, {Code, Message}}),
-            {keep_state, Data#data{pending = Rest},
-             [{{timeout, {req, Id}}, infinity, request_timeout}]};
+            Data1 = settle_data(P, Data#data{pending = Rest}),
+            {keep_state, Data1, [drop_req_timeout(Id)]};
         _ ->
             keep_state_and_data
     end.
+
+settle_data(#pending{progress_token = Tok}, Data) ->
+    drop_progress(Tok, Data).
+
+drop_progress(undefined, Data) -> Data;
+drop_progress(Tok, Data) ->
+    Data#data{progress = maps:remove(Tok, Data#data.progress)}.
+
+drop_req_timeout(Id) ->
+    {{timeout, {req, Id}}, infinity, request_timeout}.
 
 handle_server_request(Id, Method, Params, _State,
                       #data{handler_mod = Mod, handler_state = HS} = Data) ->
@@ -456,6 +489,10 @@ handle_server_notification(<<"notifications/resources/updated">> = Method, Param
     Uri = maps:get(<<"uri">>, Params, <<>>),
     notify_subscribers(Uri, Params, Data),
     dispatch_notification(Method, Params, Data);
+handle_server_notification(<<"notifications/progress">> = Method, Params,
+                           _State, Data) ->
+    notify_progress(Params, Data),
+    dispatch_notification(Method, Params, Data);
 handle_server_notification(Method, Params, _State, Data) ->
     dispatch_notification(Method, Params, Data).
 
@@ -473,6 +510,16 @@ notify_subscribers(Uri, Params, Data) ->
             lists:foreach(fun(P) -> P ! {mcp_resource_updated, Uri, Params} end,
                           Pids),
             ok
+    end.
+
+notify_progress(Params, Data) ->
+    case maps:get(<<"progressToken">>, Params, undefined) of
+        undefined -> ok;
+        Tok ->
+            case maps:get(Tok, Data#data.progress, undefined) of
+                undefined -> ok;
+                Pid -> Pid ! {mcp_progress, Tok, Params}, ok
+            end
     end.
 
 %%====================================================================
@@ -558,7 +605,7 @@ finish_initialize(Version, Result, Data) ->
         server_info = maps:get(<<"serverInfo">>, Result, #{}),
         protocol_version = Version
     },
-    {next_state, ready, Data1}.
+    {next_state, ready, Data1, [arm_ping_timer(Data1)]}.
 
 %%====================================================================
 %% Transport plumbing
@@ -654,6 +701,56 @@ maybe_attach_progress_token(Params, Opts) ->
         Tok -> Params#{<<"_meta">> => #{<<"progressToken">> => Tok}}
     end.
 
+progress_token_from_params(#{<<"_meta">> := #{<<"progressToken">> := Tok}}) ->
+    Tok;
+progress_token_from_params(_) ->
+    undefined.
+
+%%====================================================================
+%% Ping cadence
+%%====================================================================
+
+ping_interval(#data{spec = Spec}) ->
+    case maps:get(ping_interval, Spec, infinity) of
+        infinity -> infinity;
+        N when is_integer(N), N > 0 -> N
+    end.
+
+ping_failure_threshold(#data{spec = Spec}) ->
+    maps:get(ping_failure_threshold, Spec, ?DEFAULT_PING_FAILURE_THRESHOLD).
+
+bump_ping_failures(#data{ping_failures = N} = Data) ->
+    Data#data{ping_failures = N + 1}.
+
+maybe_close_on_ping_failures(Data, _Id) ->
+    case Data#data.ping_failures >= ping_failure_threshold(Data) of
+        true ->
+            case Data#data.transport of
+                {Mod, TPid} -> catch Mod:close(TPid);
+                _ -> ok
+            end,
+            {stop, ping_failed};
+        false ->
+            {keep_state, Data, [arm_ping_timer(Data)]}
+    end.
+
+arm_ping_timer(Data) ->
+    case ping_interval(Data) of
+        infinity -> {state_timeout, infinity, ping_tick};
+        N -> {state_timeout, N, ping_tick}
+    end.
+
+issue_ping(Data) ->
+    {Id, Data1} = next_id(Data),
+    send_envelope(Data1,
+        barrel_mcp_protocol:encode_request(Id, <<"ping">>, #{})),
+    P = #pending{caller = ping, method = <<"ping">>,
+                 deadline = deadline(?DEFAULT_PING_TIMEOUT)},
+    Pending = (Data1#data.pending)#{Id => P},
+    {Data1#data{pending = Pending},
+     [{{timeout, {req, Id}}, ?DEFAULT_PING_TIMEOUT, request_timeout},
+      arm_ping_timer(Data1)]}.
+
 is_supported(<<"initialize">>, _) -> true;
 is_supported(<<"ping">>, _) -> true;
 is_supported(<<"notifications/", _/binary>>, _) -> true;
@@ -672,25 +769,32 @@ is_supported(_, _) -> true.
 
 do_cancel(Id, #data{pending = Pending} = Data) ->
     case maps:take(Id, Pending) of
-        {#pending{caller = From}, Rest} when From =/= init ->
+        {#pending{caller = From} = P, Rest} when From =/= init, From =/= ping ->
             gen_statem:reply(From, {error, cancelled}),
             send_envelope(Data, barrel_mcp_protocol:encode_notification(
                 <<"notifications/cancelled">>,
                 #{<<"requestId">> => Id, <<"reason">> => <<"cancelled by client">>})),
-            {keep_state, Data#data{pending = Rest},
-             [{{timeout, {req, Id}}, infinity, request_timeout}]};
+            Data1 = settle_data(P, Data#data{pending = Rest}),
+            {keep_state, Data1, [drop_req_timeout(Id)]};
         _ ->
             keep_state_and_data
     end.
 
 timeout_pending(Id, #data{pending = Pending} = Data) ->
     case maps:take(Id, Pending) of
-        {#pending{caller = From}, Rest} when From =/= init ->
+        {#pending{caller = ping} = P, Rest} ->
+            Data1 = settle_data(P, bump_ping_failures(Data#data{pending = Rest})),
+            send_envelope(Data1, barrel_mcp_protocol:encode_notification(
+                <<"notifications/cancelled">>,
+                #{<<"requestId">> => Id, <<"reason">> => <<"timeout">>})),
+            maybe_close_on_ping_failures(Data1, Id);
+        {#pending{caller = From} = P, Rest} when From =/= init ->
             gen_statem:reply(From, {error, timeout}),
             send_envelope(Data, barrel_mcp_protocol:encode_notification(
                 <<"notifications/cancelled">>,
                 #{<<"requestId">> => Id, <<"reason">> => <<"timeout">>})),
-            {keep_state, Data#data{pending = Rest}};
+            Data1 = settle_data(P, Data#data{pending = Rest}),
+            {keep_state, Data1};
         _ ->
             keep_state_and_data
     end.

--- a/test/barrel_mcp_client_progress_tests.erl
+++ b/test/barrel_mcp_client_progress_tests.erl
@@ -1,0 +1,124 @@
+%%%-------------------------------------------------------------------
+%%% @doc Tests for client-side ping cadence and progress map cleanup.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_progress_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([slow_handler/1]).
+
+-define(PORT, 19393).
+-define(URL, <<"http://127.0.0.1:19393/mcp">>).
+
+ping_test_() ->
+    {setup,
+     fun setup_loopback/0,
+     fun cleanup_loopback/1,
+     {timeout, 30, [
+         {"ping cadence keeps the client alive against a live server",
+          fun test_ping_keeps_alive/0},
+         {"no ping is sent when ping_interval is left as default (infinity)",
+          fun test_ping_disabled_by_default/0},
+         {"progress_token registers in client state and clears on settle",
+          fun test_progress_lifecycle/0}
+     ]}}.
+
+setup_loopback() ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    ok = barrel_mcp_registry:wait_for_ready(),
+    {ok, _} = barrel_mcp_http_stream:start(#{port => ?PORT, session_enabled => true}),
+    timer:sleep(150),
+    ok.
+
+cleanup_loopback(_) ->
+    catch barrel_mcp_http_stream:stop(),
+    ok.
+
+test_ping_keeps_alive() ->
+    {ok, Pid} = start_client(#{ping_interval => 100}),
+    timer:sleep(450),
+    ?assert(is_process_alive(Pid)),
+    %% A regular request still works while pings interleave.
+    {ok, _} = barrel_mcp_client:server_info(Pid),
+    barrel_mcp_client:close(Pid).
+
+test_ping_disabled_by_default() ->
+    {ok, Pid} = start_client(#{}),
+    timer:sleep(300),
+    ?assert(is_process_alive(Pid)),
+    barrel_mcp_client:close(Pid).
+
+test_progress_lifecycle() ->
+    %% Register a slow tool that lets us see the progress entry while
+    %% the request is still in flight.
+    ok = barrel_mcp_registry:reg(tool, <<"slow">>, ?MODULE, slow_handler, #{}),
+    {ok, Pid} = start_client(#{}),
+    Self = self(),
+    Tok = <<"prog-lifecycle-1">>,
+    Caller = spawn_link(fun() ->
+        Res = barrel_mcp_client:call_tool(Pid, <<"slow">>, #{},
+                                          #{progress_token => Tok}),
+        Self ! {settled, Res}
+    end),
+    %% Wait until the token is visible in the gen_statem's progress map.
+    wait_progress_present(Pid, Tok, 50),
+    receive
+        {settled, {ok, _}} -> ok
+    after 5000 ->
+        exit(Caller, kill),
+        ?assert(false)
+    end,
+    %% Once settled, the entry must be gone.
+    wait_progress_absent(Pid, Tok, 50),
+    ok = barrel_mcp_registry:unreg(tool, <<"slow">>),
+    barrel_mcp_client:close(Pid).
+
+start_client(Extras) ->
+    Spec = maps:merge(#{
+        transport => {http, ?URL},
+        handler => {barrel_mcp_client_handler_default, []}
+    }, Extras),
+    {ok, Pid} = barrel_mcp_client:start(Spec),
+    wait_ready(Pid, 30),
+    {ok, Pid}.
+
+wait_ready(_Pid, 0) -> error(client_not_ready);
+wait_ready(Pid, N) ->
+    case catch barrel_mcp_client:server_capabilities(Pid) of
+        {ok, _} -> ok;
+        _ ->
+            timer:sleep(100),
+            wait_ready(Pid, N - 1)
+    end.
+
+%% slow tool handler — gives the test time to inspect the progress
+%% map before the response settles.
+slow_handler(_Args) ->
+    timer:sleep(200),
+    <<"done">>.
+
+wait_progress_present(_Pid, _Tok, 0) -> error({progress_not_seen});
+wait_progress_present(Pid, Tok, N) ->
+    case progress_map(Pid) of
+        #{Tok := _} -> ok;
+        _ ->
+            timer:sleep(20),
+            wait_progress_present(Pid, Tok, N - 1)
+    end.
+
+wait_progress_absent(_Pid, _Tok, 0) -> error({progress_lingered});
+wait_progress_absent(Pid, Tok, N) ->
+    case progress_map(Pid) of
+        #{Tok := _} ->
+            timer:sleep(20),
+            wait_progress_absent(Pid, Tok, N - 1);
+        _ -> ok
+    end.
+
+progress_map(Pid) ->
+    {_State, Data} = sys:get_state(Pid),
+    %% data record: progress is the 9th field (1-based: 1=record_tag,
+    %% 2=spec, 3=transport, 4=request_id, 5=pending, 6=handler_mod,
+    %% 7=handler_state, 8=async_replies, 9=subscriptions, 10=progress).
+    element(10, Data).


### PR DESCRIPTION
## Summary

- **Progress dispatch.** `call_tool/4` now registers the caller pid against the supplied `progress_token`. Inbound `notifications/progress` are routed to that pid as `{mcp_progress, Token, Params}` for the lifetime of the request. The entry clears automatically when the request settles, is cancelled, or times out.
- **Periodic ping.** Opt-in `ping_interval` in the connect spec (default `infinity`) sends `ping` while the client is in `ready`. After `ping_failure_threshold` consecutive failures (default `3`), the client closes its transport and stops with reason `ping_failed`.

## Status

- 156/156 EUnit tests green (3 new).
- Dialyzer clean.