### PR TITLE
HTTP transport hardening and strict JSON-RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security and spec conformance (Streamable HTTP + JSON-RPC)
+
+- **Origin validation.** Streamable HTTP and the legacy `barrel_mcp_http` now validate the `Origin` header on POST/GET/DELETE/OPTIONS using `uri_string:parse/1` (structural scheme/host/port match — no binary prefix matching). New options `allowed_origins` and `allow_missing_origin`. The literal `Origin: null` value is treated as a distinct present origin and is rejected unless explicitly allowed.
+- **Default bind to loopback.** Both transports default to `{127, 0, 0, 1}`. Public binds require an explicit `allowed_origins`; the start function refuses with `{error, allowed_origins_required}` otherwise.
+- **CORS tightening.** `Access-Control-Allow-Origin` now echoes the validated `Origin` (no wildcard) with `Vary: Origin`, and is omitted entirely when no `Origin` is sent. The `Access-Control-Allow-Headers` allow-list is derived from the configured auth provider via a new optional `auth_headers/1` callback on `barrel_mcp_auth`. Custom API-key header names are honoured both in CORS and in `extract_headers`.
+- **Streamable HTTP response shape.** Notifications and POSTed responses to server-initiated requests now return **202 Accepted** with empty body. Missing `Mcp-Session-Id` on a non-initialize request returns **400 Bad Request**; unknown/invalid id returns **404 Not Found**. `initialize` is the only request that may run without a session.
+- **`MCP-Protocol-Version` server validation.** Present-but-unsupported header → 400 with the supported list. Missing header on a session that has completed initialize falls back to the session-stored negotiated version. Pre-init / no session falls back to `2025-03-26` per spec compatibility guidance. New `?MCP_SUPPORTED_VERSIONS` macro.
+- **JSON-RPC id strictness.** `barrel_mcp_protocol:handle/2` and `decode_envelope/1` now reject ids that are not `binary` or `integer` (including `null`) with `-32600 Invalid Request`.
+- **Batch rejection.** Top-level JSON arrays are explicitly rejected with `-32600 Batch requests are not supported` at both the HTTP boundary and inside `handle/2`.
+- **ETS visibility.** `barrel_mcp_sessions`, `barrel_mcp_resource_subs`, and `barrel_mcp_pending_requests` are now `protected`. Every public mutator on `barrel_mcp_session` (create, update_activity, delete, set_client_capabilities, set_protocol_version, set_sse_pid, subscribe_resource, unsubscribe_resource, deliver_response, cleanup_expired) routes through the gen_server.
+- New `test/barrel_mcp_http_stream_security_SUITE.erl` covers Origin matching, session lookup, version validation, response shape, batch / id strictness, and ETS protection.
+
 ### Added
 
 - **Spec-conformant MCP client** (`barrel_mcp_client`)

--- a/include/barrel_mcp.hrl
+++ b/include/barrel_mcp.hrl
@@ -16,6 +16,11 @@
 %% Older revisions the client knows how to speak (in preference order).
 -define(MCP_CLIENT_SUPPORTED_VERSIONS,
         [<<"2025-11-25">>, <<"2025-06-18">>, <<"2025-03-26">>, <<"2024-11-05">>]).
+%% Versions the server is willing to accept on the
+%% `MCP-Protocol-Version' request header. Same set as the client list
+%% today; bumping the server's preferred default is a separate change.
+-define(MCP_SUPPORTED_VERSIONS,
+        [<<"2025-11-25">>, <<"2025-06-18">>, <<"2025-03-26">>, <<"2024-11-05">>]).
 
 %% JSON-RPC Error Codes
 -define(JSONRPC_PARSE_ERROR, -32700).

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
 
 {dialyzer, [
     {warnings, [unmatched_returns, error_handling, unknown]},
-    {plt_extra_apps, [cowboy, hackney]}
+    {plt_extra_apps, [cowboy, hackney, ranch]}
 ]}.
 
 {xref_checks, [undefined_function_calls, undefined_functions,

--- a/src/barrel_mcp_auth.erl
+++ b/src/barrel_mcp_auth.erl
@@ -67,7 +67,8 @@
     get_auth_info/1,
     extract_bearer_token/1,
     extract_api_key/2,
-    extract_basic_auth/1
+    extract_basic_auth/1,
+    auth_headers/1
 ]).
 
 %% Types
@@ -133,7 +134,13 @@
 -callback challenge(Reason :: auth_error(), State :: term()) ->
     {StatusCode :: integer(), Headers :: map(), Body :: binary()}.
 
--optional_callbacks([init/1]).
+%% Optional: declare which HTTP request headers carry credentials so
+%% the HTTP transport can build the CORS `Access-Control-Allow-Headers'
+%% list and read the right inputs in `extract_headers/1'. Returning
+%% the empty list means "no auth header" (e.g. cookie-based, or none).
+-callback auth_headers(State :: term()) -> [binary()].
+
+-optional_callbacks([init/1, auth_headers/1]).
 
 %%====================================================================
 %% API
@@ -178,6 +185,39 @@ authenticate(#{provider := Provider} = Config, Request, State) ->
 challenge_response(#{provider := Provider} = Config, Reason) ->
     ProviderState = maps:get(provider_state, Config, undefined),
     Provider:challenge(Reason, ProviderState).
+
+%% @doc Return the list of HTTP request headers (lower-case) the
+%% configured provider expects to read credentials from. Used by the
+%% HTTP transport to build CORS `Access-Control-Allow-Headers' and to
+%% extract inputs in the request handler. Falls back to a sensible
+%% default per built-in provider when the provider does not export
+%% `auth_headers/1'.
+-spec auth_headers(auth_config()) -> [binary()].
+auth_headers(#{provider := barrel_mcp_auth_none}) ->
+    [];
+auth_headers(#{provider := Provider} = Config) ->
+    case erlang:function_exported(Provider, auth_headers, 1) of
+        true ->
+            ProviderState = maps:get(provider_state, Config, undefined),
+            Provider:auth_headers(ProviderState);
+        false ->
+            default_auth_headers(Provider, Config)
+    end.
+
+default_auth_headers(barrel_mcp_auth_bearer, _) -> [<<"authorization">>];
+default_auth_headers(barrel_mcp_auth_basic, _)  -> [<<"authorization">>];
+default_auth_headers(barrel_mcp_auth_apikey, Config) ->
+    Opts = maps:get(provider_opts, Config, #{}),
+    Custom = maps:get(header_name, Opts, undefined),
+    Base = [<<"x-api-key">>, <<"authorization">>],
+    case Custom of
+        undefined -> Base;
+        H when is_binary(H) -> [string:lowercase(H) | Base]
+    end;
+default_auth_headers(barrel_mcp_auth_custom, _) ->
+    [<<"authorization">>, <<"x-api-key">>];
+default_auth_headers(_, _) ->
+    [].
 
 %% @doc Get authentication info from a context map.
 %%

--- a/src/barrel_mcp_http.erl
+++ b/src/barrel_mcp_http.erl
@@ -38,33 +38,40 @@
 %%====================================================================
 
 %% @doc Start HTTP server for MCP.
+%%
+%% Same security defaults as `barrel_mcp_http_stream':
+%% binds to `127.0.0.1' by default, requires explicit
+%% `allowed_origins' for non-loopback binds.
 -spec start(map()) -> {ok, pid()} | {error, term()}.
 start(Opts) ->
     Port = maps:get(port, Opts, 9090),
-    Ip = maps:get(ip, Opts, {0, 0, 0, 0}),
-
-    %% Initialize authentication
-    AuthConfig = init_auth(maps:get(auth, Opts, #{})),
-
-    %% Handler state includes auth config
-    HandlerState = #{
-        auth_config => AuthConfig
-    },
-
-    Routes = [
-        {'_', [
-            {"/mcp", ?MODULE, HandlerState},
-            {"/", ?MODULE, HandlerState}
-        ]}
-    ],
-    Dispatch = cowboy_router:compile(Routes),
-
-    cowboy:start_clear(?HTTP_LISTENER, [
-        {port, Port},
-        {ip, Ip}
-    ], #{
-        env => #{dispatch => Dispatch}
-    }).
+    Ip = maps:get(ip, Opts, {127, 0, 0, 1}),
+    Loopback = barrel_mcp_http_stream:is_loopback(Ip),
+    case barrel_mcp_http_stream:resolve_allowed_origins(
+           Loopback, maps:get(allowed_origins, Opts, undefined)) of
+        {error, _} = Err -> Err;
+        {ok, AllowedOrigins} ->
+            AllowMissing = maps:get(allow_missing_origin, Opts, Loopback),
+            AuthConfig = init_auth(maps:get(auth, Opts, #{})),
+            HandlerState = #{
+                auth_config => AuthConfig,
+                allowed_origins => AllowedOrigins,
+                allow_missing_origin => AllowMissing
+            },
+            Routes = [
+                {'_', [
+                    {"/mcp", ?MODULE, HandlerState},
+                    {"/", ?MODULE, HandlerState}
+                ]}
+            ],
+            Dispatch = cowboy_router:compile(Routes),
+            cowboy:start_clear(?HTTP_LISTENER, [
+                {port, Port},
+                {ip, Ip}
+            ], #{
+                env => #{dispatch => Dispatch}
+            })
+    end.
 
 %% @doc Stop HTTP server.
 -spec stop() -> ok | {error, not_found}.
@@ -76,19 +83,24 @@ stop() ->
 %%====================================================================
 
 init(Req0, State) ->
-    Method = cowboy_req:method(Req0),
-    case Method of
-        <<"POST">> ->
-            handle_post(Req0, State);
-        <<"OPTIONS">> ->
-            handle_options(Req0, State);
-        _ ->
-            Req = cowboy_req:reply(405, #{
-                <<"content-type">> => <<"application/json">>,
-                <<"allow">> => <<"POST, OPTIONS">>
-            }, <<"{\"error\":\"Method not allowed\"}">>, Req0),
+    case barrel_mcp_http_stream:validate_origin(Req0, State) of
+        ok ->
+            dispatch_method(cowboy_req:method(Req0), Req0, State);
+        {error, _} ->
+            Req = cowboy_req:reply(403, #{}, <<>>, Req0),
             {ok, Req, State}
     end.
+
+dispatch_method(<<"POST">>, Req0, State) ->
+    handle_post(Req0, State);
+dispatch_method(<<"OPTIONS">>, Req0, State) ->
+    handle_options(Req0, State);
+dispatch_method(_, Req0, State) ->
+    Req = cowboy_req:reply(405, #{
+        <<"content-type">> => <<"application/json">>,
+        <<"allow">> => <<"POST, OPTIONS">>
+    }, <<"{\"error\":\"Method not allowed\"}">>, Req0),
+    {ok, Req, State}.
 
 %%====================================================================
 %% Internal Functions

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -28,6 +28,13 @@
     stop/0
 ]).
 
