### PR TITLE
Developer documentation for building MCP clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,28 @@ jobs:
           key: ${{ runner.os }}-rebar3-${{ matrix.otp }}-${{ hashFiles('rebar.lock') }}
           restore-keys: |
             ${{ runner.os }}-rebar3-${{ matrix.otp }}-
-      - name: Run tests
+      - name: Run eunit
         run: rebar3 eunit
+      - name: Run common_test (snippet check + suites)
+        run: rebar3 ct
+
+  examples:
+    name: Examples / OTP ${{ matrix.otp }}
+    needs: compile
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp: ['27', '28']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          rebar3-version: '3.24'
+      - name: Set up _checkouts symlinks
+        run: make examples-setup
+      - name: Run example suites
+        run: make examples-test
 
   check:
     name: Check / OTP ${{ matrix.otp }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ _checkouts/
 ebin/
 *.beam
 
+# Examples — _checkouts symlinks created by `make examples-setup'
+examples/*/_checkouts/
+
 # Claude Code scratch
 .claude/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Progress dispatch: when a caller passes `progress_token` to `call_tool/4`, the client registers the caller pid against that token and routes inbound `notifications/progress` to it as `{mcp_progress, Token, Params}`. The mapping clears automatically when the request settles, is cancelled, or times out.
 - Periodic ping: `ping_interval` (default `infinity`, opt-in) sends `ping` while in `ready`. After `ping_failure_threshold` consecutive failures (default `3`), the connection closes with reason `ping_failed`.
 
+### Added (docs)
+
+- `guides/building-a-client.md` — task-oriented walkthrough for hosting MCP clients on `barrel_mcp` (transport choice, connect spec, lifecycle, capability negotiation, tool calls, server-initiated requests via the handler behaviour, OAuth, federation, schema validation, error reference).
+- `guides/internals.md` — architecture and behaviour contracts (module map, supervision tree, state machine, message flow, transport/handler/auth contracts, ETS layout, wire format).
+- `examples/echo_client/` — minimal MCP host that boots a local server, lists tools, calls `echo`. Common-test suite asserts the round-trip.
+- `examples/sampling_host/` — host implementing `barrel_mcp_client_handler` to answer `sampling/createMessage`. Common-test suite covers the full server-to-client round-trip.
+- `test/snippet_check.escript` + `test/doc_snippets_SUITE.erl` — extracts every `` ```erlang `` fenced block from the new guides and example READMEs and verifies it compiles. Wired into `rebar3 ct`.
+- `Makefile` with `examples-setup` and `examples-test` targets; CI runs example suites on OTP 27 + 28.
+- Per-function `@doc` and `-spec` on the public client surface (`barrel_mcp_client`, `barrel_mcp_clients`, `barrel_mcp_client_handler` example).
+- ex_doc sidebar reorganised: client modules grouped, new "Building a Client" / "Client Internals" pages.
+
 ### Added (auth)
 
 - `barrel_mcp_client_auth_oauth`: OAuth 2.1 + PKCE per the MCP authorization spec.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+.PHONY: all compile test ct eunit dialyzer docs examples-setup examples-test clean
+
+all: compile
+
+compile:
+	rebar3 compile
+
+test: eunit ct
+
+eunit:
+	rebar3 eunit
+
+ct:
+	rebar3 ct
+
+dialyzer:
+	rebar3 dialyzer
+
+docs:
+	rebar3 ex_doc
+
+# Set up `_checkouts' symlinks so each example resolves `barrel_mcp'
+# to the parent repo without fetching from hex/git.
+examples-setup:
+	@for ex in examples/*/; do \
+	    mkdir -p "$$ex/_checkouts"; \
+	    ln -snf ../../.. "$$ex/_checkouts/barrel_mcp"; \
+	done
+
+examples-test: examples-setup
+	@for ex in examples/*/; do \
+	    echo "==> $$ex"; \
+	    (cd "$$ex" && rebar3 ct) || exit 1; \
+	done
+
+clean:
+	rebar3 clean
+	rm -rf examples/*/_build examples/*/_checkouts

--- a/README.md
+++ b/README.md
@@ -395,26 +395,25 @@ barrel_mcp:start_stdio().
 
 ### Using as Client
 
-```erlang
-%% Connect to an MCP server
-{ok, Client} = barrel_mcp_client:connect(#{
+`barrel_mcp_client` is a `gen_statem`. Start it, wait for the
+handshake to complete, call tools.
+
+```erl
+{ok, Pid} = barrel_mcp_client:start_link(#{
     transport => {http, <<"http://localhost:9090/mcp">>}
-}).
-
-%% Initialize connection
-{ok, ServerInfo, Client1} = barrel_mcp_client:initialize(Client).
-
-%% List available tools
-{ok, Tools, Client2} = barrel_mcp_client:list_tools(Client1).
-
-%% Call a tool
-{ok, Result, Client3} = barrel_mcp_client:call_tool(Client2, <<"search">>, #{
-    <<"query">> => <<"hello world">>
-}).
-
-%% Close connection
-ok = barrel_mcp_client:close(Client3).
+}),
+{ok, Tools}  = barrel_mcp_client:list_tools(Pid),
+{ok, Result} = barrel_mcp_client:call_tool(Pid, <<"search">>,
+                                           #{<<"query">> => <<"hello">>}),
+ok = barrel_mcp_client:close(Pid).
 ```
+
+For the full task-oriented walkthrough — transport choice, auth,
+OAuth, server-to-client handlers, federation, schema validation —
+see [Building a client](guides/building-a-client.md). For
+architecture and behaviour contracts, see
+[Internals](guides/internals.md). Two runnable examples live under
+[`examples/`](examples/).
 
 ## Claude Desktop Configuration
 

--- a/examples/echo_client/README.md
+++ b/examples/echo_client/README.md
@@ -1,0 +1,28 @@
+# echo_client
+
+Minimal MCP host built on `barrel_mcp_client`. Boots a `barrel_mcp`
+Streamable HTTP server in-process, registers an `echo` tool, connects
+a client, calls the tool, and prints the result.
+
+## Run it
+
+```
+cd examples/echo_client
+rebar3 shell
+1> echo_client:run().
+tools: [<<"echo">>]
+echo: hello, mcp
+<<"hello, mcp">>
+```
+
+## Run the test
+
+```
+cd examples/echo_client
+rebar3 ct
+```
+
+## What to read
+
+- `src/echo_client.erl` — the entire flow in ~50 lines.
+- `test/echo_client_SUITE.erl` — common_test wrapper.

--- a/examples/echo_client/rebar.config
+++ b/examples/echo_client/rebar.config
@@ -1,0 +1,19 @@
+%% Standalone build configuration for the echo_client example.
+%%
+%% Inside this repository, the build picks up `barrel_mcp` via
+%% `_checkouts/barrel_mcp', which is a symlink back to the parent
+%% directory created by `make examples-setup' (or by hand:
+%% `mkdir -p _checkouts && ln -s ../../.. _checkouts/barrel_mcp').
+%%
+%% Outside the repository, replace the dep below with a hex coordinate
+%% such as `{barrel_mcp, "1.x"}'.
+
+{erl_opts, [debug_info, warnings_as_errors]}.
+
+{deps, [
+    {barrel_mcp, {git, "https://github.com/barrel-platform/barrel_mcp.git", {branch, "main"}}}
+]}.
+
+{shell, [{apps, [barrel_mcp, echo_client]}]}.
+
+{eunit_opts, [verbose]}.

--- a/examples/echo_client/src/echo_client.app.src
+++ b/examples/echo_client/src/echo_client.app.src
@@ -1,0 +1,9 @@
+{application, echo_client, [
+    {description, "barrel_mcp echo client example"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {applications, [kernel, stdlib, barrel_mcp]},
+    {env, []},
+    {modules, []},
+    {licenses, ["Apache-2.0"]}
+]}.

--- a/examples/echo_client/src/echo_client.erl
+++ b/examples/echo_client/src/echo_client.erl
@@ -1,0 +1,78 @@
+%%%-------------------------------------------------------------------
+%%% @doc Minimal MCP host using `barrel_mcp_client'.
+%%%
+%%% Boots a `barrel_mcp' Streamable HTTP server in-process, registers
+%%% an `echo' tool, connects a client, calls the tool, and prints the
+%%% result. Run with `rebar3 shell -eval 'echo_client:run().'' or
+%%% drive it from a common_test suite (see `test/echo_client_SUITE').
+%%% @end
+%%%-------------------------------------------------------------------
+-module(echo_client).
+
+-export([run/0, run/1, echo/1]).
+
+-define(DEFAULT_PORT, 18080).
+
+%% @doc Run the example end-to-end. Returns the echoed text.
+-spec run() -> binary().
+run() ->
+    run(?DEFAULT_PORT).
+
+-spec run(pos_integer()) -> binary().
+run(Port) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    ok = barrel_mcp_registry:wait_for_ready(),
+    ok = ensure_echo_tool(),
+    {ok, _} = ensure_server(Port),
+    Url = iolist_to_binary(io_lib:format("http://127.0.0.1:~B/mcp", [Port])),
+    {ok, Client} = barrel_mcp_client:start(#{
+        transport => {http, Url},
+        handler => {barrel_mcp_client_handler_default, []}
+    }),
+    ok = wait_ready(Client, 30),
+    {ok, Tools} = barrel_mcp_client:list_tools_all(Client),
+    io:format("tools: ~p~n", [[maps:get(<<"name">>, T) || T <- Tools]]),
+    {ok, Result} = barrel_mcp_client:call_tool(
+        Client, <<"echo">>, #{<<"text">> => <<"hello, mcp">>}),
+    [#{<<"type">> := <<"text">>, <<"text">> := Echoed}] =
+        maps:get(<<"content">>, Result),
+    io:format("echo: ~s~n", [Echoed]),
+    barrel_mcp_client:close(Client),
+    Echoed.
+
+%% @doc Tool handler. Returns the supplied text unchanged.
+-spec echo(map()) -> binary().
+echo(#{<<"text">> := Text}) ->
+    Text.
+
+%%====================================================================
+%% Internal
+%%====================================================================
+
+ensure_echo_tool() ->
+    barrel_mcp_registry:reg(tool, <<"echo">>, ?MODULE, echo, #{
+        description => <<"Echoes the given text back as-is.">>,
+        input_schema => #{
+            <<"type">> => <<"object">>,
+            <<"required">> => [<<"text">>],
+            <<"properties">> => #{
+                <<"text">> => #{<<"type">> => <<"string">>}
+            }
+        }
+    }).
+
+ensure_server(Port) ->
+    case barrel_mcp_http_stream:start(#{port => Port,
+                                        session_enabled => true}) of
+        {ok, _} = Ok -> Ok;
+        {error, {already_started, Pid}} -> {ok, Pid}
+    end.
+
+wait_ready(_Pid, 0) -> {error, not_ready};
+wait_ready(Pid, N) ->
+    case catch barrel_mcp_client:server_capabilities(Pid) of
+        {ok, _} -> ok;
+        _ ->
+            timer:sleep(100),
+            wait_ready(Pid, N - 1)
+    end.

--- a/examples/echo_client/test/echo_client_SUITE.erl
+++ b/examples/echo_client/test/echo_client_SUITE.erl
@@ -1,0 +1,29 @@
+%%%-------------------------------------------------------------------
+%%% @doc Common-test suite for the echo_client example.
+%%%
+%%% Runs `echo_client:run/1' on a non-default port and asserts the
+%%% returned binary matches the input.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(echo_client_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([round_trip/1]).
+
+all() -> [round_trip].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    Config.
+
+end_per_suite(_Config) ->
+    catch barrel_mcp_http_stream:stop(),
+    application:stop(barrel_mcp),
+    ok.
+
+round_trip(_Config) ->
+    Echoed = echo_client:run(28080),
+    <<"hello, mcp">> = Echoed,
+    ok.

--- a/examples/sampling_host/README.md
+++ b/examples/sampling_host/README.md
@@ -1,0 +1,40 @@
+# sampling_host
+
+End-to-end example of the server-to-client sampling round-trip. The
+host:
+
+- declares `sampling` capability when it connects;
+- implements `barrel_mcp_client_handler` to answer
+  `sampling/createMessage` with a canned reply;
+- calls a server-side tool that asks the connected client to sample a
+  message and wraps the reply.
+
+## Run it
+
+```
+cd examples/sampling_host
+rebar3 shell
+1> sampling_host:run().
+<<"got: a canned reply">>
+```
+
+## Run the test
+
+```
+cd examples/sampling_host
+rebar3 ct
+```
+
+## What to read
+
+- `src/sampling_host.erl` — the full flow. The
+  `barrel_mcp_client_handler` callbacks are at the bottom of the
+  module; the server-side tool is `ask_sampler/1`.
+- `test/sampling_host_SUITE.erl` — common_test wrapper.
+
+## Why this matters
+
+A real LLM agent host implements `handle_request/3` to call the LLM
+provider's API. The pattern shown here is the same shape — replace
+`{reply, Result, State}` with an HTTP call to Anthropic, OpenAI, a
+local Hermes model, or anything else.

--- a/examples/sampling_host/rebar.config
+++ b/examples/sampling_host/rebar.config
@@ -1,0 +1,16 @@
+%% Standalone build configuration for the sampling_host example.
+%%
+%% Inside this repository, the build picks up `barrel_mcp' via
+%% `_checkouts/barrel_mcp', which is a symlink back to the parent
+%% directory created by `make examples-setup' (or by hand:
+%% `mkdir -p _checkouts && ln -s ../../.. _checkouts/barrel_mcp').
+
+{erl_opts, [debug_info, warnings_as_errors]}.
+
+{deps, [
+    {barrel_mcp, {git, "https://github.com/barrel-platform/barrel_mcp.git", {branch, "main"}}}
+]}.
+
+{shell, [{apps, [barrel_mcp, sampling_host]}]}.
+
+{eunit_opts, [verbose]}.

--- a/examples/sampling_host/src/sampling_host.app.src
+++ b/examples/sampling_host/src/sampling_host.app.src
@@ -1,0 +1,9 @@
+{application, sampling_host, [
+    {description, "barrel_mcp sampling host example"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {applications, [kernel, stdlib, barrel_mcp]},
+    {env, []},
+    {modules, []},
+    {licenses, ["Apache-2.0"]}
+]}.

--- a/examples/sampling_host/src/sampling_host.erl
+++ b/examples/sampling_host/src/sampling_host.erl
@@ -1,0 +1,148 @@
+%%%-------------------------------------------------------------------
+%%% @doc Example host that implements `barrel_mcp_client_handler' and
+%%% answers `sampling/createMessage' with a canned reply.
+%%%
+%%% Demonstrates the full server-to-client round-trip: the host calls
+%%% a tool on a remote MCP server; the server-side tool handler asks
+%%% the connected client to sample an LLM message; the client's
+%%% handler returns a canned response; the server-side tool handler
+%%% returns that response as its tool result.
+%%%
+%%% Run with `rebar3 shell -eval 'sampling_host:run().'' or via the
+%%% common_test suite under `test/sampling_host_SUITE'.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(sampling_host).
+
+-behaviour(barrel_mcp_client_handler).
+
+-export([run/0, run/1]).
+
+%% Tool handler exported for the registry.
+-export([ask_sampler/1]).
+
+%% Handler behaviour callbacks.
+-export([init/1, handle_request/3, handle_notification/3, terminate/2]).
+
+-define(DEFAULT_PORT, 18081).
+
+%% @doc End-to-end run of the example. Returns the binary the
+%% handler produced, which the server-side tool wrapped in
+%% `"got: <reply>"'.
+-spec run() -> binary().
+run() ->
+    run(?DEFAULT_PORT).
+
+-spec run(pos_integer()) -> binary().
+run(Port) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    ok = barrel_mcp_registry:wait_for_ready(),
+    ok = ensure_tool(),
+    {ok, _} = ensure_server(Port),
+    Url = iolist_to_binary(io_lib:format("http://127.0.0.1:~B/mcp", [Port])),
+    {ok, Client} = barrel_mcp_client:start(#{
+        transport => {http, Url},
+        capabilities => #{sampling => true},
+        handler => {?MODULE, #{reply => <<"a canned reply">>}}
+    }),
+    ok = wait_ready(Client, 30),
+    ok = wait_sampling_session(50),
+    {ok, Result} = barrel_mcp_client:call_tool(
+        Client, <<"ask_sampler">>, #{<<"prompt">> => <<"hi">>},
+        #{timeout => 10000}),
+    [#{<<"type">> := <<"text">>, <<"text">> := Text}] =
+        maps:get(<<"content">>, Result),
+    barrel_mcp_client:close(Client),
+    Text.
+
+%%====================================================================
+%% Server-side tool: ask the connected sampling-capable client.
+%%====================================================================
+
+%% @doc Tool handler. Looks up the only sampling-capable session and
+%% asks it to produce a message. In a real host you would route by
+%% the calling session id; we keep the example single-client.
+-spec ask_sampler(map()) -> binary().
+ask_sampler(#{<<"prompt">> := Prompt}) ->
+    [SessionId | _] = barrel_mcp:list_sessions_with_sampling(),
+    Params = #{
+        <<"messages">> => [
+            #{<<"role">> => <<"user">>,
+              <<"content">> => #{<<"type">> => <<"text">>,
+                                 <<"text">> => Prompt}}
+        ],
+        <<"maxTokens">> => 64
+    },
+    {ok, Result, _Usage} =
+        barrel_mcp:sampling_create_message(SessionId, Params,
+                                           #{timeout_ms => 5000}),
+    Reply = maps:get(<<"text">>, maps:get(<<"content">>, Result)),
+    iolist_to_binary([<<"got: ">>, Reply]).
+
+%%====================================================================
+%% Client-side handler: answer the server's sampling request.
+%%====================================================================
+
+init(#{reply := _} = State) ->
+    {ok, State}.
+
+handle_request(<<"sampling/createMessage">>, _Params, #{reply := R} = S) ->
+    Result = #{
+        <<"content">> => #{<<"type">> => <<"text">>, <<"text">> => R},
+        <<"model">> => <<"example-canned-model">>,
+        <<"role">> => <<"assistant">>,
+        <<"usage">> => #{<<"input_tokens">> => 1, <<"output_tokens">> => 1}
+    },
+    {reply, Result, S};
+handle_request(Method, _Params, S) ->
+    {error, -32601, <<"Method not found: ", Method/binary>>, S}.
+
+handle_notification(_Method, _Params, S) ->
+    {ok, S}.
+
+terminate(_Reason, _S) ->
+    ok.
+
+%%====================================================================
+%% Internal
+%%====================================================================
+
+ensure_tool() ->
+    barrel_mcp_registry:reg(tool, <<"ask_sampler">>, ?MODULE, ask_sampler, #{
+        description => <<"Asks the connected client to sample a message.">>,
+        input_schema => #{
+            <<"type">> => <<"object">>,
+            <<"required">> => [<<"prompt">>],
+            <<"properties">> => #{
+                <<"prompt">> => #{<<"type">> => <<"string">>}
+            }
+        }
+    }).
+
+ensure_server(Port) ->
+    case barrel_mcp_http_stream:start(#{port => Port,
+                                        session_enabled => true}) of
+        {ok, _} = Ok -> Ok;
+        {error, {already_started, Pid}} -> {ok, Pid}
+    end.
+
+wait_ready(_Pid, 0) -> {error, not_ready};
+wait_ready(Pid, N) ->
+    case catch barrel_mcp_client:server_capabilities(Pid) of
+        {ok, _} -> ok;
+        _ ->
+            timer:sleep(100),
+            wait_ready(Pid, N - 1)
+    end.
+
+%% Wait until the SSE GET has been received by the server and the
+%% session is registered as sampling-capable. The client sends GET
+%% asynchronously after init, so a brief wait avoids a race.
+wait_sampling_session(0) -> {error, no_sampling_session};
+wait_sampling_session(N) ->
+    case barrel_mcp:list_sessions_with_sampling() of
+        [_|_] -> ok;
+        [] ->
+            timer:sleep(50),
+            wait_sampling_session(N - 1)
+    end.

--- a/examples/sampling_host/test/sampling_host_SUITE.erl
+++ b/examples/sampling_host/test/sampling_host_SUITE.erl
@@ -1,0 +1,30 @@
+%%%-------------------------------------------------------------------
+%%% @doc Common-test suite for the sampling_host example.
+%%%
+%%% Asserts the full server-to-client sampling round-trip works:
+%%% the client's handler answers `sampling/createMessage' and the
+%%% server-side tool wraps the reply in its own response.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(sampling_host_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([sampling_round_trip/1]).
+
+all() -> [sampling_round_trip].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    Config.
+
+end_per_suite(_Config) ->
+    catch barrel_mcp_http_stream:stop(),
+    application:stop(barrel_mcp),
+    ok.
+
+sampling_round_trip(_Config) ->
+    Text = sampling_host:run(28081),
+    <<"got: a canned reply">> = Text,
+    ok.

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -1,0 +1,520 @@
+# Building an MCP Client with `barrel_mcp`
+
+`barrel_mcp` is a pure MCP library. It implements the wire protocol,
+the transports, and the client state machine. It does **not** call
+LLM providers, build prompts, or run an agent loop — those belong to
+the host application that uses this library.
+
+This guide is task-oriented. Each section answers "I want to do X"
+with a working snippet, notes, and a pointer to the spec or wire
+detail. Snippets tagged `` ```erlang `` are extracted from this file
+and compile-checked in CI; snippets tagged `` ```erl `` are
+illustrative output only.
+
+If you have not yet read [the architecture](internals.md), the short
+summary is: a `barrel_mcp_client` is a `gen_statem` that owns one
+connection to one MCP server. It dispatches inbound responses to
+waiting callers, server-initiated requests to a host-supplied handler
+module, and notifications to either subscribers or the same handler.
+
+---
+
+## 1. What `barrel_mcp` gives you, and what it doesn't
+
+It gives you:
+
+- Streamable HTTP and stdio transports.
+- A spec-conformant MCP client (`barrel_mcp_client`).
+- Server-to-client request dispatch via the
+  [`barrel_mcp_client_handler`](#10-handle-server-initiated-requests)
+  behaviour.
+- OAuth 2.1 + PKCE primitives (RFC 9728, RFC 8414, RFC 8707) and a
+  refresh-only auth handle.
+- A federation registry (`barrel_mcp_clients`) for hosting many MCP
+  connections in one app.
+- A JSON Schema subset validator (`barrel_mcp_schema`).
+
+It does not give you:
+
+- LLM provider HTTP (Anthropic, OpenAI, Hermes, etc.). Implement that
+  in your host application.
+- An agent loop. Drive your own multi-turn loop using the building
+  blocks below.
+- Tool-name namespacing across servers. That's host policy.
+- A browser-based redirect listener for OAuth. Hosts run that step
+  with whatever UI fits their environment.
+
+---
+
+## 2. Choose a transport
+
+| Transport | Use it when | Where it lives |
+| --- | --- | --- |
+| Streamable HTTP | The server is remote or runs as a long-lived service. You want session resumption and server-initiated requests over SSE. | `barrel_mcp_client_http` |
+| stdio | The server is a local subprocess (CLI tools, native MCP servers shipped as binaries). | `barrel_mcp_client_stdio` |
+
+In both cases the high-level API on `barrel_mcp_client` is identical.
+The transport tuple in the connect spec is the only difference:
+
+```erl
+%% Streamable HTTP
+#{transport => {http, <<"https://server.example/mcp">>}}
+
+%% stdio
+#{transport => {stdio, #{command => "/usr/local/bin/mcp-server",
+                         args => ["--quiet"]}}}
+```
+
+---
+
+## 3. Connect spec reference
+
+`barrel_mcp_client:start_link/1` and `start/1` accept a single map.
+Every key is documented below.
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `transport` | `{http, Url}` \| `{stdio, #{command, args}}` | required | Which transport to open. |
+| `client_info` | `#{name, version}` | `#{name => <<"barrel_mcp_client">>, version => <<"2.0.0">>}` | Sent in `initialize`. |
+| `capabilities` | map | `#{}` | Client capabilities to declare. Booleans become spec-shape objects on the wire (e.g. `#{sampling => true}` becomes `#{<<"sampling">> => #{}}`). |
+| `handler` | `{Mod, Args}` | `{barrel_mcp_client_handler_default, []}` | Module implementing `barrel_mcp_client_handler` to handle server-initiated requests and notifications. |
+| `auth` | `none` \| `{bearer, Token}` \| `{oauth, Config}` | `none` | Authentication. See section 14. |
+| `protocol_version` | binary | `?MCP_CLIENT_PROTOCOL_VERSION` (`<<"2025-11-25">>`) | Target protocol version. The client negotiates downward if the server reports an older one. |
+| `request_timeout` | pos_integer | `30000` | Default per-request timeout in ms. |
+| `init_timeout` | pos_integer | `30000` | Time allowed for the `initialize` round-trip. |
+| `ping_interval` | pos_integer \| `infinity` | `infinity` | If set, the client sends `ping` every N ms while in `ready`. |
+| `ping_failure_threshold` | pos_integer | `3` | Consecutive ping failures before the connection is closed with reason `ping_failed`. |
+
+---
+
+## 4. Connect and close
+
+```erl
+{ok, Client} = barrel_mcp_client:start_link(#{
+    transport => {http, <<"http://127.0.0.1:9090/mcp">>}
+}),
+%% ... use Client ...
+ok = barrel_mcp_client:close(Client).
+```
+
+`start_link/1` links the calling process to the client. Use `start/1`
+for unsupervised one-offs (tests, scripts).
+
+The state machine moves `connecting → initializing → ready`. Calls
+made before `ready` return `{error, not_ready}`. Wait for the first
+`server_capabilities/1` to succeed if you need to gate work on
+readiness:
+
+```erlang
+wait_ready(Pid, 0) -> {error, not_ready};
+wait_ready(Pid, N) ->
+    case catch barrel_mcp_client:server_capabilities(Pid) of
+        {ok, _} -> ok;
+        _ ->
+            timer:sleep(100),
+            wait_ready(Pid, N - 1)
+    end.
+```
+
+---
+
+## 5. Capability negotiation and version downgrade
+
+The client declares what it can answer (sampling, roots, elicitation)
+and the server replies with what it can serve (tools, resources,
+prompts, logging, completions). After the handshake:
+
+```erlang
+get_caps(Pid) ->
+    {ok, ServerCaps} = barrel_mcp_client:server_capabilities(Pid),
+    case maps:is_key(<<"tools">>, ServerCaps) of
+        true -> ok;
+        false -> {error, no_tools}
+    end.
+```
+
+Version is negotiated automatically. The client sends
+`?MCP_CLIENT_PROTOCOL_VERSION` (`<<"2025-11-25">>` today); if the
+server replies with an older version (e.g. `2025-03-26`), the client
+adopts that and uses it on every subsequent `MCP-Protocol-Version`
+header. Read it back with `barrel_mcp_client:protocol_version/1`.
+
+---
+
+## 6. List tools, resources, and prompts
+
+Single-page calls return one chunk:
+
+```erlang
+list_one_page(Pid) ->
+    {ok, Tools} = barrel_mcp_client:list_tools(Pid),
+    Tools.
+```
+
+Pagination is opt-in. Pass `#{want_cursor => true}` to receive
+`{ok, Items, NextCursor | undefined}`. If the server has more pages
+than you want to walk by hand, use the `*_all` helpers:
+
+```erlang
+list_every_tool(Pid) ->
+    {ok, AllTools} = barrel_mcp_client:list_tools_all(Pid),
+    AllTools.
+```
+
+The same shape applies to `list_resources/1,2`,
+`list_resource_templates/1,2`, and `list_prompts/1,2`.
+
+---
+
+## 7. Call a tool
+
+```erlang
+call_echo(Pid) ->
+    barrel_mcp_client:call_tool(Pid, <<"echo">>, #{<<"text">> => <<"hi">>}).
+```
+
+`call_tool/4` accepts an option map:
+
+```erlang
+call_with_progress(Pid, Token) ->
+    barrel_mcp_client:call_tool(
+        Pid,
+        <<"slow">>,
+        #{<<"size">> => 1000},
+        #{progress_token => Token, timeout => 60000}).
+```
+
+When `progress_token` is supplied, the calling process receives one
+`{mcp_progress, Token, Params}` message per `notifications/progress`
+the server emits, until the request settles (response, cancel, or
+timeout).
+
+The full echo-client example lives in
+[`examples/echo_client/src/echo_client.erl`](https://github.com/barrel-platform/barrel_mcp/tree/main/examples/echo_client/src/echo_client.erl).
+
+---
+
+## 8. Read and subscribe to resources
+
+```erlang
+read_resource(Pid, Uri) ->
+    barrel_mcp_client:read_resource(Pid, Uri).
+```
+
+Subscribe to be notified of updates:
+
+```erlang
+watch_resource(Pid, Uri) ->
+    {ok, _} = barrel_mcp_client:subscribe(Pid, Uri),
+    receive
+        {mcp_resource_updated, Uri, Params} ->
+            handle_update(Params)
+    after 5000 ->
+        timeout
+    end.
+handle_update(_) -> ok.
+```
+
+The subscription stays in the client's state until you call
+`unsubscribe(Pid, Uri)` or close the client. Subscribers are
+identified by their pid; multiple processes can subscribe to the same
+URI on the same client.
+
+---
+
+## 9. Get prompts and run completion
+
+```erlang
+fetch_prompt(Pid) ->
+    barrel_mcp_client:get_prompt(Pid, <<"summarize">>,
+                                 #{<<"length">> => <<"short">>}).
+```
+
+```erlang
+ask_completion(Pid) ->
+    barrel_mcp_client:complete(Pid,
+        #{<<"type">> => <<"ref/prompt">>, <<"name">> => <<"summarize">>},
+        #{<<"name">> => <<"length">>, <<"value">> => <<"sho">>}).
+```
+
+`complete/3` is the spec-named `completion/complete` request used to
+auto-complete prompt argument values.
+
+---
+
+## 10. Handle server-initiated requests
+
+The server can call into the client (`sampling/createMessage`,
+`roots/list`, `elicitation/create`). Implement
+`barrel_mcp_client_handler` and supply it as `handler => {Mod, Args}`.
+
+Three return shapes from `handle_request/3`:
+
+- `{reply, Result, State}` — synchronous answer.
+- `{error, Code, Message, State}` — JSON-RPC error response.
+- `{async, Tag, State}` — defer; reply later from any process via
+  `barrel_mcp_client:reply_async(Pid, Tag, Result)`.
+
+Skeleton:
+
+```erlang
+-module(my_handler).
+-behaviour(barrel_mcp_client_handler).
+-export([init/1, handle_request/3, handle_notification/3, terminate/2]).
+
+init(Args) ->
+    {ok, Args}.
+
+handle_request(<<"sampling/createMessage">>, Params, State) ->
+    Result = sample_via_llm(Params, State),
+    {reply, Result, State};
+handle_request(<<"roots/list">>, _, State) ->
+    {reply, #{<<"roots">> => [
+        #{<<"uri">> => <<"file:///workspace">>,
+          <<"name">> => <<"workspace">>}
+    ]}, State};
+handle_request(Method, _Params, State) ->
+    {error, -32601, <<"Method not found: ", Method/binary>>, State}.
+
+handle_notification(_Method, _Params, State) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+sample_via_llm(_, _) ->
+    %% Replace with an HTTP call to your LLM provider.
+    #{<<"content">> => #{<<"type">> => <<"text">>, <<"text">> => <<"hi">>},
+      <<"model">> => <<"placeholder">>,
+      <<"role">> => <<"assistant">>}.
+```
+
+The `sampling_host` example in
+[`examples/sampling_host/src/sampling_host.erl`](https://github.com/barrel-platform/barrel_mcp/tree/main/examples/sampling_host/src/sampling_host.erl)
+shows the full server-to-client round-trip end to end.
+
+---
+
+## 11. Asynchronous handler replies
+
+When answering a server request takes time (calling an LLM provider,
+asking a user, etc.), block the model thread instead of the state
+machine:
+
+```erl
+handle_request(<<"sampling/createMessage">>, Params, State) ->
+    Tag = make_ref(),
+    Self = self(),  %% the host process; not the gen_statem
+    spawn(fun() ->
+        Result = slow_llm_call(Params),
+        barrel_mcp_client:reply_async(Self, Tag, Result)
+    end),
+    {async, Tag, State}.
+```
+
+`reply_async/3` may also be used for errors via
+`reply_async(Pid, Tag, {error, Code, Message})`.
+
+---
+
+## 12. Notifications
+
+The handler's `handle_notification/3` callback receives every inbound
+notification with its raw `params` map. Common methods:
+
+- `notifications/resources/updated` — also dispatched to subscribers
+  of the URI as `{mcp_resource_updated, Uri, Params}` (see section 8).
+- `notifications/progress` — also dispatched to the caller of the
+  request that owns the progress token (see section 7).
+- `notifications/tools/list_changed`, `.../resources/list_changed`,
+  `.../prompts/list_changed` — surface only via the handler.
+- `notifications/message` — server logging stream. Surface in the
+  handler.
+
+The handler is the right place to integrate with your application's
+metrics, logs, or UI.
+
+---
+
+## 13. Cancel, time out, ping
+
+```erlang
+cancel_request(Pid, Id) ->
+    barrel_mcp_client:cancel(Pid, Id).
+```
+
+The id is the JSON-RPC request id for the in-flight call.
+`barrel_mcp_client` increments these internally; in tests you can
+read pending ids via `sys:get_state/1`. In production you usually
+don't cancel by id — you set a `timeout` on `call_tool/4` and let
+the deadline fire.
+
+Periodic ping is opt-in:
+
+```erl
+%% Spec snippet — a key on barrel_mcp_client:start_link/1's input map.
+#{ping_interval => 30000, ping_failure_threshold => 3}
+```
+
+After three consecutive ping failures (default), the connection
+closes with reason `ping_failed` and the linked owner sees the exit.
+
+---
+
+## 14. Authenticate
+
+### Static bearer
+
+```erl
+#{transport => {http, <<"https://server.example/mcp">>},
+  auth => {bearer, <<"my-static-token">>}}
+```
+
+`barrel_mcp_client_auth_bearer` attaches `Authorization: Bearer ...`
+on every request. A 401 returns `{error, unauthorized}` and the
+caller must restart with a new token.
+
+### OAuth 2.1 + PKCE
+
+The interactive authorization-code redirect is a host concern; once
+you have an access token (and ideally a refresh token), pass them
+through:
+
+```erl
+#{transport => {http, <<"https://server.example/mcp">>},
+  auth => {oauth, #{
+    access_token   => <<"eyJ...">>,
+    refresh_token  => <<"opaque">>,
+    token_endpoint => <<"https://auth.example/token">>,
+    client_id      => <<"my-client">>,
+    resource       => <<"https://server.example/mcp">>
+  }}}
+```
+
+On 401 the library posts a `refresh_token` grant to `token_endpoint`
+(with the RFC 8707 `resource` parameter), updates the handle, and
+retries the original request once.
+
+To drive the *initial* auth code flow yourself, use the discovery
+helpers:
+
+```erlang
+discover(Server) ->
+    {ok, Resp401, Headers} = first_request_returns_401(Server),
+    Www = proplists:get_value(<<"www-authenticate">>, Headers),
+    PrmUrl = barrel_mcp_client_auth_oauth:parse_www_authenticate(Www),
+    {ok, Prm} = barrel_mcp_client_auth_oauth:discover_protected_resource(PrmUrl),
+    [Issuer | _] = maps:get(<<"authorization_servers">>, Prm),
+    {ok, AS} = barrel_mcp_client_auth_oauth:discover_authorization_server(Issuer),
+    {Url, Verifier, _State} = barrel_mcp_client_auth_oauth:build_authorization_url(
+        maps:get(<<"authorization_endpoint">>, AS),
+        #{client_id => <<"my-client">>,
+          redirect_uri => <<"http://localhost:38080/cb">>,
+          resource => maps:get(<<"resource">>, Prm)}),
+    {Url, Verifier, AS, Resp401}.
+first_request_returns_401(_) ->
+    {ok, ignore, [{<<"www-authenticate">>,
+                   <<"Bearer resource_metadata=\"https://srv/.well-known/oauth-protected-resource\"">>}]}.
+```
+
+After the user authorizes and you capture the `code` from the
+redirect, exchange it:
+
+```erl
+{ok, Tokens} = barrel_mcp_client_auth_oauth:exchange_code(
+    maps:get(<<"token_endpoint">>, AS),
+    #{code => Code,
+      code_verifier => Verifier,
+      client_id => <<"my-client">>,
+      redirect_uri => <<"http://localhost:38080/cb">>,
+      resource => maps:get(<<"resource">>, Prm)}).
+```
+
+Then start the client with the tokens above.
+
+---
+
+## 15. Schema-validate before calling
+
+`barrel_mcp_schema:validate/2` covers the JSON Schema subset MCP
+tools actually use. Cache the schema returned by `tools/list`, then
+validate before dispatching:
+
+```erlang
+call_validated(Pid, Name, Args, Schema) ->
+    case barrel_mcp_schema:validate(Args, Schema) of
+        ok -> barrel_mcp_client:call_tool(Pid, Name, Args);
+        {error, Errors} -> {error, {invalid_args, Errors}}
+    end.
+```
+
+This is opt-in — many hosts trust the LLM output enough to skip it.
+Use it when you want a clear error before the request reaches the
+server.
+
+---
+
+## 16. Federate many MCP servers
+
+```erl
+{ok, _} = barrel_mcp:start_client(<<"github">>, #{
+    transport => {http, <<"https://mcp.github.example/">>},
+    auth => {bearer, GhToken}
+}),
+{ok, _} = barrel_mcp:start_client(<<"local-files">>, #{
+    transport => {stdio, #{command => "/usr/local/bin/mcp-files"}}
+}),
+
+GitHub = barrel_mcp:whereis_client(<<"github">>),
+{ok, Tools} = barrel_mcp_client:list_tools(GitHub).
+```
+
+Each connection is a supervised worker. Crashes are isolated; the
+registry's monitor prunes the dead entry automatically. Tool-name
+namespacing across servers is your call; a common pattern is
+`<<ServerId/binary, "::", ToolName/binary>>` when surfacing the
+catalogue to an LLM.
+
+---
+
+## 17. Errors you can see
+
+| Return | Cause |
+| --- | --- |
+| `{error, not_ready}` | Call made before the `initialize` handshake completed. Wait for `ready`. |
+| `{error, {unsupported, Method}}` | Server didn't advertise the capability the call requires. |
+| `{error, {Code, Message}}` | Server returned a JSON-RPC error. |
+| `{error, cancelled}` | Caller invoked `cancel/2`. |
+| `{error, timeout}` | The per-request timeout fired. |
+| `{error, unauthorized}` | 401 with no usable refresh path. |
+| `{error, {protocol_version, Server, Supported}}` | Server's version is outside the client's supported list. Init failed. |
+
+---
+
+## 18. Production checklist
+
+- Run clients under a supervisor. `barrel_mcp:start_client/2` does
+  this for you; for ad-hoc clients call `barrel_mcp_client:start_link/1`
+  inside your own supervision tree.
+- Set `request_timeout` to a value that matches your SLO. The default
+  30 s is generous.
+- Set `ping_interval` if your transport is a long-lived HTTP
+  connection that may sit idle behind proxies.
+- Implement `handle_notification/3` to forward `notifications/message`
+  to your logging system; this is how MCP servers emit operational
+  signals.
+- Validate tool inputs with `barrel_mcp_schema:validate/2` before
+  forwarding model output.
+- For OAuth, persist refresh tokens; the in-memory handle dies with
+  the client.
+
+---
+
+## See also
+
+- [Internals](internals.md) — architecture and behaviour contracts.
+- [`examples/echo_client/`](https://github.com/barrel-platform/barrel_mcp/tree/main/examples/echo_client) — minimal
+  end-to-end host.
+- [`examples/sampling_host/`](https://github.com/barrel-platform/barrel_mcp/tree/main/examples/sampling_host) — handler
+  behaviour worked example.
+- [Features](features.md) — spec coverage matrix.

--- a/guides/client.md
+++ b/guides/client.md
@@ -1,4 +1,10 @@
-# MCP Client
+# MCP Client (reference)
+
+> **Looking for a walkthrough?** Read
+> [Building a client](building-a-client.md) for the task-oriented
+> guide; this file is the older API reference and stays for cross
+> linking. The new guide covers the gen_statem API, OAuth,
+> handlers, federation, and runnable examples.
 
 barrel_mcp includes a client library for connecting to external MCP servers.
 This allows your Erlang application to consume tools, resources, and prompts

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -113,4 +113,6 @@ For Claude Desktop integration, use the stdio transport:
 
 - [Tools, Resources & Prompts](tools-resources-prompts.md) - Learn about MCP primitives
 - [Authentication](authentication.md) - Secure your MCP server
-- [MCP Client](client.md) - Connect to external MCP servers
+- [Building a client](building-a-client.md) - Task-oriented walkthrough for hosting MCP clients (recommended)
+- [Client internals](internals.md) - Architecture and behaviour contracts
+- [MCP Client (reference)](client.md) - Older API reference, kept for cross-linking

--- a/guides/internals.md
+++ b/guides/internals.md
@@ -1,0 +1,279 @@
+# Internals
+
+How `barrel_mcp` is wired on the client side. Read this if you are
+extending the library, debugging a stuck connection, or generating
+code that introspects the architecture.
+
+This file is paired with [Building a client](building-a-client.md);
+the building guide is task-oriented, this one is structural.
+
+## 1. Module map
+
+| Module | Role |
+| --- | --- |
+| `barrel_mcp` | Top-level façade. `start_client/2`, `notify_resource_updated/1,2`, `sampling_create_message/3`, etc. |
+| `barrel_mcp_client` | The client `gen_statem`. Owns one connection. |
+| `barrel_mcp_client_sup` | Supervises client workers (transient). |
+| `barrel_mcp_clients` | Federation registry: `ServerId → pid()`. |
+| `barrel_mcp_client_transport` | Behaviour: `connect/2`, `send/2`, `close/1`. |
+| `barrel_mcp_client_stdio` | Transport impl over `open_port/2`. |
+| `barrel_mcp_client_http` | Transport impl over Streamable HTTP (POST + SSE GET). |
+| `barrel_mcp_client_handler` | Behaviour for server-initiated requests and notifications. |
+| `barrel_mcp_client_handler_default` | No-op default handler. |
+| `barrel_mcp_client_auth` | Behaviour: `init/1`, `header/1`, `refresh/2`. |
+| `barrel_mcp_client_auth_bearer` | Static-token impl. |
+| `barrel_mcp_client_auth_oauth` | OAuth 2.1 + PKCE impl + discovery helpers. |
+| `barrel_mcp_protocol` | JSON-RPC envelope codec; shared with the server. |
+| `barrel_mcp_pagination` | Cursor walker for `*/list` requests. |
+| `barrel_mcp_schema` | JSON Schema subset validator. |
+
+## 2. Supervision tree
+
+```
+barrel_mcp_sup (one_for_one)
+├── barrel_mcp_registry      -- server-side registry of tools/resources/prompts
+├── barrel_mcp_session       -- server-side session manager
+├── barrel_mcp_client_sup    -- one_for_one of barrel_mcp_client workers
+│   ├── client(<<"server-1">>)
+│   └── client(<<"server-2">>)
+└── barrel_mcp_clients       -- registry: ServerId -> pid + monitor
+```
+
+`barrel_mcp_clients` is a `gen_server` that owns the lookup table
+and serializes registration so two callers can't race on the same
+`ServerId`. Lookups (`whereis_client/1`, `list_clients/0`) hit the
+ETS table directly without crossing the process boundary.
+
+## 3. Client state machine
+
+`barrel_mcp_client` is a `gen_statem` in `state_functions` mode.
+
+```
+                         start_link/1
+                              │
+                              ▼
+                       ┌────────────┐
+                       │ connecting │  open transport, send `initialize'
+                       └─────┬──────┘
+                             │ transport up
+                             ▼
+                       ┌──────────────┐
+                       │ initializing │  state-timeout = init_timeout
+                       └─────┬────────┘
+                             │ initialize response (negotiated version)
+                             │ + notifications/initialized
+                             │ + open SSE GET (HTTP only)
+                             ▼
+                       ┌────────┐
+                       │ ready  │◀──── all client API calls go here
+                       └─┬──┬───┘
+                         │  │
+              close/1 ───┘  └─── transport_closed | ping_failed
+                              ▼
+                       ┌─────────┐
+                       │ closing │
+                       └─────────┘
+```
+
+State transitions:
+
+- `connecting → initializing` — internal event after `open_transport/1`.
+- `initializing → ready` — successful `initialize` response, version in
+  `?MCP_CLIENT_SUPPORTED_VERSIONS`.
+- `initializing → stop {init_failed, _}` — server returned a JSON-RPC
+  error to `initialize` or omitted `protocolVersion`.
+- `ready → closing` — caller cast `close`, or stop on `mcp_closed`,
+  or stop with `ping_failed`.
+
+## 4. Inbound message flow
+
+```
+transport process (stdio port owner | http gen_server)
+        │
+        │  {mcp_in, TransportPid, Json}
+        ▼
+barrel_mcp_client gen_statem (info handler)
+        │
+        ├── decode_envelope/1 -> request | response | notification | error
+        │
+        ├── response/error  -> ETS pending lookup -> gen_statem:reply(Caller, _)
+        ├── request         -> handler:handle_request/3 -> send response
+        └── notification    -> handler:handle_notification/3
+                               (+ subscriber routing for resources/updated)
+                               (+ progress routing for notifications/progress)
+```
+
+The transport process owns the wire — socket, port, SSE buffer — and
+forwards one JSON-RPC envelope per `{mcp_in, _, _}` message. The
+gen_statem never reads the wire directly. This means transports can
+implement framing however suits them (line-delimited for stdio,
+SSE-event-delimited for HTTP) without leaking that into the state
+machine.
+
+When the transport ends, it sends `{mcp_closed, TransportPid, Reason}`
+and the gen_statem stops with that reason.
+
+## 5. Outbound flow
+
+```
+caller                              barrel_mcp_client gen_statem
+   │                                          │
+   │ gen_statem:call({request, M, P, T})      │
+   ├─────────────────────────────────────────►│
+   │                                          ├─ next_id/1
+   │                                          ├─ pending#{Id => #pending{...}}
+   │                                          ├─ encode_request/3
+   │                                          └─ transport:send/2
+   │                                          ▼
+   │                                   transport process
+   │                                          │
+   │                                          ▼
+   │                                   ... server ...
+   │                                          │
+   │                                          ▼
+   │                                   {mcp_in, _, ResponseJson}
+   │                                          │
+   │                                  match by id, gen_statem:reply
+   │◀─────────────────────────────────────────│
+```
+
+`pending` is a map keyed by request id. Each entry tracks the caller
+`{From}`, the method name, the deadline, and the optional progress
+token. The state machine drops the entry on settle and clears any
+matching state-timeout.
+
+## 6. Behaviour contracts
+
+### `barrel_mcp_client_transport`
+
+```
+-callback connect(Owner :: pid(), Opts :: map()) ->
+    {ok, pid()} | {error, term()}.
+-callback send(TransportPid :: pid(), JsonBinary :: iodata()) ->
+    ok | {error, term()}.
+-callback close(TransportPid :: pid()) -> ok.
+```
+
+The transport process MUST emit `{mcp_in, TransportPid, JsonBinary}`
+to `Owner` for every complete inbound JSON-RPC envelope. On
+shutdown — peer disconnect, port exit, fatal error — it MUST emit
+`{mcp_closed, TransportPid, Reason}` exactly once.
+
+### `barrel_mcp_client_handler`
+
+```
+-callback init(Args :: term()) -> {ok, state()} | {error, term()}.
+-callback handle_request(Method :: binary(),
+                         Params :: map(),
+                         State :: state()) ->
+    {reply, Result :: term(), state()} |
+    {error, Code :: integer(), Message :: binary(), state()} |
+    {async, Tag :: term(), state()}.
+-callback handle_notification(Method :: binary(),
+                              Params :: map(),
+                              State :: state()) -> {ok, state()}.
+-callback terminate(Reason :: term(), State :: state()) -> any().
+```
+
+The default handler (`barrel_mcp_client_handler_default`) returns
+`method_not_found` for every request and ignores every notification.
+Hosts only implement what they declare in their `capabilities`.
+
+The `{async, Tag, State}` reply form lets a handler defer the
+response while the state machine continues to process other inbound
+traffic. The host posts the actual reply via
+`barrel_mcp_client:reply_async/3`.
+
+### `barrel_mcp_client_auth`
+
+```
+-callback init(Config :: term()) -> {ok, handle()} | {error, term()}.
+-callback header(handle()) -> {ok, binary()} | none | {error, term()}.
+-callback refresh(handle(), WwwAuthenticate :: binary() | undefined) ->
+    {ok, handle()} | {error, term()}.
+```
+
+The HTTP transport calls `header/1` on every outgoing request. On a
+401 it calls `refresh/2` once with the `WWW-Authenticate` header
+value, then retries the original request with the new handle. The
+caller-facing constructor is `barrel_mcp_client_auth:new/1` which
+wraps the chosen impl as `{Module, State}` (or `none` for no auth).
+
+## 7. State record fields
+
+| Field | Type | Holds |
+| --- | --- | --- |
+| `spec` | map | The connect spec passed to `start_link/1`. |
+| `transport` | `{Mod, Pid}` | Active transport. |
+| `request_id` | int | Monotonic counter for outbound JSON-RPC ids. |
+| `pending` | map | `Id ⇒ #pending{caller, method, deadline, progress_token}`. |
+| `handler_mod` | atom | The host's handler module. |
+| `handler_state` | term | The handler's per-instance state. |
+| `async_replies` | map | `Tag ⇒ Id` for `{async, Tag, _}` requests. |
+| `subscriptions` | map | `Uri ⇒ [pid()]` for `notifications/resources/updated`. |
+| `progress` | map | `Token ⇒ pid()` for `notifications/progress`. |
+| `ping_failures` | int | Consecutive ping errors; resets on success. |
+| `server_capabilities` | map | What the server advertised at init. |
+| `server_info` | map | `name`, `version` from the server. |
+| `protocol_version` | binary | Negotiated version, after init. |
+
+## 8. Wire format reference
+
+### Streamable HTTP
+
+Headers attached on every outgoing request:
+
+| Header | When | Notes |
+| --- | --- | --- |
+| `content-type: application/json` | always | request body is a JSON-RPC envelope (or empty for GET). |
+| `accept: application/json, text/event-stream` | always | the server may answer with either. |
+| `mcp-session-id: <id>` | after the initialize POST returns one | echoed on every subsequent POST/GET/DELETE. |
+| `mcp-protocol-version: <version>` | after init completes | the negotiated version. |
+| `authorization: Bearer ...` | when an auth handle attaches one | bearer or OAuth-fronted. |
+| `last-event-id: <id>` | reconnecting the GET SSE | not yet a full replay path; tracked but not yet replayed. |
+
+The POST endpoint may answer with a JSON envelope or with an SSE
+stream. The transport classifies on `content-type` and either
+forwards the single envelope or parses SSE events until the matching
+`done`. SSE event format:
+
+```
+id: <id>
+event: <name>
+data: <JSON-RPC envelope>
+\n
+```
+
+The transport ignores `event:`, captures `id:` for resumability, and
+forwards each `data:` payload as one `mcp_in` message.
+
+The GET endpoint opens a long-lived SSE for unsolicited
+server-to-client traffic. A 405 here means the server doesn't support
+unsolicited streams; the client silently drops the GET and only
+receives server-initiated requests interleaved on POST responses.
+
+DELETE on close, with `Mcp-Session-Id`.
+
+### stdio
+
+Line-delimited JSON-RPC. One envelope per line. The transport reads
+up to a 1 MiB line limit (configurable in
+`barrel_mcp_client_stdio`). Anything larger fails framing with
+`{mcp_closed, _, line_too_long}`.
+
+stdin and stdout are the only channels. stderr from the subprocess is
+discarded by default; redirect it in your launcher if you need it.
+
+## 9. Where to look in the source
+
+| Want to read | File |
+| --- | --- |
+| State machine + public API | `src/barrel_mcp_client.erl` |
+| Streamable HTTP transport | `src/barrel_mcp_client_http.erl` |
+| stdio transport | `src/barrel_mcp_client_stdio.erl` |
+| Handler behaviour + default | `src/barrel_mcp_client_handler.erl`, `src/barrel_mcp_client_handler_default.erl` |
+| OAuth flow | `src/barrel_mcp_client_auth_oauth.erl` |
+| Federation | `src/barrel_mcp_clients.erl`, `src/barrel_mcp_client_sup.erl` |
+| Pagination walker | `src/barrel_mcp_pagination.erl` |
+| Schema validator | `src/barrel_mcp_schema.erl` |
+| Wire envelope codec | `src/barrel_mcp_protocol.erl` |

--- a/rebar.config
+++ b/rebar.config
@@ -32,12 +32,15 @@
     {extras, [
         {"README.md", #{title => "Overview"}},
         {"guides/getting-started.md", #{title => "Getting Started"}},
+        {"guides/building-a-client.md", #{title => "Building a Client"}},
+        {"guides/internals.md", #{title => "Client Internals"}},
+        {"guides/features.md", #{title => "Features"}},
         {"guides/http-stream.md", #{title => "Streamable HTTP Transport"}},
         {"guides/stdio.md", #{title => "stdio Transport"}},
         {"guides/authentication.md", #{title => "Authentication"}},
         {"guides/custom-authentication.md", #{title => "Custom Authentication"}},
         {"guides/tools-resources-prompts.md", #{title => "Tools, Resources & Prompts"}},
-        {"guides/client.md", #{title => "MCP Client"}},
+        {"guides/client.md", #{title => "MCP Client (reference)"}},
         {"LICENSE", #{title => "License"}}
     ]},
     {main, "README.md"},
@@ -46,12 +49,19 @@
     {api_reference, true},
     {groups_for_modules, [
         {"Main API", [barrel_mcp]},
-        {"Authentication", [barrel_mcp_auth, barrel_mcp_auth_none,
-                           barrel_mcp_auth_bearer, barrel_mcp_auth_apikey,
-                           barrel_mcp_auth_basic, barrel_mcp_auth_custom]},
+        {"Server Authentication", [barrel_mcp_auth, barrel_mcp_auth_none,
+                                   barrel_mcp_auth_bearer, barrel_mcp_auth_apikey,
+                                   barrel_mcp_auth_basic, barrel_mcp_auth_custom]},
         {"Server", [barrel_mcp_http, barrel_mcp_http_stream, barrel_mcp_stdio, barrel_mcp_protocol]},
         {"Session", [barrel_mcp_session]},
-        {"Client", [barrel_mcp_client]},
+        {"Client", [barrel_mcp_client, barrel_mcp_clients,
+                    barrel_mcp_client_handler, barrel_mcp_client_handler_default,
+                    barrel_mcp_client_transport,
+                    barrel_mcp_client_stdio, barrel_mcp_client_http]},
+        {"Client Authentication", [barrel_mcp_client_auth,
+                                   barrel_mcp_client_auth_bearer,
+                                   barrel_mcp_client_auth_oauth]},
+        {"Utilities", [barrel_mcp_pagination, barrel_mcp_schema]},
         {"Registry", [barrel_mcp_registry]}
     ]}
 ]}.

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -136,11 +136,23 @@ start(Spec) ->
 close(Pid) ->
     gen_statem:cast(Pid, close).
 
-%% @doc List tools on the server. Single page.
+%% @doc List tools advertised by the server. Returns a single page.
+%% Use {@link list_tools/2} with `#{want_cursor => true}' or
+%% {@link list_tools_all/1} to walk pagination.
 -spec list_tools(pid()) -> {ok, [map()]} | {error, term()}.
 list_tools(Pid) ->
     list_tools(Pid, #{}).
 
+%% @doc List tools with pagination control.
+%%
+%% `Opts' may contain:
+%% <ul>
+%%   <li>`{cursor, Cursor}' — start from a previously-returned
+%%       `nextCursor'.</li>
+%%   <li>`{want_cursor, true}' — return `{ok, Items, NextCursor}' even
+%%       on the last page (with `undefined' for `NextCursor').</li>
+%%   <li>`{timeout, Ms}' — override the per-request timeout.</li>
+%% </ul>
 -spec list_tools(pid(), map()) -> {ok, [map()], NextCursor :: binary() | undefined} |
                                   {ok, [map()]} | {error, term()}.
 list_tools(Pid, Opts) ->
@@ -151,41 +163,72 @@ list_tools(Pid, Opts) ->
 list_tools_all(Pid) ->
     walk_all(fun(Cursor) -> list_tools(Pid, page_opts(Cursor)) end).
 
-%% @doc Call a tool. Args are forwarded as `arguments'.
+%% @doc Invoke a tool by name. `Args' is forwarded verbatim as the
+%% JSON-RPC `arguments' field. Returns the server's `result' map,
+%% which has a `<<"content">>' list of content blocks.
 -spec call_tool(pid(), binary(), map()) -> {ok, map()} | {error, term()}.
 call_tool(Pid, Name, Args) ->
     call_tool(Pid, Name, Args, #{}).
 
+%% @doc Invoke a tool with options.
+%%
+%% `Opts' may contain:
+%% <ul>
+%%   <li>`{progress_token, Token}' — register the calling process to
+%%       receive `{mcp_progress, Token, Params}' messages until the
+%%       request settles.</li>
+%%   <li>`{timeout, Ms}' — override the per-request timeout
+%%       (`request_timeout' from the connect spec, default 30000).</li>
+%% </ul>
 -spec call_tool(pid(), binary(), map(), map()) -> {ok, map()} | {error, term()}.
 call_tool(Pid, Name, Args, Opts) ->
     Params0 = #{<<"name">> => Name, <<"arguments">> => Args},
     Params = maybe_attach_progress_token(Params0, Opts),
     request(Pid, <<"tools/call">>, Params, request_timeout(Opts)).
 
+%% @doc List resources advertised by the server. Single page.
 -spec list_resources(pid()) -> {ok, [map()]} | {error, term()}.
 list_resources(Pid) -> list_resources(Pid, #{}).
 
+%% @doc List resources with pagination control. Same `Opts' shape as
+%% {@link list_tools/2}.
+-spec list_resources(pid(), map()) -> {ok, [map()], binary() | undefined} |
+                                       {ok, [map()]} | {error, term()}.
 list_resources(Pid, Opts) ->
     paged(Pid, <<"resources/list">>, <<"resources">>, Opts).
 
-%% @doc Walk all `resources/list' pages.
+%% @doc Walk every `resources/list' page and return the union.
 -spec list_resources_all(pid()) -> {ok, [map()]} | {error, term()}.
 list_resources_all(Pid) ->
     walk_all(fun(Cursor) -> list_resources(Pid, page_opts(Cursor)) end).
 
+%% @doc List resource templates advertised by the server. Single
+%% page.
+-spec list_resource_templates(pid()) -> {ok, [map()]} | {error, term()}.
 list_resource_templates(Pid) -> list_resource_templates(Pid, #{}).
 
+%% @doc List resource templates with pagination control. Same `Opts'
+%% shape as {@link list_tools/2}.
+-spec list_resource_templates(pid(), map()) ->
+    {ok, [map()], binary() | undefined} | {ok, [map()]} | {error, term()}.
 list_resource_templates(Pid, Opts) ->
     paged(Pid, <<"resources/templates/list">>, <<"resourceTemplates">>, Opts).
 
-%% @doc Walk all `resources/templates/list' pages.
+%% @doc Walk every `resources/templates/list' page.
 -spec list_resource_templates_all(pid()) -> {ok, [map()]} | {error, term()}.
 list_resource_templates_all(Pid) ->
     walk_all(fun(Cursor) -> list_resource_templates(Pid, page_opts(Cursor)) end).
 
+%% @doc Read a resource by URI.
+-spec read_resource(pid(), binary()) -> {ok, map()} | {error, term()}.
 read_resource(Pid, Uri) ->
     request(Pid, <<"resources/read">>, #{<<"uri">> => Uri}).
 
+%% @doc Subscribe the calling process to updates for `Uri'. The
+%% calling process receives `{mcp_resource_updated, Uri, Params}' on
+%% every inbound `notifications/resources/updated' for that URI until
+%% it calls {@link unsubscribe/2} or the client closes.
+-spec subscribe(pid(), binary()) -> {ok, map()} | {error, term()}.
 subscribe(Pid, Uri) ->
     case request(Pid, <<"resources/subscribe">>, #{<<"uri">> => Uri}) of
         {ok, _} = Ok ->
@@ -194,6 +237,8 @@ subscribe(Pid, Uri) ->
         Err -> Err
     end.
 
+%% @doc Stop receiving updates for `Uri' on the calling process.
+-spec unsubscribe(pid(), binary()) -> {ok, map()} | {error, term()}.
 unsubscribe(Pid, Uri) ->
     case request(Pid, <<"resources/unsubscribe">>, #{<<"uri">> => Uri}) of
         {ok, _} = Ok ->
@@ -202,52 +247,84 @@ unsubscribe(Pid, Uri) ->
         Err -> Err
     end.
 
+%% @doc List prompts advertised by the server. Single page.
+-spec list_prompts(pid()) -> {ok, [map()]} | {error, term()}.
 list_prompts(Pid) -> list_prompts(Pid, #{}).
 
+%% @doc List prompts with pagination control. Same `Opts' shape as
+%% {@link list_tools/2}.
+-spec list_prompts(pid(), map()) -> {ok, [map()], binary() | undefined} |
+                                     {ok, [map()]} | {error, term()}.
 list_prompts(Pid, Opts) ->
     paged(Pid, <<"prompts/list">>, <<"prompts">>, Opts).
 
-%% @doc Walk all `prompts/list' pages.
+%% @doc Walk every `prompts/list' page.
 -spec list_prompts_all(pid()) -> {ok, [map()]} | {error, term()}.
 list_prompts_all(Pid) ->
     walk_all(fun(Cursor) -> list_prompts(Pid, page_opts(Cursor)) end).
 
+%% @doc Render a prompt with the given arguments.
+-spec get_prompt(pid(), binary(), map()) -> {ok, map()} | {error, term()}.
 get_prompt(Pid, Name, Args) ->
     request(Pid, <<"prompts/get">>, #{
         <<"name">> => Name,
         <<"arguments">> => Args
     }).
 
+%% @doc Send `completion/complete' to ask the server to suggest values
+%% for a prompt or resource template argument. `Ref' is the JSON-RPC
+%% `ref' map (e.g. `#{<<"type">> => <<"ref/prompt">>, <<"name">> => N}')
+%% and `Argument' is `#{<<"name">> => Key, <<"value">> => Partial}'.
+-spec complete(pid(), map(), map()) -> {ok, map()} | {error, term()}.
 complete(Pid, Ref, Argument) ->
     request(Pid, <<"completion/complete">>, #{
         <<"ref">> => Ref,
         <<"argument">> => Argument
     }).
 
+%% @doc Send `logging/setLevel'. `Level' is one of `debug', `info',
+%% `notice', `warning', `error', `critical', `alert', `emergency' as
+%% a binary.
+-spec set_log_level(pid(), binary()) -> {ok, map()} | {error, term()}.
 set_log_level(Pid, Level) when is_binary(Level) ->
     request(Pid, <<"logging/setLevel">>, #{<<"level">> => Level}).
 
+%% @doc Send a `ping' request and wait for the response.
+-spec ping(pid()) -> {ok, map()} | {error, term()}.
 ping(Pid) ->
     request(Pid, <<"ping">>, #{}).
 
 %% @doc Cancel a previously-issued request by id. Sends
-%% `notifications/cancelled' and removes the pending slot so the
-%% caller receives `{error, cancelled}'.
+%% `notifications/cancelled' to the server and unblocks the caller
+%% with `{error, cancelled}'.
+-spec cancel(pid(), integer()) -> ok.
 cancel(Pid, RequestId) ->
     gen_statem:cast(Pid, {cancel, RequestId}).
 
-%% @doc Deliver an asynchronous reply for a request that the handler
-%% returned `{async, Tag, _}' for. Result may be a plain term (sent as
-%% a JSON-RPC `result') or `{error, Code, Message}'.
+%% @doc Deliver a deferred reply for a server-initiated request that
+%% the handler answered with `{async, Tag, _}'. `Result' is either a
+%% plain term (sent as the JSON-RPC `result') or
+%% `{error, Code, Message}'.
+-spec reply_async(pid(), term(),
+                  term() | {error, integer(), binary()}) -> ok.
 reply_async(Pid, Tag, Result) ->
     gen_statem:cast(Pid, {async_reply, Tag, Result}).
 
+%% @doc Return the `serverInfo' map the server reported during
+%% `initialize' (with keys like `<<"name">>' and `<<"version">>').
+-spec server_info(pid()) -> {ok, map() | undefined}.
 server_info(Pid) ->
     gen_statem:call(Pid, server_info).
 
+%% @doc Return the server capabilities map negotiated during
+%% `initialize'. Useful to gate work on optional features.
+-spec server_capabilities(pid()) -> {ok, map() | undefined}.
 server_capabilities(Pid) ->
     gen_statem:call(Pid, server_capabilities).
 
+%% @doc Return the negotiated protocol version (e.g.
+%% `<<"2025-11-25">>' or `<<"2025-03-26">>' if the server downgraded).
+-spec protocol_version(pid()) -> {ok, binary() | undefined}.
 protocol_version(Pid) ->
     gen_statem:call(Pid, protocol_version).
 

--- a/src/barrel_mcp_client_auth.erl
+++ b/src/barrel_mcp_client_auth.erl
@@ -19,18 +19,18 @@
 -type handle() :: term().
 -type t() :: {module(), handle()} | none.
 
-%% @doc Build the auth handle from a config term.
+%% Build the auth handle from a config term.
 %%   `none' — no auth header sent.
 %%   `{bearer, Token}' — static bearer token.
-%%   `{oauth, Config}' — OAuth 2.1 + PKCE (Phase D).
+%%   `{oauth, Config}' — OAuth 2.1 + PKCE.
 -callback init(Config :: term()) -> {ok, handle()} | {error, term()}.
 
-%% @doc Return the value to put in the `Authorization' header.
+%% Return the value to put in the `Authorization' header.
 %% Returning `none' means do not attach an Authorization header.
 -callback header(handle()) ->
     {ok, binary()} | none | {error, term()}.
 
-%% @doc Refresh the credential after a 401. `WwwAuthenticate' is the
+%% Refresh the credential after a 401. `WwwAuthenticate' is the
 %% raw header value returned by the server, used by OAuth flows for
 %% protected-resource-metadata discovery.
 -callback refresh(handle(), WwwAuthenticate :: binary() | undefined) ->

--- a/src/barrel_mcp_client_handler.erl
+++ b/src/barrel_mcp_client_handler.erl
@@ -31,6 +31,37 @@
 %%% `barrel_mcp_client:reply_async(ClientPid, Tag, Result)' from any
 %%% process. The client's state machine will not block while the
 %%% handler is computing.
+%%%
+%%% == Example ==
+%%%
+%%% A handler that answers `sampling/createMessage' synchronously:
+%%%
+%%% ```
+%%% -module(my_sampler).
+%%% -behaviour(barrel_mcp_client_handler).
+%%% -export([init/1, handle_request/3, handle_notification/3,
+%%%          terminate/2]).
+%%%
+%%% init(Args) -> {ok, Args}.
+%%%
+%%% handle_request(<<"sampling/createMessage">>, Params, S) ->
+%%%     Reply = call_my_llm(Params),  %% your provider integration
+%%%     Result = #{<<"content">> => #{<<"type">> => <<"text">>,
+%%%                                    <<"text">> => Reply},
+%%%                <<"model">> => <<"my-model">>,
+%%%                <<"role">> => <<"assistant">>},
+%%%     {reply, Result, S};
+%%% handle_request(Method, _Params, S) ->
+%%%     {error, -32601, <<"Method not found: ", Method/binary>>, S}.
+%%%
+%%% handle_notification(_Method, _Params, S) -> {ok, S}.
+%%% terminate(_Reason, _State) -> ok.
+%%% '''
+%%%
+%%% Wire the handler in via the connect spec:
+%%% `#{handler => {my_sampler, []}}'.
+%%%
+%%% See `examples/sampling_host/' for a runnable end-to-end version.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_client_handler).

--- a/src/barrel_mcp_client_transport.erl
+++ b/src/barrel_mcp_client_transport.erl
@@ -24,18 +24,18 @@
 -type t() :: {module(), pid()}.
 -export_type([t/0]).
 
-%% @doc Open a transport. `Owner' will receive `mcp_in' / `mcp_closed'
+%% Open a transport. `Owner' will receive `mcp_in' / `mcp_closed'
 %% messages from the spawned transport process.
 -callback connect(Owner :: pid(), Opts :: map()) ->
     {ok, pid()} | {error, term()}.
 
-%% @doc Send a fully-encoded JSON-RPC envelope (binary JSON) to the
-%% peer. Implementations may add transport framing (newline, SSE) but
-%% must not modify the JSON content.
+%% Send a fully-encoded JSON-RPC envelope (binary JSON) to the peer.
+%% Implementations may add transport framing (newline, SSE) but must
+%% not modify the JSON content.
 -callback send(TransportPid :: pid(), JsonBinary :: iodata()) ->
     ok | {error, term()}.
 
-%% @doc Close the transport.
+%% Close the transport.
 -callback close(TransportPid :: pid()) -> ok.
 
 %%====================================================================

--- a/src/barrel_mcp_clients.erl
+++ b/src/barrel_mcp_clients.erl
@@ -33,21 +33,35 @@
 %% Public API
 %%====================================================================
 
+%% @doc Start the registry. Called by `barrel_mcp_sup'; you don't
+%% normally call this directly.
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-%% @doc Start a supervised client worker for `ServerId'. Fails if a
-%% worker is already registered for that id.
+%% @doc Start a supervised `barrel_mcp_client' worker registered as
+%% `ServerId'. Fails with `{already_registered, Pid}' if a worker
+%% already holds that id.
+%%
+%% Example:
+%% ```
+%% {ok, _} = barrel_mcp_clients:start_client(<<"github">>, #{
+%%     transport => {http, <<"https://mcp.github.example/">>},
+%%     auth => {bearer, GhToken}
+%% }).
+%% '''
 -spec start_client(term(), barrel_mcp_client:connect_spec()) ->
     {ok, pid()} | {error, term()}.
 start_client(ServerId, Spec) ->
     gen_server:call(?MODULE, {start_client, ServerId, Spec}).
 
-%% @doc Stop the client worker for `ServerId'.
+%% @doc Stop the client worker registered as `ServerId'. Returns
+%% `{error, not_found}' if no worker holds that id.
 -spec stop_client(term()) -> ok | {error, not_found}.
 stop_client(ServerId) ->
     gen_server:call(?MODULE, {stop_client, ServerId}).
 
+%% @doc Look up a worker pid by its `ServerId'. Returns `undefined' if
+%% none is registered. ETS-backed; safe to call from any process.
 -spec whereis_client(term()) -> pid() | undefined.
 whereis_client(ServerId) ->
     case ets:lookup(?TABLE, ServerId) of
@@ -55,6 +69,7 @@ whereis_client(ServerId) ->
         [] -> undefined
     end.
 
+%% @doc Snapshot the registry as `[{ServerId, Pid}]'. ETS-backed.
 -spec list_clients() -> [{term(), pid()}].
 list_clients() ->
     ets:foldl(fun({Id, Pid, _}, Acc) -> [{Id, Pid} | Acc] end, [], ?TABLE).

--- a/test/doc_snippets_SUITE.erl
+++ b/test/doc_snippets_SUITE.erl
@@ -1,0 +1,66 @@
+%%%-------------------------------------------------------------------
+%%% @doc Common-test suite that runs `test/snippet_check.escript' so
+%%% CI catches drift in `guides/building-a-client.md',
+%%% `guides/internals.md', and `examples/*/README.md'.
+%%%
+%%% Snippets in markdown tagged ` ```erlang ` are extracted and
+%%% compiled. Tag illustrative blocks with ` ```erl ` (or any other
+%%% info string) to skip them.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(doc_snippets_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-export([all/0]).
+-export([snippets_compile/1]).
+
+all() -> [snippets_compile].
+
+snippets_compile(_Config) ->
+    Script = filename:join([code:lib_dir(barrel_mcp), "..", "..", "..", "..",
+                            "test", "snippet_check.escript"]),
+    %% When the suite runs from a release-style location, fall back to
+    %% the canonical project path.
+    Resolved = case filelib:is_regular(Script) of
+                   true -> Script;
+                   false ->
+                       filename:join([project_root(),
+                                      "test", "snippet_check.escript"])
+               end,
+    Cmd = "escript " ++ Resolved,
+    {Status, Output} = run(Cmd),
+    ct:log("snippet_check output:~n~s", [Output]),
+    case Status of
+        0 -> ok;
+        N -> ct:fail({snippet_check_failed, N, Output})
+    end.
+
+run(Cmd) ->
+    Port = open_port({spawn, Cmd}, [exit_status, stderr_to_stdout, binary]),
+    collect(Port, <<>>).
+
+collect(Port, Acc) ->
+    receive
+        {Port, {data, D}} -> collect(Port, <<Acc/binary, D/binary>>);
+        {Port, {exit_status, S}} -> {S, binary_to_list(Acc)}
+    after 60000 ->
+        catch port_close(Port),
+        {1, "snippet_check: timed out"}
+    end.
+
+%% Walk up from this file's location to the project root (the
+%% directory containing `rebar.config').
+project_root() ->
+    walk_up(filename:dirname(code:which(?MODULE))).
+
+walk_up(Dir) ->
+    case filelib:is_regular(filename:join(Dir, "rebar.config")) of
+        true -> Dir;
+        false ->
+            Parent = filename:dirname(Dir),
+            case Parent of
+                Dir -> error(project_root_not_found);
+                _ -> walk_up(Parent)
+            end
+    end.

--- a/test/snippet_check.escript
+++ b/test/snippet_check.escript
@@ -1,0 +1,207 @@
+#!/usr/bin/env escript
+%%! -noshell
+%%
+%% snippet_check — extract every ```erlang fenced block from the
+%% project's documentation and verify each compiles.
+%%
+%% Usage:
+%%   escript test/snippet_check.escript
+%%
+%% Conventions:
+%%   - Fences with info string `erlang' are compiled.
+%%   - Fences with info string `erl' (or any other) are skipped — use
+%%     them for illustrative output, REPL transcripts, or fragments
+%%     that aren't expected to compile in isolation.
+%%   - A snippet that starts with `-module(' is treated as a complete
+%%     module and compiled as-is.
+%%   - Otherwise the snippet is wrapped in a synthetic module:
+%%       -module(snippet_<n>).
+%%       -compile([export_all, nowarn_export_all]).
+%%       -include_lib("kernel/include/file.hrl").
+%%       doc_snippet() ->
+%%           <body>.
+%%     If the body lacks a trailing dot it is added.
+%%
+%% Output:
+%%   Lists every snippet ("OK" or "FAIL") with file:line. Exits 0 iff
+%%   every `erlang'-tagged fence compiled.
+
+main(_) ->
+    Files = collect_doc_files(),
+    Results = lists:flatmap(fun check_file/1, Files),
+    Failures = [R || {fail, _, _, _} = R <- Results],
+    case Failures of
+        [] ->
+            io:format("snippet_check: ~B snippet(s) OK~n", [length(Results)]),
+            erlang:halt(0);
+        _ ->
+            io:format("~nsnippet_check: ~B failure(s):~n", [length(Failures)]),
+            lists:foreach(fun({fail, F, L, Reason}) ->
+                io:format("  ~s:~B  ~p~n", [F, L, Reason])
+            end, Failures),
+            erlang:halt(1)
+    end.
+
+%%====================================================================
+%% Discovery
+%%====================================================================
+
+%% New, snippet-tested docs only. Older guides (client.md, http-stream.md,
+%% etc.) remain illustrative — port them over when their snippets are
+%% rewritten to compile standalone.
+collect_doc_files() ->
+    Globs = ["guides/building-a-client.md",
+             "guides/internals.md",
+             "examples/*/README.md"],
+    lists:flatmap(fun(G) -> filelib:wildcard(G) end, Globs).
+
+%%====================================================================
+%% Per-file extraction
+%%====================================================================
+
+check_file(File) ->
+    {ok, Bin} = file:read_file(File),
+    Lines = binary:split(Bin, <<"\n">>, [global]),
+    {Snippets, _} = extract_snippets(Lines, 1, [], undefined),
+    [check_snippet(File, Snip) || Snip <- lists:reverse(Snippets)].
+
+%% State machine: outside a fence, look for ```erlang start; inside,
+%% accumulate until the closing ```. Other fence types are skipped.
+extract_snippets([], _, Acc, _) ->
+    {Acc, undefined};
+extract_snippets([Line | Rest], LineNo, Acc, undefined) ->
+    case fence_open(Line) of
+        {erlang, _Tag} ->
+            extract_snippets(Rest, LineNo + 1, Acc, {LineNo, []});
+        {skip, _Tag} ->
+            extract_snippets(Rest, LineNo + 1, Acc, skip);
+        none ->
+            extract_snippets(Rest, LineNo + 1, Acc, undefined)
+    end;
+extract_snippets([Line | Rest], LineNo, Acc, skip) ->
+    case is_fence_close(Line) of
+        true -> extract_snippets(Rest, LineNo + 1, Acc, undefined);
+        false -> extract_snippets(Rest, LineNo + 1, Acc, skip)
+    end;
+extract_snippets([Line | Rest], LineNo, Acc, {Start, Buf}) ->
+    case is_fence_close(Line) of
+        true ->
+            Body = iolist_to_binary(lists:join(<<"\n">>, lists:reverse(Buf))),
+            extract_snippets(Rest, LineNo + 1,
+                             [{Start, Body} | Acc], undefined);
+        false ->
+            extract_snippets(Rest, LineNo + 1, Acc, {Start, [Line | Buf]})
+    end.
+
+fence_open(Line) ->
+    Trim = string:trim(Line),
+    case Trim of
+        <<"```erlang", _/binary>> -> {erlang, <<"erlang">>};
+        <<"```erl">> -> {skip, <<"erl">>};
+        <<"```erl ", _/binary>> -> {skip, <<"erl">>};
+        <<"```", Rest/binary>> when Rest =/= <<>> -> {skip, Rest};
+        <<"```">> -> {skip, <<>>};
+        _ -> none
+    end.
+
+is_fence_close(Line) ->
+    case string:trim(Line) of
+        <<"```">> -> true;
+        _ -> false
+    end.
+
+%%====================================================================
+%% Per-snippet compile
+%%====================================================================
+
+check_snippet(File, {Line, Body}) ->
+    case classify(Body) of
+        skip ->
+            io:format("SKIP ~s:~B (empty)~n", [File, Line]),
+            {ok, File, Line};
+        {module, Forms} ->
+            try_compile(File, Line, Forms);
+        {expression, Forms} ->
+            try_compile(File, Line, Forms)
+    end.
+
+classify(Body) ->
+    case string:trim(Body) of
+        <<>> -> skip;
+        Trimmed ->
+            case binary:match(Trimmed, <<"-module(">>) of
+                {0, _} -> {module, Trimmed};
+                _ ->
+                    case looks_like_function_defs(Trimmed) of
+                        true -> {module, wrap_module(Trimmed)};
+                        false -> {expression, wrap_expr(Trimmed)}
+                    end
+            end
+    end.
+
+%% A snippet is treated as one or more function definitions when it
+%% starts with `name(...) ->'. Anything else is wrapped as the body of
+%% a synthetic `doc_snippet/0' function.
+looks_like_function_defs(Body) ->
+    case re:run(Body, "^[a-z_][a-zA-Z0-9_]*\\s*\\(.*?\\)\\s*->",
+                [{capture, none}]) of
+        match -> true;
+        nomatch -> false
+    end.
+
+wrap_module(Body) ->
+    Body1 = ensure_trailing_dot(Body),
+    iolist_to_binary([
+        <<"-module(">>, synthetic_module_atom(),
+        <<").\n-compile([export_all, nowarn_export_all]).\n">>,
+        Body1
+    ]).
+
+wrap_expr(Body) ->
+    Body1 = case binary:last(Body) of
+        $. -> binary:part(Body, 0, byte_size(Body) - 1);
+        _ -> Body
+    end,
+    iolist_to_binary([
+        <<"-module(">>, synthetic_module_atom(),
+        <<").\n-compile([export_all, nowarn_export_all]).\n">>,
+        <<"doc_snippet() ->\n">>,
+        Body1, <<".\n">>
+    ]).
+
+ensure_trailing_dot(Body) ->
+    case binary:last(Body) of
+        $. -> Body;
+        _ -> <<Body/binary, ".">>
+    end.
+
+synthetic_module_atom() ->
+    list_to_binary("snippet_" ++
+                   integer_to_list(erlang:unique_integer([positive]))).
+
+try_compile(File, Line, Source) ->
+    Module = synthetic_module_name(),
+    SrcFile = "/tmp/" ++ Module ++ ".erl",
+    case file:write_file(SrcFile, Source) of
+        ok ->
+            case compile:file(SrcFile, [binary, return_errors, return_warnings,
+                                        {warn_format, 0}]) of
+                {ok, _, _, _} ->
+                    file:delete(SrcFile),
+                    io:format("OK   ~s:~B~n", [File, Line]),
+                    {ok, File, Line};
+                {ok, _, _} ->
+                    file:delete(SrcFile),
+                    io:format("OK   ~s:~B~n", [File, Line]),
+                    {ok, File, Line};
+                {error, Errors, Warnings} ->
+                    file:delete(SrcFile),
+                    io:format("FAIL ~s:~B~n", [File, Line]),
+                    {fail, File, Line, {Errors, Warnings}}
+            end;
+        Err ->
+            {fail, File, Line, {write_failed, Err}}
+    end.
+
+synthetic_module_name() ->
+    "snippet_" ++ integer_to_list(erlang:unique_integer([positive])).


### PR DESCRIPTION
Adds task-oriented documentation, runnable examples, and snippet drift protection so a developer (or a code-generating tool consuming the docs) can build a working MCP client without reading the source.

- `guides/building-a-client.md` — task-oriented walkthrough (transport, lifecycle, capabilities, tool calls, handler behaviour, OAuth, federation, schema validation, errors).
- `guides/internals.md` — architecture and behaviour contracts.
- `examples/echo_client` and `examples/sampling_host` — runnable hosts with CT suites.
- `test/snippet_check.escript` — every \`\`\`erlang block in the new docs is compiled by `rebar3 ct`.
- CI runs example suites on OTP 27 + 28.