### PR TITLE
OAuth 2.1 + PKCE for the MCP client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ _checkouts/
 ebin/
 *.beam
 
+# Claude Code scratch
+.claude/
+
 # Rebar3
 rebar.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Progress dispatch: when a caller passes `progress_token` to `call_tool/4`, the client registers the caller pid against that token and routes inbound `notifications/progress` to it as `{mcp_progress, Token, Params}`. The mapping clears automatically when the request settles, is cancelled, or times out.
 - Periodic ping: `ping_interval` (default `infinity`, opt-in) sends `ping` while in `ready`. After `ping_failure_threshold` consecutive failures (default `3`), the connection closes with reason `ping_failed`.
 
+### Added (auth)
+
+- `barrel_mcp_client_auth_oauth`: OAuth 2.1 + PKCE per the MCP authorization spec.
+  - Discovery helpers hosts can use during initial token acquisition: `parse_www_authenticate/1`, `discover_protected_resource/1` (RFC 9728), `discover_authorization_server/1` (RFC 8414, with OpenID Connect fallback).
+  - PKCE primitives: `gen_code_verifier/0`, `code_challenge/1` (S256), `build_authorization_url/2`.
+  - Token endpoint: `exchange_code/2` (authorization-code grant) and `refresh_token/2` (refresh grant). Both honour the RFC 8707 `resource` parameter and support confidential-client HTTP Basic.
+  - Behaviour implementation that attaches `Authorization: Bearer ...` and refreshes transparently on 401 when a `refresh_token` was supplied.
+- `barrel_mcp_client_auth:new({oauth, Config})` is now wired through; `Config` accepts `access_token` (required), `refresh_token`, `token_endpoint`, `client_id`, `client_secret`, `resource`, `scopes`. The interactive authorization-code redirect step stays a host concern; once the host has tokens it hands them to the client and the library handles refresh.
+
 ## [1.1.0] - 2025-01-27
 
 ### Added

--- a/guides/features.md
+++ b/guides/features.md
@@ -73,8 +73,20 @@ by the spec.
 
 - `barrel_mcp_client_auth` behaviour.
 - `barrel_mcp_client_auth_bearer`: static token.
-- OAuth 2.1 + PKCE: planned (Protected Resource Metadata discovery,
-  RFC 8707 `resource` parameter).
+- `barrel_mcp_client_auth_oauth`: OAuth 2.1 + PKCE.
+  - Discovery: `parse_www_authenticate/1`, `discover_protected_resource/1`
+    (RFC 9728), `discover_authorization_server/1` (RFC 8414 with OpenID
+    Connect fallback).
+  - PKCE: `gen_code_verifier/0`, `code_challenge/1` (S256),
+    `build_authorization_url/2`.
+  - Token endpoint: `exchange_code/2`, `refresh_token/2`. Both attach
+    the RFC 8707 `resource` parameter; confidential clients use HTTP
+    Basic.
+  - As an auth handle: when used through `auth => {oauth, Config}` on
+    the client spec, the library attaches `Authorization: Bearer ...`
+    on every request and runs the refresh-token grant on 401 if a
+    `refresh_token` was supplied. The interactive authorization-code
+    redirect stays a host concern.
 
 ### Schema validation (`barrel_mcp_schema`)
 
@@ -93,5 +105,7 @@ end.
 
 ### Roadmap
 
-- OAuth 2.1 + PKCE auth (Protected Resource Metadata discovery,
-  RFC 8707 `resource` parameter).
+- Resumable Streamable HTTP via `Last-Event-ID` (transport buffers
+  the last id but does not yet replay missed events on reconnect).
+- Periodic deadline timer for in-flight requests beyond the per-call
+  timeout (today timeouts fire only when configured per-request).

--- a/src/barrel_mcp_client_auth.erl
+++ b/src/barrel_mcp_client_auth.erl
@@ -50,9 +50,11 @@ new({bearer, Token}) when is_binary(Token) ->
         {ok, H} -> {barrel_mcp_client_auth_bearer, H};
         Err -> Err
     end;
-new({oauth, _Config}) ->
-    %% Phase D.
-    {error, oauth_not_yet_supported}.
+new({oauth, Config}) when is_map(Config) ->
+    case barrel_mcp_client_auth_oauth:init(Config) of
+        {ok, H} -> {barrel_mcp_client_auth_oauth, H};
+        Err -> Err
+    end.
 
 %% @doc Lookup the Authorization header for the current state.
 -spec header(t()) -> {ok, binary()} | none | {error, term()}.