+%% Helpers re-used by the legacy `barrel_mcp_http' transport.
+-export([
+    is_loopback/1,
+    resolve_allowed_origins/2,
+    validate_origin/2
+]).
+
 %% Cowboy loop handler callbacks
 -export([init/2, info/3, terminate/3]).
 
@@ -38,69 +45,105 @@
 %%====================================================================
 
 %% @doc Start the Streamable HTTP server.
+%%
+%% == Security defaults ==
+%%
+%% Since version 1.2 the server binds to `127.0.0.1' by default.
+%% Public binds (any non-loopback IP) require an explicit
+%% `allowed_origins' to prevent DNS-rebinding and CORS-style
+%% attacks. The server validates the `Origin' header on every
+%% request and rejects mismatches with HTTP 403.
+%%
+%% == Options ==
+%%
+%% <ul>
+%%   <li>`port' — TCP port (default 9090).</li>
+%%   <li>`ip' — bind address (default `{127,0,0,1}').</li>
+%%   <li>`auth' — authentication provider config.</li>
+%%   <li>`session_enabled' — `true' (default) to use
+%%       `Mcp-Session-Id' sessions.</li>
+%%   <li>`ssl' — TLS options (`certfile', `keyfile',
+%%       optional `cacertfile').</li>
+%%   <li>`allowed_origins' — `[binary()] | any'. List of allowed
+%%       Origin values (case-sensitive scheme/host/port match) or
+%%       the atom `any' to disable validation. Required for
+%%       non-loopback binds. Defaults to a loopback allow-list when
+%%       bound to `127.0.0.1' / `::1'.</li>
+%%   <li>`allow_missing_origin' — `true' to accept requests with
+%%       no `Origin' header (typical of non-browser clients).
+%%       Defaults to `true' on loopback, `false' otherwise.</li>
+%% </ul>
 -spec start(Opts) -> {ok, pid()} | {error, term()} when
     Opts :: #{
         port => pos_integer(),
         ip => inet:ip_address(),
         auth => map(),
         session_enabled => boolean(),
-        ssl => map()
+        ssl => map(),
+        allowed_origins => [binary()] | any,
+        allow_missing_origin => boolean()
     }.
 start(Opts) ->
     Port = maps:get(port, Opts, 9090),
-    Ip = maps:get(ip, Opts, {0, 0, 0, 0}),
+    Ip = maps:get(ip, Opts, {127, 0, 0, 1}),
     SessionEnabled = maps:get(session_enabled, Opts, true),
 
-    %% Ensure session manager is started if sessions are enabled
-    _ = case SessionEnabled of
-        true ->
-            ensure_session_manager();
-        false ->
-            ok
-    end,
+    Loopback = is_loopback(Ip),
+    case resolve_allowed_origins(Loopback,
+                                 maps:get(allowed_origins, Opts, undefined)) of
+        {error, _} = Err ->
+            Err;
+        {ok, AllowedOrigins} ->
+            AllowMissing = maps:get(allow_missing_origin, Opts, Loopback),
 
-    %% Initialize authentication
-    AuthConfig = init_auth(maps:get(auth, Opts, #{})),
-
-    %% Handler state
-    HandlerState = #{
-        auth_config => AuthConfig,
-        session_enabled => SessionEnabled
-    },
-
-    Routes = [
-        {'_', [
-            {"/mcp", ?MODULE, HandlerState},
-            {"/", ?MODULE, HandlerState}
-        ]}
-    ],
-    Dispatch = cowboy_router:compile(Routes),
-
-    %% Start with TLS or clear depending on ssl option
-    case maps:get(ssl, Opts, undefined) of
-        #{certfile := Cert, keyfile := Key} = SslOpts ->
-            CaCert = maps:get(cacertfile, SslOpts, undefined),
-            TlsOpts = [
-                {port, Port},
-                {ip, Ip},
-                {certfile, Cert},
-                {keyfile, Key}
-            ] ++ case CaCert of
-                undefined -> [];
-                _ -> [{cacertfile, CaCert}]
+            %% Ensure session manager is started if sessions are enabled
+            _ = case SessionEnabled of
+                true -> ensure_session_manager();
+                false -> ok
             end,
-            cowboy:start_tls(?STREAM_LISTENER, TlsOpts, #{
-                env => #{dispatch => Dispatch},
-                idle_timeout => infinity
-            });
-        _ ->
-            cowboy:start_clear(?STREAM_LISTENER, [
-                {port, Port},
-                {ip, Ip}
-            ], #{
-                env => #{dispatch => Dispatch},
-                idle_timeout => infinity
-            })
+
+            AuthConfig = init_auth(maps:get(auth, Opts, #{})),
+
+            HandlerState = #{
+                auth_config => AuthConfig,
+                session_enabled => SessionEnabled,
+                allowed_origins => AllowedOrigins,
+                allow_missing_origin => AllowMissing
+            },
+
+            Routes = [
+                {'_', [
+                    {"/mcp", ?MODULE, HandlerState},
+                    {"/", ?MODULE, HandlerState}
+                ]}
+            ],
+            Dispatch = cowboy_router:compile(Routes),
+
+            case maps:get(ssl, Opts, undefined) of
+                #{certfile := Cert, keyfile := Key} = SslOpts ->
+                    CaCert = maps:get(cacertfile, SslOpts, undefined),
+                    TlsOpts = [
+                        {port, Port},
+                        {ip, Ip},
+                        {certfile, Cert},
+                        {keyfile, Key}
+                    ] ++ case CaCert of
+                        undefined -> [];
+                        _ -> [{cacertfile, CaCert}]
+                    end,
+                    cowboy:start_tls(?STREAM_LISTENER, TlsOpts, #{
+                        env => #{dispatch => Dispatch},
+                        idle_timeout => infinity
+                    });
+                _ ->
+                    cowboy:start_clear(?STREAM_LISTENER, [
+                        {port, Port},
+                        {ip, Ip}
+                    ], #{
+                        env => #{dispatch => Dispatch},
+                        idle_timeout => infinity
+                    })
+            end
     end.
 
 %% @doc Stop the Streamable HTTP server.
@@ -114,22 +157,27 @@ stop() ->
 
 init(Req0, State) ->
     Method = cowboy_req:method(Req0),
-    case Method of
-        <<"POST">> ->
-            handle_post(Req0, State);
-        <<"GET">> ->
-            handle_get_sse(Req0, State);
-        <<"DELETE">> ->
-            handle_delete(Req0, State);
-        <<"OPTIONS">> ->
-            handle_options(Req0, State);
-        _ ->
-            Req = cowboy_req:reply(405, #{
-                <<"content-type">> => <<"application/json">>,
-                <<"allow">> => <<"POST, GET, DELETE, OPTIONS">>
-            }, <<"{\"error\":\"Method not allowed\"}">>, Req0),
+    case validate_origin(Req0, State) of
+        ok ->
+            dispatch_method(Method, Req0, State);
+        {error, _Reason} ->
+            %% Respond 403 with no body. We deliberately omit
+            %% Access-Control-Allow-Origin so the browser surfaces
+            %% the rejection rather than retrying.
+            Req = cowboy_req:reply(403, #{}, <<>>, Req0),
             {ok, Req, State}
     end.
+
+dispatch_method(<<"POST">>, Req0, State)    -> handle_post(Req0, State);
+dispatch_method(<<"GET">>, Req0, State)     -> handle_get_sse(Req0, State);
+dispatch_method(<<"DELETE">>, Req0, State)  -> handle_delete(Req0, State);
+dispatch_method(<<"OPTIONS">>, Req0, State) -> handle_options(Req0, State);
+dispatch_method(_, Req0, State) ->
+    Req = cowboy_req:reply(405, cors_response_headers(Req0, State, #{
+        <<"content-type">> => <<"application/json">>,
+        <<"allow">> => <<"POST, GET, DELETE, OPTIONS">>
+    }), <<"{\"error\":\"Method not allowed\"}">>, Req0),
+    {ok, Req, State}.
 
 info(session_terminated, Req, State) ->
     %% Session was terminated, close the SSE stream
@@ -166,13 +214,13 @@ handle_post(Req0, State) ->
     %% Validate Accept header
     case validate_accept_header(Req0) of
         {error, Reason} ->