--- a/src/barrel_mcp_client_auth_oauth.erl
+++ b/src/barrel_mcp_client_auth_oauth.erl
@@ -1,0 +1,367 @@
+%%%-------------------------------------------------------------------
+%%% @doc OAuth 2.1 + PKCE authorization for `barrel_mcp_client'.
+%%%
+%%% Implements the MCP authorization flow described in
+%%% <a href="https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization">
+%%% the spec</a> and the underlying RFCs:
+%%%
+%%% <ul>
+%%%   <li>RFC 9728 — Protected Resource Metadata (PRM)</li>
+%%%   <li>RFC 8414 — Authorization Server Metadata</li>
+%%%   <li>RFC 7636 — PKCE (S256)</li>
+%%%   <li>RFC 8707 — `resource' indicator on auth + token requests</li>
+%%%   <li>RFC 6749 / OAuth 2.1 — authorization-code + refresh_token grants</li>
+%%% </ul>
+%%%
+%%% == What this module does ==
+%%%
+%%% Two responsibilities, kept separate so hosts can mix them as
+%%% they need:
+%%%
+%%% <ol>
+%%%   <li>**Discovery helpers** that hosts use during initial token
+%%%       acquisition: parse `WWW-Authenticate', fetch PRM, fetch AS
+%%%       metadata, build authorization URLs with PKCE, exchange the
+%%%       returned code at the token endpoint.</li>
+%%%   <li>**`barrel_mcp_client_auth' behaviour implementation** that
+%%%       attaches the `Authorization: Bearer ...' header on every
+%%%       outgoing request and refreshes the token automatically on
+%%%       401 (when a `refresh_token' was supplied).</li>
+%%% </ol>
+%%%
+%%% == What this module does NOT do ==
+%%%
+%%% The authorization-code redirect step requires a browser and a
+%%% local listener to capture the callback — that's a host concern,
+%%% not a library one. Hosts run the interactive step however suits
+%%% them (open a URL, do a CLI device-code flow, paste a code), then
+%%% pass the resulting tokens back via the `{oauth, Config}' tuple.
+%%% The library handles refresh from there.
+%%%
+%%% == Config shape ==
+%%%
+%%% ```
+%%% {oauth, #{
+%%%   access_token   := binary(),       %% required
+%%%   refresh_token  => binary(),       %% optional; enables refresh
+%%%   token_endpoint => binary(),       %% required if refresh_token set
+%%%   client_id      => binary(),       %% required if refresh_token set
+%%%   client_secret  => binary(),       %% optional confidential client
+%%%   resource       => binary(),       %% RFC 8707 canonical id
+%%%   scopes         => [binary()]      %% optional
+%%% }}
+%%% '''
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_auth_oauth).
+
+-behaviour(barrel_mcp_client_auth).
+
+%% Behaviour callbacks
+-export([init/1, header/1, refresh/2]).
+
+%% Public discovery + PKCE + token helpers (host-side).
+-export([
+    parse_www_authenticate/1,
+    discover_protected_resource/1,
+    discover_authorization_server/1,
+    gen_code_verifier/0,
+    code_challenge/1,
+    build_authorization_url/2,
+    exchange_code/2,
+    refresh_token/2
+]).
+
+-export_type([config/0, handle/0]).
+
+-type config() :: #{
+    access_token := binary(),
+    refresh_token => binary(),
+    token_endpoint => binary(),
+    client_id => binary(),
+    client_secret => binary(),
+    resource => binary(),
+    scopes => [binary()]
+}.
+
+-record(h, {
+    access_token :: binary(),
+    refresh_token :: binary() | undefined,
+    token_endpoint :: binary() | undefined,
+    client_id :: binary() | undefined,
+    client_secret :: binary() | undefined,
+    resource :: binary() | undefined,
+    scopes :: [binary()] | undefined
+}).
+
+-type handle() :: #h{}.
+
+%%====================================================================
+%% Behaviour callbacks
+%%====================================================================
+
+init(#{access_token := AT} = Cfg) when is_binary(AT), AT =/= <<>> ->
+    {ok, #h{
+        access_token = AT,
+        refresh_token = maps:get(refresh_token, Cfg, undefined),
+        token_endpoint = maps:get(token_endpoint, Cfg, undefined),
+        client_id = maps:get(client_id, Cfg, undefined),
+        client_secret = maps:get(client_secret, Cfg, undefined),
+        resource = maps:get(resource, Cfg, undefined),
+        scopes = maps:get(scopes, Cfg, undefined)
+    }};
+init(_) ->
+    {error, missing_access_token}.
+
+header(#h{access_token = AT}) ->
+    {ok, <<"Bearer ", AT/binary>>}.
+
+refresh(#h{refresh_token = undefined}, _Www) ->
+    {error, no_refresh_token};
+refresh(#h{token_endpoint = undefined}, _Www) ->
+    {error, no_token_endpoint};
+refresh(#h{client_id = undefined}, _Www) ->
+    {error, no_client_id};
+refresh(#h{} = H, _Www) ->
+    case do_refresh(H) of
+        {ok, NewTokens} ->
+            {ok, apply_token_response(H, NewTokens)};
+        {error, _} = Err ->
+            Err
+    end.
+
+%%====================================================================
+%% Discovery
+%%====================================================================
+
+%% @doc Extract the `resource_metadata' URL from a `WWW-Authenticate'
+%% header per RFC 9728. Returns `undefined' if not present.
+-spec parse_www_authenticate(binary() | undefined) -> binary() | undefined.
+parse_www_authenticate(undefined) -> undefined;
+parse_www_authenticate(Header) when is_binary(Header) ->
+    case re:run(Header,
+                <<"resource_metadata=\"?([^\",;]+)\"?">>,
+                [{capture, all_but_first, binary}]) of
+        {match, [Url]} -> Url;
+        nomatch -> undefined
+    end.
+
+%% @doc Fetch and parse the Protected Resource Metadata document.
+-spec discover_protected_resource(binary()) ->
+    {ok, map()} | {error, term()}.
+discover_protected_resource(Url) ->
+    case http_get_json(Url) of
+        {ok, #{<<"resource">> := _,
+               <<"authorization_servers">> := AS} = Doc} when is_list(AS) ->
+            {ok, Doc};
+        {ok, Other} ->
+            {error, {invalid_prm, Other}};
+        Err -> Err
+    end.
+
+%% @doc Fetch the Authorization Server Metadata for the given issuer
+%% URL. Tries `/.well-known/oauth-authorization-server' first, then
+%% falls back to `/.well-known/openid-configuration'.
+-spec discover_authorization_server(binary()) ->
+    {ok, map()} | {error, term()}.
+discover_authorization_server(Issuer) ->
+    Base = trim_trailing_slash(Issuer),
+    Primary = <<Base/binary, "/.well-known/oauth-authorization-server">>,
+    Fallback = <<Base/binary, "/.well-known/openid-configuration">>,
+    case http_get_json(Primary) of
+        {ok, _} = Ok -> validate_as(Ok);
+        {error, _} ->
+            case http_get_json(Fallback) of
+                {ok, _} = Ok2 -> validate_as(Ok2);
+                Err -> Err
+            end
+    end.
+
+validate_as({ok, #{<<"authorization_endpoint">> := _,
+                   <<"token_endpoint">> := _} = Doc}) ->
+    {ok, Doc};
+validate_as({ok, Other}) ->
+    {error, {invalid_as_metadata, Other}}.
+
+%%====================================================================
+%% PKCE
+%%====================================================================
+
+%% @doc Generate a 64-byte random URL-safe code verifier (RFC 7636).
+-spec gen_code_verifier() -> binary().
+gen_code_verifier() ->
+    base64url(crypto:strong_rand_bytes(64)).
+
+%% @doc Derive the S256 code challenge for a verifier.
+-spec code_challenge(binary()) -> binary().
+code_challenge(Verifier) ->
+    base64url(crypto:hash(sha256, Verifier)).
+
+%%====================================================================
+%% Authorization URL + token endpoint
+%%====================================================================
+
+%% @doc Build an authorization-code+PKCE URL for the user to visit.
+%% `Params' must include `client_id' and `redirect_uri'; the function
+%% handles `code_challenge'/`code_challenge_method' for you given the
+%% verifier. `state' is generated automatically if not supplied.
+-spec build_authorization_url(binary(), map()) -> {binary(), binary(), binary()}.
+build_authorization_url(AuthEndpoint, Params) ->
+    Verifier = maps:get(code_verifier, Params, gen_code_verifier()),
+    State = maps:get(state, Params, base64url(crypto:strong_rand_bytes(16))),
+    Q = #{
+        <<"response_type">> => <<"code">>,
+        <<"client_id">> => required(client_id, Params),
+        <<"redirect_uri">> => required(redirect_uri, Params),
+        <<"code_challenge">> => code_challenge(Verifier),
+        <<"code_challenge_method">> => <<"S256">>,
+        <<"state">> => State
+    },
+    Q1 = maps:fold(fun add_optional/3, Q, #{
+        scope => maps:get(scopes, Params, undefined),
+        resource => maps:get(resource, Params, undefined)
+    }),
+    Url = iolist_to_binary([AuthEndpoint, $?, urlencode(Q1)]),
+    {Url, Verifier, State}.
+
+%% @doc Exchange an authorization code for tokens.
+-spec exchange_code(binary(), map()) ->
+    {ok, map()} | {error, term()}.
+exchange_code(TokenEndpoint, Params) ->
+    Body = #{
+        <<"grant_type">> => <<"authorization_code">>,
+        <<"code">> => required(code, Params),
+        <<"code_verifier">> => required(code_verifier, Params),
+        <<"client_id">> => required(client_id, Params),
+        <<"redirect_uri">> => required(redirect_uri, Params)
+    },
+    Body1 = maps:fold(fun add_optional/3, Body, #{
+        client_secret => maps:get(client_secret, Params, undefined),
+        resource => maps:get(resource, Params, undefined)
+    }),
+    http_post_form(TokenEndpoint, Body1, maps:get(client_secret, Params, undefined),
+                   maps:get(client_id, Params, undefined)).
+
+%% @doc Refresh an access token via the refresh_token grant.
+-spec refresh_token(binary(), map()) ->
+    {ok, map()} | {error, term()}.
+refresh_token(TokenEndpoint, Params) ->
+    Body = #{
+        <<"grant_type">> => <<"refresh_token">>,
+        <<"refresh_token">> => required(refresh_token, Params),
+        <<"client_id">> => required(client_id, Params)
+    },
+    Body1 = maps:fold(fun add_optional/3, Body, #{
+        client_secret => maps:get(client_secret, Params, undefined),
+        resource => maps:get(resource, Params, undefined),
+        scope => maps:get(scopes, Params, undefined)
+    }),
+    http_post_form(TokenEndpoint, Body1, maps:get(client_secret, Params, undefined),
+                   maps:get(client_id, Params, undefined)).
+
+%%====================================================================
+%% Internal — refresh wired through the behaviour
+%%====================================================================
+
+do_refresh(#h{refresh_token = RT, token_endpoint = TE,
+              client_id = CI, client_secret = CS,
+              resource = Res, scopes = Scopes}) ->
+    Params = drop_undefined(#{
+        refresh_token => RT,
+        client_id => CI,
+        client_secret => CS,
+        resource => Res,
+        scopes => Scopes
+    }),
+    refresh_token(TE, Params).
+
+apply_token_response(#h{} = H, #{<<"access_token">> := AT} = R) ->
+    H#h{access_token = AT,
+        refresh_token = maps:get(<<"refresh_token">>, R, H#h.refresh_token)};
+apply_token_response(H, _) -> H.
+
+%%====================================================================
+%% HTTP helpers
+%%====================================================================
+
+http_get_json(Url) ->
+    case hackney:request(get, Url, [{<<"accept">>, <<"application/json">>}],
+                         <<>>, [with_body, {follow_redirect, true}]) of
+        {ok, 200, _Hdrs, Body} ->
+            try {ok, json:decode(Body)}
+            catch _:_ -> {error, {invalid_json, Body}} end;
+        {ok, Status, _Hdrs, _Body} ->
+            {error, {http_error, Status}};
+        {error, _} = Err -> Err
+    end.
+
+http_post_form(Url, Form, ClientSecret, ClientId)
+  when is_binary(ClientId), ClientId =/= <<>>,
+       is_binary(ClientSecret), ClientSecret =/= <<>> ->
+    %% Confidential client uses HTTP Basic auth and omits client_id
+    %% from body per OAuth 2.1.
+    Form1 = maps:remove(<<"client_id">>, Form),
+    Auth = base64:encode(<<ClientId/binary, ":", ClientSecret/binary>>),
+    Headers = [{<<"authorization">>, <<"Basic ", Auth/binary>>},
+               {<<"content-type">>, <<"application/x-www-form-urlencoded">>},
+               {<<"accept">>, <<"application/json">>}],
+    do_post_form(Url, Headers, Form1);
+http_post_form(Url, Form, _, _) ->
+    Headers = [{<<"content-type">>, <<"application/x-www-form-urlencoded">>},
+               {<<"accept">>, <<"application/json">>}],
+    do_post_form(Url, Headers, Form).
+
+do_post_form(Url, Headers, Form) ->
+    Body = urlencode(Form),
+    case hackney:request(post, Url, Headers, Body, [with_body]) of
+        {ok, 200, _Hdrs, RB} ->
+            try {ok, json:decode(RB)}
+            catch _:_ -> {error, {invalid_json, RB}} end;
+        {ok, Status, _Hdrs, RB} ->
+            {error, {http_error, Status, RB}};
+        {error, _} = Err -> Err
+    end.
+
+%%====================================================================
+%% Encoders
+%%====================================================================
+
+urlencode(Map) when is_map(Map) ->
+    Pairs = lists:map(fun({K, V}) -> [pct(K), $=, pct(value(V))] end,
+                      maps:to_list(Map)),
+    iolist_to_binary(lists:join($&, Pairs)).
+
+value(L) when is_list(L) -> iolist_to_binary(lists:join(<<" ">>, L));
+value(B) when is_binary(B) -> B;
+value(I) when is_integer(I) -> integer_to_binary(I);
+value(A) when is_atom(A) -> atom_to_binary(A, utf8).
+
+pct(B) when is_binary(B) -> uri_string:quote(B);
+pct(B) -> uri_string:quote(value(B)).
+
+base64url(Bin) ->
+    Enc = base64:encode(Bin),
+    binary:replace(
+        binary:replace(
+            binary:replace(Enc, <<"+">>, <<"-">>, [global]),
+            <<"/">>, <<"_">>, [global]),
+        <<"=">>, <<>>, [global]).
+
+trim_trailing_slash(B) ->
+    case binary:last(B) of
+        $/ -> binary:part(B, 0, byte_size(B) - 1);
+        _ -> B
+    end.
+
+required(Key, Map) ->
+    case maps:find(Key, Map) of
+        {ok, V} -> V;
+        error -> error({missing, Key})
+    end.
+
+add_optional(_K, undefined, Acc) -> Acc;
+add_optional(K, V, Acc) ->
+    Acc#{atom_to_binary(K, utf8) => V}.
+
+drop_undefined(Map) ->
+    maps:filter(fun(_, V) -> V =/= undefined end, Map).

--- a/test/barrel_mcp_client_auth_oauth_tests.erl
+++ b/test/barrel_mcp_client_auth_oauth_tests.erl
@@ -1,0 +1,179 @@
+%%%-------------------------------------------------------------------
+%%% @doc Tests for `barrel_mcp_client_auth_oauth' covering pure
+%%% helpers and a refresh-token round-trip against a tiny cowboy
+%%% authorization server.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_auth_oauth_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([init/2]).
+
+-define(PORT, 19494).
+-define(BASE, <<"http://127.0.0.1:19494">>).
+
+%%====================================================================
+%% Pure helpers
+%%====================================================================
+
+parse_www_authenticate_with_quotes_test() ->
+    H = <<"Bearer realm=\"x\", resource_metadata=\"https://srv/.well-known/oauth-protected-resource\", error=\"invalid_token\"">>,
+    ?assertEqual(<<"https://srv/.well-known/oauth-protected-resource">>,
+                 barrel_mcp_client_auth_oauth:parse_www_authenticate(H)).
+
+parse_www_authenticate_no_quotes_test() ->
+    H = <<"Bearer resource_metadata=https://srv/.well-known/oauth-protected-resource">>,
+    ?assertEqual(<<"https://srv/.well-known/oauth-protected-resource">>,
+                 barrel_mcp_client_auth_oauth:parse_www_authenticate(H)).
+
+parse_www_authenticate_missing_test() ->
+    ?assertEqual(undefined,
+                 barrel_mcp_client_auth_oauth:parse_www_authenticate(
+                   <<"Bearer realm=\"x\"">>)).
+
+parse_www_authenticate_undefined_test() ->
+    ?assertEqual(undefined,
+                 barrel_mcp_client_auth_oauth:parse_www_authenticate(undefined)).
+
+pkce_verifier_is_url_safe_test() ->
+    V = barrel_mcp_client_auth_oauth:gen_code_verifier(),
+    ?assert(byte_size(V) >= 43),
+    ?assertEqual(nomatch, binary:match(V, [<<"+">>, <<"/">>, <<"=">>])).
+
+pkce_challenge_is_deterministic_test() ->
+    V = <<"static-verifier-for-determinism">>,
+    C1 = barrel_mcp_client_auth_oauth:code_challenge(V),
+    C2 = barrel_mcp_client_auth_oauth:code_challenge(V),
+    ?assertEqual(C1, C2),
+    ?assertEqual(nomatch, binary:match(C1, [<<"+">>, <<"/">>, <<"=">>])).
+
+build_authorization_url_test() ->
+    {Url, Verifier, State} = barrel_mcp_client_auth_oauth:build_authorization_url(
+        <<"https://as/auth">>,
+        #{client_id => <<"cid">>,
+          redirect_uri => <<"http://localhost:9999/cb">>,
+          resource => <<"https://mcp/server">>,
+          scopes => [<<"read">>, <<"write">>]}),
+    ?assert(byte_size(Verifier) > 0),
+    ?assert(byte_size(State) > 0),
+    ?assert(binary:match(Url, <<"response_type=code">>) =/= nomatch),
+    ?assert(binary:match(Url, <<"code_challenge_method=S256">>) =/= nomatch),
+    ?assert(binary:match(Url, <<"client_id=cid">>) =/= nomatch),
+    ?assert(binary:match(Url, <<"resource=">>) =/= nomatch).
+
+%%====================================================================
+%% Refresh round-trip against a cowboy mock
+%%====================================================================
+
+refresh_round_trip_test_() ->
+    {setup,
+     fun setup_mock/0,
+     fun cleanup_mock/1,
+     {timeout, 30, [
+         {"discover PRM",            fun test_discover_prm/0},
+         {"discover AS metadata",    fun test_discover_as/0},
+         {"refresh_token grant",     fun test_refresh_token/0},
+         {"behaviour refresh path",  fun test_behaviour_refresh/0}
+     ]}}.
+
+setup_mock() ->
+    {ok, _} = application:ensure_all_started(cowboy),
+    {ok, _} = application:ensure_all_started(hackney),
+    Dispatch = cowboy_router:compile([{'_', [
+        {"/.well-known/oauth-protected-resource", ?MODULE, prm},
+        {"/.well-known/oauth-authorization-server", ?MODULE, as},
+        {"/oauth/token", ?MODULE, token}
+    ]}]),
+    {ok, _} = cowboy:start_clear(?MODULE, [{port, ?PORT}],
+                                 #{env => #{dispatch => Dispatch}}),
+    timer:sleep(100),
+    ok.
+
+cleanup_mock(_) ->
+    catch cowboy:stop_listener(?MODULE),
+    ok.
+
+%% Cowboy handler used as a tiny mock authorization server.
+init(Req, prm) ->
+    Body = json_encode(#{
+        <<"resource">> => <<"http://127.0.0.1:19494/mcp">>,
+        <<"authorization_servers">> => [?BASE]
+    }),
+    R = cowboy_req:reply(200,
+        #{<<"content-type">> => <<"application/json">>}, Body, Req),
+    {ok, R, prm};
+init(Req, as) ->
+    Body = json_encode(#{
+        <<"issuer">> => ?BASE,
+        <<"authorization_endpoint">> => <<?BASE/binary, "/oauth/authorize">>,
+        <<"token_endpoint">> => <<?BASE/binary, "/oauth/token">>,
+        <<"code_challenge_methods_supported">> => [<<"S256">>]
+    }),
+    R = cowboy_req:reply(200,
+        #{<<"content-type">> => <<"application/json">>}, Body, Req),
+    {ok, R, as};
+init(Req0, token) ->
+    {ok, Body, Req} = cowboy_req:read_urlencoded_body(Req0),
+    Form = maps:from_list(Body),
+    Resp = case maps:get(<<"grant_type">>, Form, undefined) of
+        <<"refresh_token">> ->
+            <<"old-refresh">> = maps:get(<<"refresh_token">>, Form),
+            <<"client-1">> = maps:get(<<"client_id">>, Form),
+            <<"http://127.0.0.1:19494/mcp">> =
+                maps:get(<<"resource">>, Form),
+            #{<<"access_token">> => <<"new-access">>,
+              <<"refresh_token">> => <<"new-refresh">>,
+              <<"token_type">> => <<"Bearer">>,
+              <<"expires_in">> => 3600};
+        _ ->
+            #{<<"error">> => <<"unsupported_grant_type">>}
+    end,
+    R = cowboy_req:reply(200,
+        #{<<"content-type">> => <<"application/json">>},
+        json_encode(Resp), Req),
+    {ok, R, token}.
+
+json_encode(M) -> iolist_to_binary(json:encode(M)).
+
+%%====================================================================
+%% Tests
+%%====================================================================
+
+test_discover_prm() ->
+    Url = <<?BASE/binary, "/.well-known/oauth-protected-resource">>,
+    {ok, Doc} = barrel_mcp_client_auth_oauth:discover_protected_resource(Url),
+    ?assertEqual(<<"http://127.0.0.1:19494/mcp">>,
+                 maps:get(<<"resource">>, Doc)),
+    ?assertEqual([?BASE],
+                 maps:get(<<"authorization_servers">>, Doc)).
+
+test_discover_as() ->
+    {ok, AS} = barrel_mcp_client_auth_oauth:discover_authorization_server(?BASE),
+    ?assertEqual(<<?BASE/binary, "/oauth/token">>,
+                 maps:get(<<"token_endpoint">>, AS)).
+
+test_refresh_token() ->
+    {ok, Resp} = barrel_mcp_client_auth_oauth:refresh_token(
+        <<?BASE/binary, "/oauth/token">>,
+        #{refresh_token => <<"old-refresh">>,
+          client_id => <<"client-1">>,
+          resource => <<"http://127.0.0.1:19494/mcp">>}),
+    ?assertEqual(<<"new-access">>, maps:get(<<"access_token">>, Resp)),
+    ?assertEqual(<<"new-refresh">>, maps:get(<<"refresh_token">>, Resp)).
+
+test_behaviour_refresh() ->
+    %% Build the handle that barrel_mcp_client_auth would produce.
+    Auth = barrel_mcp_client_auth:new({oauth, #{
+        access_token => <<"old-access">>,
+        refresh_token => <<"old-refresh">>,
+        token_endpoint => <<?BASE/binary, "/oauth/token">>,
+        client_id => <<"client-1">>,
+        resource => <<"http://127.0.0.1:19494/mcp">>
+    }}),
+    ?assertNotMatch({error, _}, Auth),
+    ?assertEqual({ok, <<"Bearer old-access">>},
+                 barrel_mcp_client_auth:header(Auth)),
+    {ok, Auth1} = barrel_mcp_client_auth:refresh(Auth, <<"Bearer error=expired">>),
+    ?assertEqual({ok, <<"Bearer new-access">>},
+                 barrel_mcp_client_auth:header(Auth1)).


### PR DESCRIPTION
## Summary

`barrel_mcp_client_auth_oauth` implements the [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) with two layers of public surface:

**Discovery helpers** hosts use during initial token acquisition:

- `parse_www_authenticate/1` — extract the `resource_metadata` URL.
- `discover_protected_resource/1` — RFC 9728.
- `discover_authorization_server/1` — RFC 8414 with OpenID Connect fallback.

**PKCE + token endpoint:**

- `gen_code_verifier/0`, `code_challenge/1` (S256), `build_authorization_url/2`.
- `exchange_code/2`, `refresh_token/2` — both attach the RFC 8707 `resource` parameter and use HTTP Basic for confidential clients.

**Behaviour wiring:** `barrel_mcp_client_auth:new({oauth, Config})` is now implemented. The handle attaches `Authorization: Bearer ...` on every request and runs the refresh-token grant on 401 when a `refresh_token` was supplied. The interactive authorization-code redirect stays a host concern.

`Config` accepts `access_token` (required), `refresh_token`, `token_endpoint`, `client_id`, `client_secret`, `resource`, `scopes`.

## Status

- 167/167 EUnit tests green (11 new).
- Dialyzer clean.
- No new dependencies (token stays opaque, so `jose` is not required).