-            Req = cowboy_req:reply(406, cors_headers(),
+            Req = cowboy_req:reply(406, cors_response_headers(Req0, State, #{}),
                 json_encode(#{<<"error">> => Reason}), Req0),
             {ok, Req, State};
         ok ->
             %% Authenticate
             AuthConfig = maps:get(auth_config, State, #{provider => barrel_mcp_auth_none}),
-            Headers = extract_headers(Req0),
+            Headers = extract_headers(Req0, AuthConfig),
             AuthRequest = #{headers => Headers},
 
             case authenticate(AuthConfig, AuthRequest) of
@@ -185,144 +233,264 @@ handle_post(Req0, State) ->
 
 handle_post_authenticated(Req0, State) ->
     SessionEnabled = maps:get(session_enabled, State, true),
-
-    %% Get or create session
-    {SessionId, State1} = case SessionEnabled of
-        true ->
-            get_or_create_session(Req0, State);
-        false ->
-            {undefined, State}
-    end,
-
-    %% Update session activity
-    _ = case SessionId of
-        undefined -> ok;
-        _ -> barrel_mcp_session:update_activity(SessionId)
-    end,
-
-    %% Read and process request body
+    %% Read body first; we need to inspect the method to know whether
+    %% we may create a session (`initialize') or must look one up.
     {ok, Body, Req1} = cowboy_req:read_body(Req0),
-
     case barrel_mcp_protocol:decode(Body) of
-        {ok, #{<<"id">> := RespId} = Request}
-                when is_map_key(<<"result">>, Request);
-                     is_map_key(<<"error">>, Request) ->
-            %% Inbound is a JSON-RPC RESPONSE (not a request) for an
-            %% earlier server-initiated call (e.g. sampling/createMessage).
-            %% Route to the waiting caller; reply 204.
-            _ = barrel_mcp_session:deliver_response(RespId, Request),
-            ResponseHeaders = add_session_header(cors_headers(), SessionId),
-            Req2 = cowboy_req:reply(204, ResponseHeaders, <<>>, Req1),
-            {ok, Req2, State1};
-        {ok, Request} ->
-            %% Add auth info to request context
-            AuthInfo = maps:get(auth_info, State1, undefined),
-            ProtocolState = case SessionId of
-                undefined -> #{};
-                _ -> #{session_id => SessionId}
-            end,
-            ProtocolState1 = case AuthInfo of
-                undefined -> ProtocolState;
-                _ -> ProtocolState#{auth_info => AuthInfo}
-            end,
-            RequestWithAuth = case AuthInfo of
-                undefined -> Request;
-                _ -> Request#{<<"_auth">> => AuthInfo}
-            end,
-
-            %% Handle the MCP request
-            case barrel_mcp_protocol:handle(RequestWithAuth, ProtocolState1) of
-                no_response ->
-                    %% Notification - return 204 No Content
-                    ResponseHeaders = add_session_header(cors_headers(), SessionId),
-                    Req2 = cowboy_req:reply(204, ResponseHeaders, <<>>, Req1),
-                    {ok, Req2, State1};
-                Result ->
-                    %% Check if client accepts SSE
-                    case wants_sse_response(Req1) of
-                        true ->
-                            %% Stream response as SSE
-                            stream_sse_response(Req1, State1, SessionId, Result);
-                        false ->
-                            %% Return JSON response
-                            ResponseJson = barrel_mcp_protocol:encode(Result),
-                            ResponseHeaders = add_session_header(
-                                maps:merge(#{<<"content-type">> => <<"application/json">>}, cors_headers()),
-                                SessionId
-                            ),
-                            Req2 = cowboy_req:reply(200, ResponseHeaders, ResponseJson, Req1),
-                            {ok, Req2, State1}
-                    end
-            end;
+        {ok, Request} when is_list(Request) ->
+            %% Batches are not supported.
+            reply_jsonrpc_error(Req1, State, undefined, 400, null,
+                                ?JSONRPC_INVALID_REQUEST,
+                                <<"Batch requests are not supported">>);
+        {ok, Request} when is_map(Request) ->
+            handle_post_request(Req1, State, SessionEnabled, Request);
         {error, parse_error} ->
-            ErrorResponse = barrel_mcp_protocol:error_response(
-                null, -32700, <<"Parse error">>
-            ),
-            ResponseJson = barrel_mcp_protocol:encode(ErrorResponse),
-            ResponseHeaders = add_session_header(
-                maps:merge(#{<<"content-type">> => <<"application/json">>}, cors_headers()),
-                SessionId
-            ),
-            Req2 = cowboy_req:reply(400, ResponseHeaders, ResponseJson, Req1),
-            {ok, Req2, State1}
+            reply_jsonrpc_error(Req1, State, undefined, 400, null,
+                                -32700, <<"Parse error">>)
     end.
 
-handle_get_sse(Req0, State) ->
-    %% GET requests open an SSE stream for server-to-client notifications
-    %% This requires a valid session
-    SessionEnabled = maps:get(session_enabled, State, true),
+handle_post_request(Req0, State, SessionEnabled, Request) ->
+    %% Distinguish a JSON-RPC RESPONSE (carries result/error + id)
+    %% from a regular request/notification.
+    case is_jsonrpc_response(Request) of
+        true ->
+            handle_inbound_response(Req0, State, SessionEnabled, Request);
+        false ->
+            handle_inbound_request(Req0, State, SessionEnabled, Request)
+    end.
 
+is_jsonrpc_response(R) ->
+    is_map_key(<<"id">>, R) andalso
+        (is_map_key(<<"result">>, R) orelse is_map_key(<<"error">>, R)) andalso
+        not is_map_key(<<"method">>, R).
+
+handle_inbound_response(Req0, State, _SessionEnabled,
+                        #{<<"id">> := RespId} = Request) ->
+    _ = barrel_mcp_session:deliver_response(RespId, Request),
+    %% Per Streamable HTTP, accepted server-bound responses return 202.
+    Req = cowboy_req:reply(202, cors_response_headers(Req0, State, #{}),
+                           <<>>, Req0),
+    {ok, Req, State}.
+
+handle_inbound_request(Req0, State, SessionEnabled, Request) ->
+    Method = maps:get(<<"method">>, Request, undefined),
+    case lookup_session_for_request(Req0, State, SessionEnabled, Method) of
+        {ok, SessionId, State1} ->
+            handle_dispatch(Req0, State1, SessionId, Request);
+        {error, missing_session_id} ->
+            reply_jsonrpc_error(Req0, State, undefined, 400, null,
+                                ?JSONRPC_INVALID_REQUEST,
+                                <<"Mcp-Session-Id header required">>);
+        {error, unknown_session} ->
+            reply_jsonrpc_error(Req0, State, undefined, 404, null,
+                                ?JSONRPC_INVALID_REQUEST,
+                                <<"Unknown Mcp-Session-Id">>)
+    end.
+
+handle_dispatch(Req0, State, SessionId, Request) ->
+    %% Update session activity if we have a session.
+    _ = case SessionId of
+            undefined -> ok;
+            _ -> barrel_mcp_session:update_activity(SessionId)
+        end,
+
+    Method = maps:get(<<"method">>, Request, undefined),
+
+    case validate_protocol_version(Req0, State, SessionId, Method) of
+        {error, ProtoErr} ->
+            reply_jsonrpc_error(Req0, State, SessionId, 400, null,
+                                ?JSONRPC_INVALID_REQUEST, ProtoErr);
+        ok ->
+            AuthInfo = maps:get(auth_info, State, undefined),
+            ProtocolState0 = case SessionId of
+                                 undefined -> #{};
+                                 _ -> #{session_id => SessionId}
+                             end,
+            ProtocolState = case AuthInfo of
+                                undefined -> ProtocolState0;
+                                _ -> ProtocolState0#{auth_info => AuthInfo}
+                            end,
+            RequestWithAuth = case AuthInfo of
+                                  undefined -> Request;
+                                  _ -> Request#{<<"_auth">> => AuthInfo}
+                              end,
+            case barrel_mcp_protocol:handle(RequestWithAuth, ProtocolState) of
+                no_response ->
+                    %% Notification accepted: 202 with empty body.
+                    Headers = add_session_header(
+                                cors_response_headers(Req0, State, #{}),
+                                SessionId),
+                    Req = cowboy_req:reply(202, Headers, <<>>, Req0),
+                    {ok, Req, State};
+                Result ->
+                    %% Capture protocol_version from a successful initialize
+                    %% so subsequent requests can fall back to the
+                    %% session-stored value when the header is missing.
+                    State1 = maybe_capture_initialize_version(
+                                State, SessionId, Method, Result),
+                    case wants_sse_response(Req0) of
+                        true ->
+                            stream_sse_response(Req0, State1, SessionId, Result);
+                        false ->
+                            ResponseJson = barrel_mcp_protocol:encode(Result),
+                            Headers = add_session_header(
+                                        cors_response_headers(Req0, State1, #{
+                                            <<"content-type">> =>
+                                                <<"application/json">>
+                                        }),
+                                        SessionId),
+                            Req = cowboy_req:reply(200, Headers, ResponseJson, Req0),
+                            {ok, Req, State1}
+                    end
+            end
+    end.
+
+reply_jsonrpc_error(Req0, State, SessionId, Status, Id, Code, Message) ->
+    ErrorResponse = barrel_mcp_protocol:error_response(Id, Code, Message),
+    ResponseJson = barrel_mcp_protocol:encode(ErrorResponse),
+    Headers = add_session_header(
+                cors_response_headers(Req0, State, #{
+                    <<"content-type">> => <<"application/json">>
+                }), SessionId),
+    Req = cowboy_req:reply(Status, Headers, ResponseJson, Req0),
+    {ok, Req, State}.
+
+%% Look up (or, for `initialize', create) the session for the
+%% request. Returns:
+%%   {ok, SessionId | undefined, NewState}
+%%   {error, missing_session_id} — no header, header was required
+%%   {error, unknown_session}   — header present but id not registered
+lookup_session_for_request(_Req, State, false, _Method) ->
+    {ok, undefined, State};
+lookup_session_for_request(Req, State, true, Method) ->
+    Header = get_session_from_request(Req),
+    case {Method, Header} of
+        {<<"initialize">>, undefined} ->
+            {ok, SessionId} = barrel_mcp_session:create(#{}),
+            {ok, SessionId, State#{session_id => SessionId}};
+        {<<"initialize">>, SessionId} ->
+            case barrel_mcp_session:get(SessionId) of
+                {ok, _} -> {ok, SessionId, State#{session_id => SessionId}};
+                {error, not_found} ->
+                    {ok, NewSid} = barrel_mcp_session:create(#{}),
+                    {ok, NewSid, State#{session_id => NewSid}}
+            end;
+        {_, undefined} ->
+            {error, missing_session_id};
+        {_, SessionId} ->
+            case barrel_mcp_session:get(SessionId) of
+                {ok, _} -> {ok, SessionId, State#{session_id => SessionId}};
+                {error, not_found} -> {error, unknown_session}
+            end
+    end.
+
+%% Validate the `MCP-Protocol-Version' header per the spec:
+%% - On initialize, the header is optional (the body carries the
+%%   version).
+%% - For subsequent requests:
+%%   * present + supported → ok
+%%   * present + unsupported → error (400 with supported list)
+%%   * missing → fall back to the session-stored negotiated
+%%     version; if none, assume <<"2025-03-26">>.
+validate_protocol_version(_Req, _State, _Sid, <<"initialize">>) -> ok;
+validate_protocol_version(Req, _State, SessionId, _Method) ->
+    case cowboy_req:header(<<"mcp-protocol-version">>, Req) of
+        undefined ->
+            %% Session-stored value or default fallback. Either way: ok.
+            ok;
+        Version ->
+            case lists:member(Version, ?MCP_SUPPORTED_VERSIONS) of
+                true ->
+                    case SessionId of
+                        undefined -> ok;
+                        _ ->
+                            _ = barrel_mcp_session:set_protocol_version(
+                                  SessionId, Version),
+                            ok
+                    end;
+                false ->
+                    {error, iolist_to_binary([
+                        <<"Bad MCP-Protocol-Version: ">>, Version,
+                        <<". Supported: ">>,
+                        lists:join(<<", ">>, ?MCP_SUPPORTED_VERSIONS)
+                    ])}
+            end
+    end.
+
+%% After a successful initialize, store the negotiated
+%% `protocolVersion' on the session so later requests can fall back
+%% to it when the header is missing.
+maybe_capture_initialize_version(State, SessionId, <<"initialize">>,
+                                 #{<<"result">> := #{<<"protocolVersion">> :=
+                                                      Version}})
+  when is_binary(SessionId) ->
+    _ = barrel_mcp_session:set_protocol_version(SessionId, Version),
+    State;
+maybe_capture_initialize_version(State, _, _, _) -> State.
+
+handle_get_sse(Req0, State) ->
+    SessionEnabled = maps:get(session_enabled, State, true),
     case SessionEnabled of
         false ->
-            Req = cowboy_req:reply(400, cors_headers(),
+            Req = cowboy_req:reply(400, cors_response_headers(Req0, State, #{}),
                 json_encode(#{<<"error">> => <<"Sessions not enabled">>}), Req0),
             {ok, Req, State};
         true ->
             case get_session_from_request(Req0) of
                 undefined ->
-                    Req = cowboy_req:reply(400, cors_headers(),
+                    Req = cowboy_req:reply(400, cors_response_headers(Req0, State, #{}),
                         json_encode(#{<<"error">> => <<"Mcp-Session-Id header required">>}), Req0),
                     {ok, Req, State};
                 SessionId ->
                     case barrel_mcp_session:get(SessionId) of
                         {ok, _Session} ->
-                            %% Open SSE stream
-                            ResponseHeaders = add_session_header(#{
-                                <<"content-type">> => <<"text/event-stream">>,
-                                <<"cache-control">> => <<"no-cache">>,
-                                <<"connection">> => <<"keep-alive">>
-                            }, SessionId),
-                            ResponseHeaders1 = maps:merge(ResponseHeaders, cors_headers()),
-                            Req = cowboy_req:stream_reply(200, ResponseHeaders1, Req0),
-                            %% Register this process as the session's SSE
-                            %% pid so server-to-client primitives (sampling,
-                            %% notifications) can deliver messages here.
+                            ResponseHeaders = add_session_header(
+                                cors_response_headers(Req0, State, #{
+                                    <<"content-type">> => <<"text/event-stream">>,
+                                    <<"cache-control">> => <<"no-cache">>,
+                                    <<"connection">> => <<"keep-alive">>
+                                }), SessionId),
+                            Req = cowboy_req:stream_reply(200, ResponseHeaders, Req0),
                             _ = barrel_mcp_session:set_sse_pid(SessionId, self()),
-                            %% Enter loop mode to handle SSE events
                             {cowboy_loop, Req, State#{sse_session => SessionId}};
                         {error, not_found} ->
-                            Req = cowboy_req:reply(404, cors_headers(),
-                                json_encode(#{<<"error">> => <<"Session not found">>}), Req0),
+                            Req = cowboy_req:reply(404,
+                                cors_response_headers(Req0, State, #{}),
+                                json_encode(#{<<"error">> => <<"Unknown Mcp-Session-Id">>}),
+                                Req0),
                             {ok, Req, State}
                     end
             end
     end.
 
 handle_delete(Req0, State) ->
-    %% DELETE terminates a session
     case get_session_from_request(Req0) of
         undefined ->
-            Req = cowboy_req:reply(400, cors_headers(),
-                json_encode(#{<<"error">> => <<"Mcp-Session-Id header required">>}), Req0),
+            Req = cowboy_req:reply(400,
+                cors_response_headers(Req0, State, #{}),
+                json_encode(#{<<"error">> => <<"Mcp-Session-Id header required">>}),
+                Req0),
             {ok, Req, State};
         SessionId ->
-            barrel_mcp_session:delete(SessionId),
-            Req = cowboy_req:reply(204, cors_headers(), <<>>, Req0),
-            {ok, Req, State}
+            case barrel_mcp_session:get(SessionId) of
+                {ok, _} ->
+                    barrel_mcp_session:delete(SessionId),
+                    Req = cowboy_req:reply(204,
+                        cors_response_headers(Req0, State, #{}),
+                        <<>>, Req0),
+                    {ok, Req, State};
+                {error, not_found} ->
+                    Req = cowboy_req:reply(404,
+                        cors_response_headers(Req0, State, #{}),
+                        json_encode(#{<<"error">> => <<"Unknown Mcp-Session-Id">>}),
+                        Req0),
+                    {ok, Req, State}
+            end
     end.
 
 handle_options(Req0, State) ->
-    Req = cowboy_req:reply(204, cors_headers(), <<>>, Req0),
+    Req = cowboy_req:reply(204, cors_response_headers(Req0, State, #{}),
+                           <<>>, Req0),
     {ok, Req, State}.
 
 %%====================================================================
@@ -330,13 +498,12 @@ handle_options(Req0, State) ->
 %%====================================================================
 
 stream_sse_response(Req0, State, SessionId, Result) ->
-    %% Start SSE stream
-    ResponseHeaders = add_session_header(#{
-        <<"content-type">> => <<"text/event-stream">>,
-        <<"cache-control">> => <<"no-cache">>
-    }, SessionId),
-    ResponseHeaders1 = maps:merge(ResponseHeaders, cors_headers()),
-    Req = cowboy_req:stream_reply(200, ResponseHeaders1, Req0),
+    ResponseHeaders = add_session_header(
+        cors_response_headers(Req0, State, #{
+            <<"content-type">> => <<"text/event-stream">>,
+            <<"cache-control">> => <<"no-cache">>
+        }), SessionId),
+    Req = cowboy_req:stream_reply(200, ResponseHeaders, Req0),
 
     %% Send the response as an SSE event
     EventId = generate_event_id(),
@@ -360,23 +527,6 @@ generate_event_id() ->
 %%====================================================================
 %% Session Helpers
 %%====================================================================
-
-get_or_create_session(Req, State) ->
-    case get_session_from_request(Req) of
-        undefined ->
-            %% Create new session
-            {ok, SessionId} = barrel_mcp_session:create(#{}),
-            {SessionId, State#{session_id => SessionId}};
-        SessionId ->
-            case barrel_mcp_session:get(SessionId) of
-                {ok, _} ->
-                    {SessionId, State#{session_id => SessionId}};
-                {error, not_found} ->
-                    %% Session expired, create new one
-                    {ok, NewSessionId} = barrel_mcp_session:create(#{}),
-                    {NewSessionId, State#{session_id => NewSessionId}}
-            end
-    end.
 
 get_session_from_request(Req) ->
     cowboy_req:header(<<"mcp-session-id">>, Req, undefined).
@@ -462,30 +612,137 @@ authenticate(AuthConfig, Request) ->
 
 handle_auth_error(Req0, State, AuthConfig, Reason) ->
     {StatusCode, AuthHeaders, Body} = barrel_mcp_auth:challenge_response(AuthConfig, Reason),
-    Headers = maps:merge(AuthHeaders, cors_headers()),
+    Headers = maps:merge(AuthHeaders, cors_response_headers(Req0, State, #{})),
     Req = cowboy_req:reply(StatusCode, Headers, Body, Req0),
     {ok, Req, State}.
 
-extract_headers(Req) ->
-    HeaderNames = [<<"authorization">>, <<"x-api-key">>],
+extract_headers(Req, AuthConfig) ->
+    Names = case AuthConfig of
+                undefined -> [<<"authorization">>, <<"x-api-key">>];
+                _ ->
+                    Decl = barrel_mcp_auth:auth_headers(AuthConfig),
+                    case Decl of
+                        [] -> [<<"authorization">>, <<"x-api-key">>];
+                        _ -> Decl
+                    end
+            end,
     lists:foldl(fun(Name, Acc) ->
         case cowboy_req:header(Name, Req) of
             undefined -> Acc;
             Value -> Acc#{Name => Value}
         end
-    end, #{}, HeaderNames).
+    end, #{}, Names).
 
 %%====================================================================
 %% CORS
 %%====================================================================
 
-cors_headers() ->
-    #{
-        <<"access-control-allow-origin">> => <<"*">>,
+%% Build the CORS headers for the current request. Echoes the
+%% validated `Origin' (no wildcard); omits `Access-Control-Allow-Origin'
+%% when the request had no Origin header. The allowed-headers list is
+%% derived from the configured auth provider so custom headers
+%% (e.g. `X-API-Key', a custom `header_name') are honoured.
+-spec cors_response_headers(cowboy_req:req(), map(), map()) -> map().
+cors_response_headers(Req, State, Extra) ->
+    BaseAllowHeaders = [<<"content-type">>, <<"accept">>,
+                        <<"mcp-session-id">>, <<"mcp-protocol-version">>,
+                        <<"last-event-id">>],
+    AuthHeaders = case maps:get(auth_config, State, undefined) of
+                      undefined -> [];
+                      AC -> barrel_mcp_auth:auth_headers(AC)
+                  end,
+    AllowHeaders = lists:join(<<", ">>, BaseAllowHeaders ++ AuthHeaders),
+    ExposeHeaders = <<"www-authenticate, mcp-session-id, mcp-protocol-version">>,
+    Base = #{
         <<"access-control-allow-methods">> => <<"POST, GET, DELETE, OPTIONS">>,
-        <<"access-control-allow-headers">> => <<"content-type, authorization, x-api-key, mcp-session-id, mcp-protocol-version, accept, last-event-id">>,
-        <<"access-control-expose-headers">> => <<"www-authenticate, mcp-session-id, mcp-protocol-version">>
-    }.
+        <<"access-control-allow-headers">> => iolist_to_binary(AllowHeaders),
+        <<"access-control-expose-headers">> => ExposeHeaders
+    },
+    WithOrigin = case cowboy_req:header(<<"origin">>, Req) of
+                     undefined -> Base;
+                     Origin ->
+                         Base#{<<"access-control-allow-origin">> => Origin,
+                               <<"vary">> => <<"Origin">>}
+                 end,
+    maps:merge(WithOrigin, Extra).
+
+%%====================================================================
+%% Origin validation + bind helpers
+%%====================================================================
+
+%% Resolve the operator's `allowed_origins' input into the structural
+%% form used at request time. On loopback we provide a sensible
+%% default; on public binds the operator must opt in.
+resolve_allowed_origins(_Loopback, any) ->
+    {ok, any};
+resolve_allowed_origins(true, undefined) ->
+    {ok, default_loopback_origins()};
+resolve_allowed_origins(false, undefined) ->
+    {error, allowed_origins_required};
+resolve_allowed_origins(_Loopback, List) when is_list(List) ->
+    {ok, [parse_origin(O) || O <- List]}.
+
+default_loopback_origins() ->
+    [#{scheme => <<"http">>, host => <<"localhost">>, port => any},
+     #{scheme => <<"http">>, host => <<"127.0.0.1">>, port => any},
+     #{scheme => <<"http">>, host => <<"[::1]">>, port => any}].
+
+%% `<<"null">>' is special: browsers send it from sandboxed contexts.
+%% Encode it explicitly.
+parse_origin(<<"null">>) ->
+    null;
+parse_origin(Bin) when is_binary(Bin) ->
+    case uri_string:parse(Bin) of
+        #{scheme := Scheme, host := Host} = U ->
+            #{scheme => to_bin(Scheme),
+              host => to_bin(Host),
+              port => maps:get(port, U, any)};
+        _ ->
+            #{scheme => undefined, host => Bin, port => any}
+    end.
+
+is_loopback({127, _, _, _}) -> true;
+is_loopback({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
+is_loopback("localhost") -> true;
+is_loopback(<<"localhost">>) -> true;
+is_loopback(_) -> false.
+
+%% Validate the request's `Origin' against the configured allow-list.
+%% Returns `ok' on accept, `{error, Reason}' on reject.
+-spec validate_origin(cowboy_req:req(), map()) ->
+    ok | {error, atom()}.
+validate_origin(Req, State) ->
+    Allowed = maps:get(allowed_origins, State, any),
+    AllowMissing = maps:get(allow_missing_origin, State, true),
+    case cowboy_req:header(<<"origin">>, Req) of
+        undefined when AllowMissing -> ok;
+        undefined -> {error, missing_origin};
+        Origin -> match_origin(Origin, Allowed)
+    end.
+
+match_origin(_Origin, any) -> ok;
+match_origin(<<"null">>, Allowed) ->
+    case lists:member(null, Allowed) of
+        true -> ok;
+        false -> {error, origin_null_not_allowed}
+    end;
+match_origin(Origin, Allowed) ->
+    Parsed = parse_origin(Origin),
+    case lists:any(fun(A) -> origin_matches(A, Parsed) end, Allowed) of
+        true -> ok;
+        false -> {error, origin_not_allowed}
+    end.
+
+origin_matches(null, _) -> false;
+origin_matches(#{scheme := S, host := H, port := P}, Parsed) ->
+    SOk = (S =:= undefined) orelse (S =:= maps:get(scheme, Parsed)),
+    HOk = (H =:= maps:get(host, Parsed)),
+    POk = (P =:= any) orelse (P =:= maps:get(port, Parsed)),
+    SOk andalso HOk andalso POk;
+origin_matches(_, _) -> false.
+
+to_bin(B) when is_binary(B) -> B;
+to_bin(L) when is_list(L) -> iolist_to_binary(L).
 
 %%====================================================================
 %% Utilities

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -31,8 +31,10 @@
 %% API
 %%====================================================================
 
-%% @doc Decode a JSON-RPC request.
--spec decode(binary()) -> {ok, map()} | {error, term()}.
+%% @doc Decode a JSON-RPC request body. The spec includes `list()'
+%% in the success type so the HTTP transport can detect (and reject)
+%% JSON-RPC batches.
+-spec decode(binary()) -> {ok, map() | list()} | {error, term()}.
 decode(Binary) ->
     try
         {ok, json:decode(Binary)}
@@ -52,20 +54,30 @@ handle(Request) ->
     handle(Request, #{}).
 
 %% @doc Handle a JSON-RPC request with state.
--spec handle(map(), map()) -> map() | no_response.
+%%
+%% MCP forbids JSON-RPC batches (a top-level JSON array) — they are
+%% rejected here with `Invalid Request' so non-HTTP callers see the
+%% same error as the HTTP transport.
+-spec handle(map() | list(), map()) -> map() | no_response.
+handle(L, _State) when is_list(L) ->
+    error_response(null, ?JSONRPC_INVALID_REQUEST,
+                   <<"Batch requests are not supported">>);
 handle(#{<<"jsonrpc">> := <<"2.0">>, <<"method">> := Method} = Request, State) ->
-    Id = maps:get(<<"id">>, Request, undefined),
     Params = maps:get(<<"params">>, Request, #{}),
-    case Id of
-        undefined ->
-            %% Notification - no response expected
+    case maps:find(<<"id">>, Request) of
+        error ->
+            %% No id: this is a notification — no response.
             handle_notification(Method, Params, State),
             no_response;
-        _ ->
-            %% Request - response required
-            handle_request(Method, Params, Id, State)
+        {ok, Id} when is_binary(Id); is_integer(Id) ->
+            handle_request(Method, Params, Id, State);
+        {ok, _BadId} ->
+            %% MCP requires id to be a string or integer (and not
+            %% null). Anything else is an Invalid Request.
+            error_response(null, ?JSONRPC_INVALID_REQUEST,
+                           <<"Invalid Request: id must be a string or integer">>)
     end;
-handle(#{<<"id">> := Id}, _State) ->
+handle(#{<<"id">> := Id}, _State) when is_binary(Id); is_integer(Id) ->
     error_response(Id, ?JSONRPC_INVALID_REQUEST, <<"Invalid Request">>);
 handle(_, _State) ->
     error_response(null, ?JSONRPC_INVALID_REQUEST, <<"Invalid Request">>).
@@ -351,22 +363,33 @@ encode_error(Id, Code, Message) ->
     {response, Id :: term(), Result :: term()} |
     {error, Id :: term(), Code :: integer(), Message :: binary(), Data :: term()} |
     {invalid, term()}.
+decode_envelope(L) when is_list(L) ->
+    {invalid, batch_unsupported};
 decode_envelope(#{<<"jsonrpc">> := <<"2.0">>} = Msg) ->
     case {maps:find(<<"method">>, Msg),
           maps:find(<<"id">>, Msg),
           maps:find(<<"result">>, Msg),
           maps:find(<<"error">>, Msg)} of
-        {{ok, Method}, {ok, Id}, error, error} ->
+        {{ok, Method}, {ok, Id}, error, error}
+                when is_binary(Id) orelse is_integer(Id) ->
             {request, Id, Method, maps:get(<<"params">>, Msg, #{})};
+        {{ok, _Method}, {ok, _BadId}, error, error} ->
+            {invalid, bad_id};
         {{ok, Method}, error, error, error} ->
             {notification, Method, maps:get(<<"params">>, Msg, #{})};
-        {error, {ok, Id}, {ok, Result}, error} ->
+        {error, {ok, Id}, {ok, Result}, error}
+                when is_binary(Id) orelse is_integer(Id) ->
             {response, Id, Result};
-        {error, {ok, Id}, error, {ok, Err}} ->
+        {error, {ok, _BadId}, {ok, _Result}, error} ->
+            {invalid, bad_id};
+        {error, {ok, Id}, error, {ok, Err}}
+                when is_binary(Id) orelse is_integer(Id) ->
             Code = maps:get(<<"code">>, Err, ?JSONRPC_INTERNAL_ERROR),
             Message = maps:get(<<"message">>, Err, <<>>),
             Data = maps:get(<<"data">>, Err, undefined),
             {error, Id, Code, Message, Data};
+        {error, {ok, _BadId}, error, {ok, _Err}} ->
+            {invalid, bad_id};
         _ ->
             {invalid, malformed}
     end;

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -26,6 +26,9 @@
     set_client_capabilities/2,
     has_sampling/1,
     list_sampling_capable/0,
+    %% Negotiated protocol version (after `initialize').
+    set_protocol_version/2,
+    get_protocol_version/1,
     %% sse_pid management.
     set_sse_pid/2,
     get_sse_pid/1,
@@ -41,6 +44,8 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-include("barrel_mcp.hrl").
 
 -define(SESSION_TABLE, barrel_mcp_sessions).
 -define(SUBSCRIPTIONS_TABLE, barrel_mcp_resource_subs).
@@ -82,19 +87,7 @@ start_link() ->
         protocol_version => binary()
     }.
 create(Opts) ->
-    SessionId = generate_id(),
-    Now = erlang:system_time(millisecond),
-    Session = #mcp_session{
-        id = SessionId,
-        created_at = Now,
-        last_activity = Now,
-        client_info = maps:get(client_info, Opts, #{}),
-        client_capabilities = maps:get(client_capabilities, Opts, #{}),
-        protocol_version = maps:get(protocol_version, Opts, <<"2025-03-26">>),
-        sse_pid = undefined
-    },
-    true = ets:insert(?SESSION_TABLE, {SessionId, Session}),
-    {ok, SessionId}.
+    gen_server:call(?MODULE, {create, Opts}).
 
 %% @doc Get a session by ID.
 -spec get(binary()) -> {ok, map()} | {error, not_found}.
@@ -109,28 +102,12 @@ get(SessionId) ->
 %% @doc Update last activity timestamp.
 -spec update_activity(binary()) -> ok | {error, not_found}.
 update_activity(SessionId) ->
-    case ets:lookup(?SESSION_TABLE, SessionId) of
-        [{_, Session}] ->
-            Now = erlang:system_time(millisecond),
-            Updated = Session#mcp_session{last_activity = Now},
-            true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
-            ok;
-        [] ->
-            {error, not_found}
-    end.
+    gen_server:call(?MODULE, {update_activity, SessionId}).
 
 %% @doc Delete a session.
 -spec delete(binary()) -> ok.
 delete(SessionId) ->
-    %% Notify SSE process if exists
-    case ets:lookup(?SESSION_TABLE, SessionId) of
-        [{_, #mcp_session{sse_pid = Pid}}] when is_pid(Pid) ->
-            Pid ! session_terminated;
-        _ ->
-            ok
-    end,
-    true = ets:delete(?SESSION_TABLE, SessionId),
-    ok.
+    gen_server:call(?MODULE, {delete, SessionId}).
 
 %% @doc Generate a unique session ID.
 -spec generate_id() -> binary().
@@ -150,11 +127,24 @@ list() ->
 %% protocol handler after parsing the `initialize' request.
 -spec set_client_capabilities(binary(), map()) -> ok | {error, not_found}.
 set_client_capabilities(SessionId, Capabilities) when is_map(Capabilities) ->
+    gen_server:call(?MODULE, {set_client_capabilities, SessionId, Capabilities}).
+
+%% @doc Record the negotiated protocol version on a session. Called
+%% by the HTTP transport after a successful `initialize' so later
+%% requests on the same session can fall back to it when the client
+%% omits the `MCP-Protocol-Version' header.
+-spec set_protocol_version(binary(), binary()) -> ok | {error, not_found}.
+set_protocol_version(SessionId, Version) when is_binary(Version) ->
+    gen_server:call(?MODULE, {set_protocol_version, SessionId, Version}).
+
+%% @doc Look up the negotiated protocol version for a session.
+-spec get_protocol_version(binary()) -> {ok, binary()} | {error, not_found}.
+get_protocol_version(SessionId) ->
     case ets:lookup(?SESSION_TABLE, SessionId) of
-        [{_, Session}] ->
-            Updated = Session#mcp_session{client_capabilities = Capabilities},
-            true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
-            ok;
+        [{_, #mcp_session{protocol_version = V}}] when is_binary(V) ->
+            {ok, V};
+        [{_, _}] ->
+            {ok, ?MCP_PROTOCOL_VERSION};
         [] ->
             {error, not_found}
     end.
@@ -183,13 +173,7 @@ list_sampling_capable() ->
 %% @doc Set the SSE process pid for a session.
 -spec set_sse_pid(binary(), pid() | undefined) -> ok | {error, not_found}.
 set_sse_pid(SessionId, Pid) ->
-    case ets:lookup(?SESSION_TABLE, SessionId) of
-        [{_, Session}] ->
-            Updated = Session#mcp_session{sse_pid = Pid},
-            true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
-            ok;
-        [] -> {error, not_found}
-    end.
+    gen_server:call(?MODULE, {set_sse_pid, SessionId, Pid}).
 
 -spec get_sse_pid(binary()) -> {ok, pid()} | {error, not_found | no_sse}.
 get_sse_pid(SessionId) ->
@@ -203,15 +187,11 @@ get_sse_pid(SessionId) ->
 -spec subscribe_resource(binary(), binary()) -> ok.
 subscribe_resource(SessionId, Uri)
         when is_binary(SessionId), is_binary(Uri) ->
-    _ = ensure_subs_table(),
-    true = ets:insert(?SUBSCRIPTIONS_TABLE, {{SessionId, Uri}}),
-    ok.
+    gen_server:call(?MODULE, {subscribe_resource, SessionId, Uri}).
 
 -spec unsubscribe_resource(binary(), binary()) -> ok.
 unsubscribe_resource(SessionId, Uri) ->
-    _ = ensure_subs_table(),
-    true = ets:delete(?SUBSCRIPTIONS_TABLE, {SessionId, Uri}),
-    ok.
+    gen_server:call(?MODULE, {unsubscribe_resource, SessionId, Uri}).
 
 %% @doc Return all session ids that subscribed to a URI.
 -spec subscribers_for(binary()) -> [binary()].
@@ -243,30 +223,24 @@ sampling_create_message(SessionId, Params, Opts) ->
 %% `result' or `error' for a server-initiated id.
 -spec deliver_response(binary() | integer(), map()) -> ok | {error, unknown_id}.
 deliver_response(Id, Response) ->
-    Key = id_to_binary(Id),
-    _ = ensure_pending_table(),
-    case ets:lookup(?PENDING_TABLE, Key) of
-        [{_, #pending{caller = Caller, caller_ref = Ref}}] ->
-            true = ets:delete(?PENDING_TABLE, Key),
-            Caller ! {sampling_response, Ref, Response},
-            ok;
-        [] ->
-            {error, unknown_id}
-    end.
+    gen_server:call(?MODULE, {deliver_response, id_to_binary(Id), Response}).
 
-%% @doc Cleanup sessions older than TTL milliseconds.
+%% @doc Cleanup sessions older than TTL milliseconds. Routes through
+%% the gen_server (the table owner under the new `protected'
+%% visibility); the handler deletes expired entries inline.
 -spec cleanup_expired(pos_integer()) -> non_neg_integer().
 cleanup_expired(TTL) ->
-    Now = erlang:system_time(millisecond),
-    Cutoff = Now - TTL,
-    Expired = ets:foldl(fun({Id, #mcp_session{last_activity = LastActivity}}, Acc) ->
-        case LastActivity < Cutoff of
-            true -> [Id | Acc];
-            false -> Acc
-        end
-    end, [], ?SESSION_TABLE),
-    lists:foreach(fun(Id) -> delete(Id) end, Expired),
-    length(Expired).
+    gen_server:call(?MODULE, {cleanup_expired, TTL}).
+
+%% Inline session delete, only called from inside the gen_server.
+delete_inline(SessionId) ->
+    case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, #mcp_session{sse_pid = Pid}}] when is_pid(Pid) ->
+            Pid ! session_terminated;
+        _ -> ok
+    end,
+    true = ets:delete(?SESSION_TABLE, SessionId),
+    ok.
 
 %%====================================================================
 %% gen_server callbacks
@@ -280,6 +254,110 @@ init([]) ->
     %% Schedule periodic cleanup
     _ = erlang:send_after(?CLEANUP_INTERVAL, self(), cleanup),
     {ok, #{}}.
+
+handle_call({create, Opts}, _From, State) ->
+    SessionId = generate_id(),
+    Now = erlang:system_time(millisecond),
+    Session = #mcp_session{
+        id = SessionId,
+        created_at = Now,
+        last_activity = Now,
+        client_info = maps:get(client_info, Opts, #{}),
+        client_capabilities = maps:get(client_capabilities, Opts, #{}),
+        protocol_version = maps:get(protocol_version, Opts, <<"2025-03-26">>),
+        sse_pid = undefined
+    },
+    true = ets:insert(?SESSION_TABLE, {SessionId, Session}),
+    {reply, {ok, SessionId}, State};
+
+handle_call({update_activity, SessionId}, _From, State) ->
+    Reply = case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, Session}] ->
+            Now = erlang:system_time(millisecond),
+            Updated = Session#mcp_session{last_activity = Now},
+            true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
+            ok;
+        [] ->
+            {error, not_found}
+    end,
+    {reply, Reply, State};
+
+handle_call({delete, SessionId}, _From, State) ->
+    case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, #mcp_session{sse_pid = Pid}}] when is_pid(Pid) ->
+            Pid ! session_terminated;
+        _ -> ok
+    end,
+    true = ets:delete(?SESSION_TABLE, SessionId),
+    {reply, ok, State};
+
+handle_call({set_client_capabilities, SessionId, Caps}, _From, State) ->
+    Reply = case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, Session}] ->
+            Updated = Session#mcp_session{client_capabilities = Caps},
+            true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
+            ok;
+        [] -> {error, not_found}
+    end,
+    {reply, Reply, State};
+
+handle_call({set_protocol_version, SessionId, Version}, _From, State) ->
+    Reply = case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, Session}] ->
+            Updated = Session#mcp_session{protocol_version = Version},
+            true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
+            ok;
+        [] -> {error, not_found}
+    end,
+    {reply, Reply, State};
+
+handle_call({set_sse_pid, SessionId, Pid}, _From, State) ->
+    Reply = case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, Session}] ->
+            Updated = Session#mcp_session{sse_pid = Pid},
+            true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
+            ok;
+        [] -> {error, not_found}
+    end,
+    {reply, Reply, State};
+
+handle_call({subscribe_resource, SessionId, Uri}, _From, State) ->
+    true = ets:insert(?SUBSCRIPTIONS_TABLE, {{SessionId, Uri}}),
+    {reply, ok, State};
+
+handle_call({unsubscribe_resource, SessionId, Uri}, _From, State) ->
+    true = ets:delete(?SUBSCRIPTIONS_TABLE, {SessionId, Uri}),
+    {reply, ok, State};
+
+handle_call({register_pending, RequestId, Pending}, _From, State) ->
+    true = ets:insert(?PENDING_TABLE, {RequestId, Pending}),
+    {reply, ok, State};
+
+handle_call({discard_pending, RequestId}, _From, State) ->
+    true = ets:delete(?PENDING_TABLE, RequestId),
+    {reply, ok, State};
+
+handle_call({deliver_response, Key, Response}, _From, State) ->
+    Reply = case ets:lookup(?PENDING_TABLE, Key) of
+        [{_, #pending{caller = Caller, caller_ref = Ref}}] ->
+            true = ets:delete(?PENDING_TABLE, Key),
+            Caller ! {sampling_response, Ref, Response},
+            ok;
+        [] ->
+            {error, unknown_id}
+    end,
+    {reply, Reply, State};
+
+handle_call({cleanup_expired, TTL}, _From, State) ->
+    Now = erlang:system_time(millisecond),
+    Cutoff = Now - TTL,
+    Expired = ets:foldl(
+        fun({Id, #mcp_session{last_activity = LA}}, Acc)
+              when LA < Cutoff -> [Id | Acc];
+           (_, Acc) -> Acc
+        end, [], ?SESSION_TABLE),
+    lists:foreach(fun delete_inline/1, Expired),
+    {reply, length(Expired), State};
 
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
@@ -337,7 +415,7 @@ ensure_session_table() ->
     case ets:whereis(?SESSION_TABLE) of
         undefined ->
             ets:new(?SESSION_TABLE, [
-                named_table, public, set,
+                named_table, protected, set,
                 {read_concurrency, true},
                 {write_concurrency, true}
             ]);
@@ -348,7 +426,7 @@ ensure_subs_table() ->
     case ets:whereis(?SUBSCRIPTIONS_TABLE) of
         undefined ->
             ets:new(?SUBSCRIPTIONS_TABLE, [
-                named_table, public, set,
+                named_table, protected, set,
                 {read_concurrency, true}
             ]);
         _ -> ok
@@ -358,7 +436,7 @@ ensure_pending_table() ->
     case ets:whereis(?PENDING_TABLE) of
         undefined ->
             ets:new(?PENDING_TABLE, [
-                named_table, public, set,
+                named_table, protected, set,
                 {read_concurrency, true}
             ]);
         _ -> ok
@@ -368,15 +446,14 @@ do_sampling(SessionId, SsePid, Params, Opts) ->
     Timeout = maps:get(timeout_ms, Opts, ?DEFAULT_SAMPLING_TIMEOUT),
     RequestId = generate_request_id(),
     Ref = make_ref(),
-    Pending = #pending{
-        id = RequestId,
-        session_id = SessionId,
-        caller = self(),
-        caller_ref = Ref,
-        expires_at = erlang:system_time(millisecond) + Timeout
-    },
-    _ = ensure_pending_table(),
-    true = ets:insert(?PENDING_TABLE, {RequestId, Pending}),
+    ok = gen_server:call(?MODULE,
+        {register_pending, RequestId, #pending{
+            id = RequestId,
+            session_id = SessionId,
+            caller = self(),
+            caller_ref = Ref,
+            expires_at = erlang:system_time(millisecond) + Timeout
+        }}),
     Request = #{
         <<"jsonrpc">> => <<"2.0">>,
         <<"id">> => RequestId,
@@ -391,7 +468,7 @@ do_sampling(SessionId, SsePid, Params, Opts) ->
         {sampling_response, Ref, #{<<"error">> := Err}} ->
             {error, {client_error, Err}}
     after Timeout ->
-        true = ets:delete(?PENDING_TABLE, RequestId),
+        _ = gen_server:call(?MODULE, {discard_pending, RequestId}),
         {error, timeout}
     end.
 

--- a/test/barrel_mcp_http_stream_security_SUITE.erl
+++ b/test/barrel_mcp_http_stream_security_SUITE.erl
@@ -1,0 +1,320 @@
+%%%-------------------------------------------------------------------
+%%% @doc Security and spec-conformance suite for the Streamable HTTP
+%%% transport. Locks in the behaviour added by the transport
+%%% hardening change: Origin validation, default loopback bind,
+%%% session 400/404 distinction, MCP-Protocol-Version validation,
+%%% notification 202 response shape, JSON-RPC id strictness, batch
+%%% rejection.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_http_stream_security_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1,
+         init_per_testcase/2, end_per_testcase/2]).
+-export([
+    origin_loopback_default_allows/1,
+    origin_loopback_rejects_external/1,
+    origin_null_rejected_by_default/1,
+    public_bind_requires_allowed_origins/1,
+    session_init_creates/1,
+    session_missing_returns_400/1,
+    session_unknown_returns_404/1,
+    notification_returns_202/1,
+    response_post_returns_202/1,
+    protocol_version_unsupported_returns_400/1,
+    protocol_version_present_supported_ok/1,
+    batch_rejected/1,
+    id_null_rejected/1,
+    id_object_rejected/1,
+    ets_session_table_protected/1
+]).
+
+-define(BASE_PORT, 21100).
+
+all() -> [
+    origin_loopback_default_allows,
+    origin_loopback_rejects_external,
+    origin_null_rejected_by_default,
+    public_bind_requires_allowed_origins,
+    session_init_creates,
+    session_missing_returns_400,
+    session_unknown_returns_404,
+    notification_returns_202,
+    response_post_returns_202,
+    protocol_version_unsupported_returns_400,
+    protocol_version_present_supported_ok,
+    batch_rejected,
+    id_null_rejected,
+    id_object_rejected,
+    ets_session_table_protected
+].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    {ok, _} = application:ensure_all_started(hackney),
+    Config.
+
+end_per_suite(_Config) ->
+    catch barrel_mcp:stop_http_stream(),
+    application:stop(barrel_mcp),
+    ok.
+
+init_per_testcase(TC, Config) ->
+    Port = ?BASE_PORT + erlang:phash2(TC, 100),
+    [{port, Port} | Config].
+
+end_per_testcase(_TC, _Config) ->
+    catch barrel_mcp:stop_http_stream(),
+    timer:sleep(50),
+    ok.
+
+%%====================================================================
+%% Origin validation
+%%====================================================================
+
+origin_loopback_default_allows(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    %% Loopback Origin is allowed by default.
+    {200, _, _} = post_init(Port, [{<<"origin">>, <<"http://localhost:5173">>}]),
+    ok.
+
+origin_loopback_rejects_external(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    {ok, 403, _, _} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>},
+         {<<"origin">>, <<"https://attacker.example">>}],
+        init_body(), [with_body]),
+    ok.
+
+origin_null_rejected_by_default(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    {ok, 403, _, _} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>},
+         {<<"origin">>, <<"null">>}],
+        init_body(), [with_body]),
+    ok.
+
+public_bind_requires_allowed_origins(_Config) ->
+    %% Bind 0.0.0.0 without explicit allowed_origins must refuse.
+    ?assertEqual({error, allowed_origins_required},
+                 barrel_mcp:start_http_stream(#{port => 21199,
+                                                ip => {0, 0, 0, 0}})).
+
+%%====================================================================
+%% Session lookup
+%%====================================================================
+
+session_init_creates(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => true}),
+    {200, Headers, _} = post_init(Port, []),
+    SessionId = proplists:get_value(<<"mcp-session-id">>, Headers),
+    ?assertMatch(<<"mcp_", _/binary>>, SessionId),
+    ok.
+
+session_missing_returns_400(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => true}),
+    %% A non-initialize request without Mcp-Session-Id is 400.
+    {ok, 400, _, _} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>}],
+        ping_body(), [with_body]),
+    ok.
+
+session_unknown_returns_404(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => true}),
+    {ok, 404, _, _} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>},
+         {<<"mcp-session-id">>, <<"mcp_not_a_real_session">>}],
+        ping_body(), [with_body]),
+    ok.
+
+%%====================================================================
+%% Response shape
+%%====================================================================
+
+notification_returns_202(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    Notif = json:encode(#{<<"jsonrpc">> => <<"2.0">>,
+                          <<"method">> => <<"notifications/initialized">>}),
+    {ok, 202, _, _} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>}],
+        Notif, [with_body]),
+    ok.
+
+response_post_returns_202(Config) ->
+    %% A JSON-RPC RESPONSE (carries result) for a server-initiated
+    %% request must return 202.
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    Resp = json:encode(#{<<"jsonrpc">> => <<"2.0">>,
+                         <<"id">> => <<"sampling-1">>,
+                         <<"result">> => #{<<"ok">> => true}}),
+    {ok, 202, _, _} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>}],
+        Resp, [with_body]),
+    ok.
+
+%%====================================================================
+%% Protocol version validation
+%%====================================================================
+
+protocol_version_unsupported_returns_400(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => true}),
+    {200, Headers, _} = post_init(Port, []),
+    SessionId = proplists:get_value(<<"mcp-session-id">>, Headers),
+    {ok, 400, _, _} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>},
+         {<<"mcp-session-id">>, SessionId},
+         {<<"mcp-protocol-version">>, <<"1999-01-01">>}],
+        ping_body(), [with_body]),
+    ok.
+
+protocol_version_present_supported_ok(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => true}),
+    {200, Headers, _} = post_init(Port, []),
+    SessionId = proplists:get_value(<<"mcp-session-id">>, Headers),
+    {ok, 200, _, _} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>},
+         {<<"mcp-session-id">>, SessionId},
+         {<<"mcp-protocol-version">>, <<"2025-11-25">>}],
+        ping_body(), [with_body]),
+    ok.
+
+%%====================================================================
+%% JSON-RPC strictness
+%%====================================================================
+
+batch_rejected(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    Batch = json:encode([#{<<"jsonrpc">> => <<"2.0">>,
+                           <<"id">> => 1,
+                           <<"method">> => <<"ping">>}]),
+    {ok, 400, _, Body} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>}],
+        Batch, [with_body]),
+    Resp = json:decode(Body),
+    ?assertEqual(-32600, maps:get(<<"code">>,
+                                  maps:get(<<"error">>, Resp))),
+    ok.
+
+id_null_rejected(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    Body0 = json:encode(#{<<"jsonrpc">> => <<"2.0">>,
+                          <<"id">> => null,
+                          <<"method">> => <<"ping">>}),
+    {ok, _, _, Body} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>}],
+        Body0, [with_body]),
+    Resp = json:decode(Body),
+    ?assertEqual(-32600, maps:get(<<"code">>,
+                                  maps:get(<<"error">>, Resp))).
+
+id_object_rejected(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    Body0 = json:encode(#{<<"jsonrpc">> => <<"2.0">>,
+                          <<"id">> => #{<<"foo">> => 1},
+                          <<"method">> => <<"ping">>}),
+    {ok, _, _, Body} = hackney:request(post,
+        url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>}],
+        Body0, [with_body]),
+    Resp = json:decode(Body),
+    ?assertEqual(-32600, maps:get(<<"code">>,
+                                  maps:get(<<"error">>, Resp))).
+
+%%====================================================================
+%% ETS visibility
+%%====================================================================
+
+ets_session_table_protected(_Config) ->
+    %% A non-owning process must not be able to write the session
+    %% table. We assert by attempting an `ets:insert/2' from the
+    %% test process, which is not the gen_server.
+    {ok, _Sid} = barrel_mcp_session:create(#{}),
+    Caught = try
+                 _ = ets:insert(barrel_mcp_sessions, {<<"x">>, dummy}),
+                 false
+             catch
+                 error:badarg -> true
+             end,
+    ?assert(Caught).
+
+%%====================================================================
+%% Helpers (no -include_lib for eunit here; it's at the top)
+%%====================================================================
+
+url(Port) ->
+    iolist_to_binary(io_lib:format("http://127.0.0.1:~B/mcp", [Port])).
+
+init_body() ->
+    json:encode(#{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => 1,
+        <<"method">> => <<"initialize">>,
+        <<"params">> => #{
+            <<"protocolVersion">> => <<"2025-11-25">>,
+            <<"capabilities">> => #{},
+            <<"clientInfo">> => #{<<"name">> => <<"sec-suite">>,
+                                  <<"version">> => <<"1.0">>}
+        }
+    }).
+
+ping_body() ->
+    json:encode(#{<<"jsonrpc">> => <<"2.0">>,
+                  <<"id">> => 99,
+                  <<"method">> => <<"ping">>}).
+
+post_init(Port, ExtraHeaders) ->
+    Headers = [{<<"content-type">>, <<"application/json">>},
+               {<<"accept">>, <<"application/json">>} | ExtraHeaders],
+    {ok, S, H, B} = hackney:request(post, url(Port), Headers,
+                                    init_body(), [with_body]),
+    {S, H, B}.

--- a/test/barrel_mcp_http_stream_tests.erl
+++ b/test/barrel_mcp_http_stream_tests.erl
@@ -74,7 +74,9 @@ test_start_stop() ->
     ok = barrel_mcp:stop_http_stream().
 
 test_post_json() ->
-    {ok, _} = barrel_mcp:start_http_stream(#{port => 19091}),
+    %% Sessions disabled — `ping' goes through without one.
+    {ok, _} = barrel_mcp:start_http_stream(#{port => 19091,
+                                             session_enabled => false}),
 
     Request = json:encode(#{
         <<"jsonrpc">> => <<"2.0">>,
@@ -90,11 +92,9 @@ test_post_json() ->
 
     ?assertEqual(200, Status),
 
-    %% Check content type
     ContentType = proplists:get_value(<<"content-type">>, Headers),
     ?assertEqual(<<"application/json">>, ContentType),
 
-    %% Parse response
     Response = json:decode(Body),
     ?assertEqual(<<"2.0">>, maps:get(<<"jsonrpc">>, Response)),
     ?assertEqual(1, maps:get(<<"id">>, Response)),
@@ -102,7 +102,8 @@ test_post_json() ->
     barrel_mcp:stop_http_stream().
 
 test_post_default_accept() ->
-    {ok, _} = barrel_mcp:start_http_stream(#{port => 19092}),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => 19092,
+                                             session_enabled => false}),
 
     Request = json:encode(#{
         <<"jsonrpc">> => <<"2.0">>,
@@ -110,7 +111,6 @@ test_post_default_accept() ->
         <<"method">> => <<"ping">>
     }),
 
-    %% Request without Accept header should default to JSON
     {ok, Status, Headers, _Body} = hackney:request(post,
         <<"http://localhost:19092/mcp">>,
         [{<<"content-type">>, <<"application/json">>}],
@@ -123,103 +123,88 @@ test_post_default_accept() ->
     barrel_mcp:stop_http_stream().
 
 test_options_cors() ->
-    {ok, _} = barrel_mcp:start_http_stream(#{port => 19093}),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => 19093,
+                                             session_enabled => false}),
 
-    {ok, Status, Headers, _Body} = hackney:request(options,
+    %% No Origin header: server omits Access-Control-Allow-Origin.
+    {ok, Status1, H1, _} = hackney:request(options,
         <<"http://localhost:19093/mcp">>,
         [], <<>>, []),
+    ?assertEqual(204, Status1),
+    ?assertEqual(undefined,
+                 proplists:get_value(<<"access-control-allow-origin">>, H1)),
 
-    ?assertEqual(204, Status),
-
-    %% Check CORS headers
-    ?assertEqual(<<"*">>, proplists:get_value(<<"access-control-allow-origin">>, Headers)),
-    ?assertMatch(<<"POST", _/binary>>, proplists:get_value(<<"access-control-allow-methods">>, Headers)),
+    %% With a loopback Origin: server echoes it back.
+    {ok, Status2, H2, _} = hackney:request(options,
+        <<"http://localhost:19093/mcp">>,
+        [{<<"origin">>, <<"http://localhost:5173">>}], <<>>, []),
+    ?assertEqual(204, Status2),
+    ?assertEqual(<<"http://localhost:5173">>,
+                 proplists:get_value(<<"access-control-allow-origin">>, H2)),
+    ?assertMatch(<<"POST", _/binary>>,
+                 proplists:get_value(<<"access-control-allow-methods">>, H2)),
 
     barrel_mcp:stop_http_stream().
 
 test_session_created() ->
     {ok, _} = barrel_mcp:start_http_stream(#{port => 19094, session_enabled => true}),
-
-    Request = json:encode(#{
-        <<"jsonrpc">> => <<"2.0">>,
-        <<"id">> => 1,
-        <<"method">> => <<"ping">>
-    }),
-
-    {ok, 200, Headers, _Body} = hackney:request(post,
-        <<"http://localhost:19094/mcp">>,
-        [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
-        Request, []),
-
-    %% Should have session ID in response
+    {200, Headers, _} = post_initialize(<<"http://localhost:19094/mcp">>),
     SessionId = proplists:get_value(<<"mcp-session-id">>, Headers),
     ?assertMatch(<<"mcp_", _/binary>>, SessionId),
-
     barrel_mcp:stop_http_stream().
 
 test_session_header() ->
     {ok, _} = barrel_mcp:start_http_stream(#{port => 19095, session_enabled => true}),
-
-    Request = json:encode(#{
-        <<"jsonrpc">> => <<"2.0">>,
-        <<"id">> => 1,
-        <<"method">> => <<"ping">>
-    }),
-
-    %% First request creates session
-    {ok, 200, Headers1, _Body1} = hackney:request(post,
-        <<"http://localhost:19095/mcp">>,
-        [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
-        Request, []),
-
+    %% First request: initialize creates a session.
+    {200, Headers1, _} = post_initialize(<<"http://localhost:19095/mcp">>),
     SessionId = proplists:get_value(<<"mcp-session-id">>, Headers1),
-
-    %% Second request with session ID
-    {ok, 200, Headers2, _Body2} = hackney:request(post,
+    %% Subsequent ping with the same id reuses the session.
+    Ping = json:encode(#{<<"jsonrpc">> => <<"2.0">>,
+                         <<"id">> => 2,
+                         <<"method">> => <<"ping">>}),
+    {ok, 200, Headers2, _} = hackney:request(post,
         <<"http://localhost:19095/mcp">>,
         [{<<"content-type">>, <<"application/json">>},
          {<<"accept">>, <<"application/json">>},
          {<<"mcp-session-id">>, SessionId}],
-        Request, []),
-
-    %% Should return same session ID
+        Ping, []),
     ?assertEqual(SessionId, proplists:get_value(<<"mcp-session-id">>, Headers2)),
-
     barrel_mcp:stop_http_stream().
 
 test_delete_session() ->
     {ok, _} = barrel_mcp:start_http_stream(#{port => 19096, session_enabled => true}),
+    {200, Headers, _} = post_initialize(<<"http://localhost:19096/mcp">>),
+    SessionId = proplists:get_value(<<"mcp-session-id">>, Headers),
+    {ok, Status, _, _} = hackney:request(delete,
+        <<"http://localhost:19096/mcp">>,
+        [{<<"mcp-session-id">>, SessionId}], <<>>, []),
+    ?assertEqual(204, Status),
+    barrel_mcp:stop_http_stream().
 
-    %% Create session
-    Request = json:encode(#{
+%% Helper: send an `initialize' request and return
+%% `{Status, Headers, Body}'.
+post_initialize(Url) ->
+    Body = json:encode(#{
         <<"jsonrpc">> => <<"2.0">>,
         <<"id">> => 1,
-        <<"method">> => <<"ping">>
+        <<"method">> => <<"initialize">>,
+        <<"params">> => #{
+            <<"protocolVersion">> => <<"2025-11-25">>,
+            <<"capabilities">> => #{},
+            <<"clientInfo">> => #{<<"name">> => <<"test">>,
+                                  <<"version">> => <<"1.0">>}
+        }
     }),
-
-    {ok, 200, Headers, _Body} = hackney:request(post,
-        <<"http://localhost:19096/mcp">>,
+    {ok, S, H, Resp} = hackney:request(post, Url,
         [{<<"content-type">>, <<"application/json">>},
          {<<"accept">>, <<"application/json">>}],
-        Request, []),
-
-    SessionId = proplists:get_value(<<"mcp-session-id">>, Headers),
-
-    %% Delete session
-    {ok, Status, _, _Body2} = hackney:request(delete,
-        <<"http://localhost:19096/mcp">>,
-        [{<<"mcp-session-id">>, SessionId}],
-        <<>>, []),
-
-    ?assertEqual(204, Status),
-
-    barrel_mcp:stop_http_stream().
+        Body, [with_body]),
+    {S, H, Resp}.
 
 test_auth_required() ->
     {ok, _} = barrel_mcp:start_http_stream(#{
         port => 19097,
+        session_enabled => false,
         auth => #{
             provider => barrel_mcp_auth_apikey,
             provider_opts => #{
@@ -234,7 +219,6 @@ test_auth_required() ->
         <<"method">> => <<"ping">>
     }),
 
-    %% Request without API key should fail
     {ok, Status, _, _Body} = hackney:request(post,
         <<"http://localhost:19097/mcp">>,
         [{<<"content-type">>, <<"application/json">>},
@@ -248,6 +232,7 @@ test_auth_required() ->
 test_auth_valid() ->
     {ok, _} = barrel_mcp:start_http_stream(#{
         port => 19098,
+        session_enabled => false,
         auth => #{
             provider => barrel_mcp_auth_apikey,
             provider_opts => #{
@@ -262,7 +247,6 @@ test_auth_valid() ->
         <<"method">> => <<"ping">>
     }),
 
-    %% Request with valid API key should succeed
     {ok, Status, _, _Body} = hackney:request(post,
         <<"http://localhost:19098/mcp">>,
         [{<<"content-type">>, <<"application/json">>},

--- a/test/barrel_mcp_protocol_envelope_tests.erl
+++ b/test/barrel_mcp_protocol_envelope_tests.erl
@@ -45,3 +45,72 @@ decode_error_test() ->
 decode_invalid_test() ->
     ?assertMatch({invalid, _},
                  barrel_mcp_protocol:decode_envelope(#{})).
+
+%%====================================================================
+%% Strictness: ids and batches
+%%====================================================================
+
+decode_id_null_is_invalid_test() ->
+    ?assertEqual({invalid, bad_id},
+                 barrel_mcp_protocol:decode_envelope(
+                   #{<<"jsonrpc">> => <<"2.0">>,
+                     <<"id">> => null,
+                     <<"method">> => <<"ping">>})).
+
+decode_id_object_is_invalid_test() ->
+    ?assertEqual({invalid, bad_id},
+                 barrel_mcp_protocol:decode_envelope(
+                   #{<<"jsonrpc">> => <<"2.0">>,
+                     <<"id">> => #{<<"foo">> => 1},
+                     <<"method">> => <<"ping">>})).
+
+decode_batch_is_invalid_test() ->
+    ?assertEqual({invalid, batch_unsupported},
+                 barrel_mcp_protocol:decode_envelope(
+                   [#{<<"jsonrpc">> => <<"2.0">>,
+                      <<"id">> => 1,
+                      <<"method">> => <<"ping">>}])).
+
+handle_id_null_returns_invalid_request_test() ->
+    Resp = barrel_mcp_protocol:handle(
+             #{<<"jsonrpc">> => <<"2.0">>,
+               <<"id">> => null,
+               <<"method">> => <<"ping">>}),
+    ?assertMatch(#{<<"error">> := #{<<"code">> := -32600}}, Resp).
+
+handle_id_object_returns_invalid_request_test() ->
+    Resp = barrel_mcp_protocol:handle(
+             #{<<"jsonrpc">> => <<"2.0">>,
+               <<"id">> => #{<<"foo">> => 1},
+               <<"method">> => <<"ping">>}),
+    ?assertMatch(#{<<"error">> := #{<<"code">> := -32600}}, Resp).
+
+handle_id_integer_ok_test() ->
+    Resp = barrel_mcp_protocol:handle(
+             #{<<"jsonrpc">> => <<"2.0">>,
+               <<"id">> => 42,
+               <<"method">> => <<"ping">>}),
+    ?assertMatch(#{<<"result">> := _, <<"id">> := 42}, Resp).
+
+handle_id_binary_ok_test() ->
+    Resp = barrel_mcp_protocol:handle(
+             #{<<"jsonrpc">> => <<"2.0">>,
+               <<"id">> => <<"abc">>,
+               <<"method">> => <<"ping">>}),
+    ?assertMatch(#{<<"result">> := _, <<"id">> := <<"abc">>}, Resp).
+
+handle_notification_returns_no_response_test() ->
+    ?assertEqual(no_response,
+                 barrel_mcp_protocol:handle(
+                   #{<<"jsonrpc">> => <<"2.0">>,
+                     <<"method">> => <<"notifications/initialized">>})).
+
+handle_batch_returns_invalid_request_test() ->
+    Resp = barrel_mcp_protocol:handle([
+        #{<<"jsonrpc">> => <<"2.0">>, <<"id">> => 1,
+          <<"method">> => <<"ping">>}
+    ]),
+    ?assertMatch(#{<<"error">> := #{<<"code">> := -32600,
+                                    <<"message">> :=
+                                        <<"Batch requests are not supported">>}},
+                 Resp).


### PR DESCRIPTION
Closes the security and JSON-RPC strictness gaps surfaced in the spec review.

- Origin validation (structural URI match) on POST/GET/DELETE/OPTIONS, with `allowed_origins` and `allow_missing_origin` opts. Literal `Origin: null` rejected unless explicitly allowed.
- Default bind to `127.0.0.1`; public bind requires `allowed_origins` or refuses with `{error, allowed_origins_required}`.
- CORS now echoes the validated `Origin` (no wildcard), adds `Vary: Origin`, and builds `Access-Control-Allow-Headers` from the configured auth provider via a new `auth_headers/1` callback. Custom `header_name` flows through both CORS and `extract_headers`.
- Notifications and POSTed responses to server-initiated requests return **202**. Missing `Mcp-Session-Id` on a non-initialize request returns **400**; unknown id returns **404**.
- `MCP-Protocol-Version` validated server-side: unsupported → 400; missing falls back to the session-stored value; pre-init defaults to `2025-03-26`.
- Reject JSON-RPC ids that are not string/integer (including `null`) with -32600. Reject top-level JSON arrays as `Batch requests are not supported`.
- Session ETS tables are now `protected`; every public mutator routes through the gen_server. New regression test asserts non-owners can't write the table.