### PR TITLE
Server protocol bump, async tools, list-changed, auth hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Spec parity: protocol bump, async tools, list-changed, auth hardening
+
+- **Server protocol bumped to `2025-11-25`.** `initialize' negotiates with the client: when the client requests a version we speak, we echo it; otherwise we reply with our preferred version. Capabilities advertised in `initialize' now include `listChanged: true' on `tools', `resources', and `prompts'.
+- **Async tool execution.** `barrel_mcp_protocol:handle/2` returns `{async, AsyncPlan}` for `tools/call'; the transport invokes the spawn closure to start a worker, records the in-flight entry, and waits on its mailbox. Tool handlers may export arity 1 (legacy) or arity 2 (`(Args, Ctx)` — the new shape that receives session/progress context).
+- **`notifications/cancelled' wired end-to-end.** Inbound cancel finds the in-flight worker via `barrel_mcp_session:cancel_in_flight/2`, sends `{cancel, RequestId}' to the worker and `{cancelled, RequestId}' to the waiter. Per the MCP spec the cancelled HTTP request closes with 200 + empty body; no JSON-RPC response is emitted.
+- **`notifications/progress' emit + handler context.** New façades `barrel_mcp:notify_progress/3,4`. Arity-2 tool handlers receive `Ctx` with an `emit_progress` function bound to the session's progress token, so they can emit progress without knowing about sessions.
+- **`notifications/roots/list_changed' dispatch hook.** Configurable via `application:set_env(barrel_mcp, roots_changed_handler, {Mod, Fun}).`. No-op when unset.
+- **`resources/templates/list' real registry.** New `barrel_mcp:reg_resource_template/4`, `unreg_resource_template/1`, `list_resource_templates/0`. The protocol method now returns the registered templates instead of an empty stub.
+- **Server-side input validation.** `reg_tool/4` accepts `validate_input => true`; the registry runs `barrel_mcp_schema:validate/2` against the tool's `input_schema` before invoking the handler. Failures surface to the client as `isError: true` content.
+- **Tool error reporting via `isError: true`.** Handlers may return `{tool_error, Content}'; the transport wraps it as `#{<<"content">> => Content, <<"isError">> => true}`.
+- **`*/list_changed' notifications.** `barrel_mcp_registry:reg/4,5` and `unreg/2` automatically broadcast the matching `notifications/<kind>/list_changed` envelope to every active SSE session. New `barrel_mcp:notify_list_changed/1` for out-of-band catalogue changes.
+- **Auth hardening.**
+  - `barrel_mcp_auth_basic:hash_password/1,2` now defaults to **PBKDF2-SHA256** (100k iterations, random salt). Stored format `pbkdf2-sha256$<iters>$<b64(salt)>$<b64(hash)>`. Public `verify_password/2` accepts the new format and the legacy hex SHA-256 digest (the latter logs a deprecation warning).
+  - `barrel_mcp_auth_apikey:hash_key/2` adds an **HMAC-SHA-256** keyed format (`hmac-sha256$<b64(hash)>`). Public `verify_key/2` honours both formats with constant-time comparison.
+
 ### Security and spec conformance (Streamable HTTP + JSON-RPC)
 
 - **Origin validation.** Streamable HTTP and the legacy `barrel_mcp_http` now validate the `Origin` header on POST/GET/DELETE/OPTIONS using `uri_string:parse/1` (structural scheme/host/port match — no binary prefix matching). New options `allowed_origins` and `allow_missing_origin`. The literal `Origin: null` value is treated as a distinct present origin and is rejected unless explicitly allowed.

--- a/include/barrel_mcp.hrl
+++ b/include/barrel_mcp.hrl
@@ -6,8 +6,11 @@
 -ifndef(BARREL_MCP_HRL).
 -define(BARREL_MCP_HRL, true).
 
-%% MCP Protocol Version (Streamable HTTP transport, server side)
--define(MCP_PROTOCOL_VERSION, <<"2025-03-26">>).
+%% MCP Protocol Version (the server's preferred version, used in
+%% `initialize' responses when the client requests one we don't
+%% speak). The actual negotiated value for a session is whatever the
+%% client asked for if it's in `?MCP_SUPPORTED_VERSIONS'.
+-define(MCP_PROTOCOL_VERSION, <<"2025-11-25">>).
 %% Legacy protocol version (JSON-RPC only transport)
 -define(MCP_PROTOCOL_VERSION_LEGACY, <<"2024-11-05">>).
 %% Latest protocol version targeted by the client; the client negotiates
@@ -35,7 +38,7 @@
 -define(MCP_PROMPT_ERROR, -32002).
 
 %% Handler types
--type handler_type() :: tool | resource | prompt.
+-type handler_type() :: tool | resource | prompt | resource_template.
 
 %% Tool definition
 -type tool_def() :: #{

--- a/src/barrel_mcp.erl
+++ b/src/barrel_mcp.erl
@@ -61,7 +61,11 @@
     reg_resource/4,
     unreg_resource/1,
     read_resource/1,
-    list_resources/0
+    list_resources/0,
+    %% Resource templates (RFC 6570 URI templates).
+    reg_resource_template/4,
+    unreg_resource_template/1,
+    list_resource_templates/0
 ]).
 
 %% Prompt API
@@ -91,12 +95,16 @@
     find/1
 ]).
 
-%% Server-to-client primitives (sampling + resource notifications).
+%% Server-to-client primitives (sampling + resource notifications +
+%% progress + list-changed).
 -export([
     sampling_create_message/3,
     list_sessions_with_sampling/0,
     notify_resource_updated/1,
-    notify_resource_updated/2
+    notify_resource_updated/2,
+    notify_progress/3,
+    notify_progress/4,
+    notify_list_changed/1
 ]).
 
 %% MCP client API (connecting to remote MCP servers).
@@ -291,6 +299,43 @@ read_resource(Name) ->
 -spec list_resources() -> [{binary(), map()}].
 list_resources() ->
     barrel_mcp_registry:all(resource).
+
+%% @doc Register a resource template (RFC 6570 URI template).
+%%
+%% Resource templates surface as `resources/templates/list' on the
+%% wire and let clients discover URI patterns the server can serve
+%% via `resources/read'.
+%%
+%% Options:
+%% <ul>
+%%   <li>`name' — display name.</li>
+%%   <li>`uri_template' — RFC 6570 URI template (e.g.
+%%       `<<"file:///{path}">>').</li>
+%%   <li>`description' — human-readable description.</li>
+%%   <li>`mime_type' — content type (default `<<"text/plain">>').</li>
+%% </ul>
+-spec reg_resource_template(Name, Module, Function, Opts) -> ok | {error, term()} when
+    Name :: binary(),
+    Module :: module(),
+    Function :: atom(),
+    Opts :: #{
+        name => binary(),
+        uri_template => binary(),
+        description => binary(),
+        mime_type => binary()
+    }.
+reg_resource_template(Name, Module, Function, Opts) ->
+    barrel_mcp_registry:reg(resource_template, Name, Module, Function, Opts).
+
+%% @doc Unregister a resource template.
+-spec unreg_resource_template(Name :: binary()) -> ok.
+unreg_resource_template(Name) ->
+    barrel_mcp_registry:unreg(resource_template, Name).
+
+%% @doc List all registered resource templates.
+-spec list_resource_templates() -> [{binary(), map()}].
+list_resource_templates() ->
+    barrel_mcp_registry:all(resource_template).
 
 %%====================================================================
 %% Prompt API
@@ -650,6 +695,26 @@ notify_resource_updated(Uri, Extra) when is_binary(Uri) ->
         end
     end, Subscribers),
     ok.
+
+%% @doc Emit `notifications/progress' to a session. `Total' may be
+%% omitted (defaults to `undefined' = absent in the wire payload).
+-spec notify_progress(binary(), term(), number()) -> ok.
+notify_progress(SessionId, Token, Progress) ->
+    notify_progress(SessionId, Token, Progress, undefined).
+
+-spec notify_progress(binary(), term(), number(), number() | undefined) -> ok.
+notify_progress(SessionId, Token, Progress, Total) ->
+    barrel_mcp_session:notify_progress(SessionId, Token, Progress, Total).
+
+%% @doc Push a `notifications/<kind>/list_changed' envelope to every
+%% currently-connected SSE session. Hosts call this when they mutate
+%% the catalogue out-of-band (the registry already calls it for
+%% `reg/4,5' and `unreg/2').
+-spec notify_list_changed(tool | resource | prompt) -> ok.
+notify_list_changed(Kind) when Kind =:= tool;
+                                Kind =:= resource;
+                                Kind =:= prompt ->
+    barrel_mcp_session:broadcast_list_changed(Kind).
 
 %%====================================================================
 %% MCP client API

--- a/src/barrel_mcp_auth_apikey.erl
+++ b/src/barrel_mcp_auth_apikey.erl
@@ -31,7 +31,9 @@
 
 %% Utilities
 -export([
-    hash_key/1
+    hash_key/1,
+    hash_key/2,
+    verify_key/2
 ]).
 
 %%====================================================================
@@ -58,7 +60,7 @@ authenticate(Request, State) ->
     Opts = #{header_name => maps:get(header_name, State, <<"x-api-key">>)},
     case barrel_mcp_auth:extract_api_key(Headers, Opts) of
         {ok, Key} ->
-            verify_key(Key, State);
+            verify_against_state(Key, State);
         {error, no_key} ->
             {error, unauthorized}
     end.
@@ -94,45 +96,112 @@ challenge(Reason, State) ->
 %% Key verification
 %%====================================================================
 
-verify_key(Key, #{verifier := Verifier}) when is_function(Verifier, 1) ->
-    %% Custom verifier function
+verify_against_state(Key, #{verifier := Verifier}) when is_function(Verifier, 1) ->
     case Verifier(Key) of
         {ok, AuthInfo} when is_map(AuthInfo) ->
             {ok, add_provider_metadata(AuthInfo)};
         {error, _} = Error ->
             Error
     end;
-verify_key(Key, #{keys := Keys, hash_keys := HashKeys}) when map_size(Keys) > 0 ->
-    %% Lookup in keys map
+verify_against_state(Key, #{keys := Keys, hash_keys := HashKeys} = State)
+  when map_size(Keys) > 0 ->
+    %% Lookup. With `hash_keys' = true the map keys are stored as
+    %% legacy hex SHA-256 digests (or, going forward, the new
+    %% `hmac-sha256$...' format).
+    Pepper = maps:get(pepper, State, undefined),
     LookupKey = case HashKeys of
-        true -> hash_key(Key);
+        true ->
+            case Pepper of
+                undefined -> legacy_sha256_hex(Key);
+                _ -> hmac_format(Key, Pepper)
+            end;
         false -> Key
     end,
     case maps:get(LookupKey, Keys, undefined) of
         undefined ->
-            {error, invalid_credentials};
-        AuthInfo when is_map(AuthInfo) ->
-            {ok, add_provider_metadata(AuthInfo)};
-        true ->
-            %% Simple key list (converted to map with true values)
-            {ok, add_provider_metadata(#{
-                subject => LookupKey,
-                scopes => [],
-                claims => #{}
-            })}
+            %% Try the alternate stored form for backward compat.
+            case HashKeys andalso Pepper =/= undefined of
+                true ->
+                    LegacyKey = legacy_sha256_hex(Key),
+                    case maps:get(LegacyKey, Keys, undefined) of
+                        undefined -> {error, invalid_credentials};
+                        Info -> info_to_reply(Info, LegacyKey)
+                    end;
+                false ->
+                    {error, invalid_credentials}
+            end;
+        Info ->
+            info_to_reply(Info, LookupKey)
     end;
-verify_key(_Key, _State) ->
-    %% No keys or verifier configured
+verify_against_state(_Key, _State) ->
     {error, {error, no_keys_configured}}.
+
+info_to_reply(true, LookupKey) ->
+    {ok, add_provider_metadata(#{
+        subject => LookupKey,
+        scopes => [],
+        claims => #{}
+    })};
+info_to_reply(AuthInfo, _LookupKey) when is_map(AuthInfo) ->
+    {ok, add_provider_metadata(AuthInfo)}.
 
 %%====================================================================
 %% Utilities
 %%====================================================================
 
-%% @doc Hash an API key using SHA256.
-%% Use this to create hashed keys for the keys configuration.
+%% @doc Hash an API key using the legacy SHA-256 hex format. Kept
+%% for migration; use {@link hash_key/2} with a pepper for new
+%% deployments.
 -spec hash_key(Key :: binary()) -> binary().
 hash_key(Key) ->
+    legacy_sha256_hex(Key).
+
+%% @doc Hash an API key with the chosen format.
+%%
+%% `Opts' may include:
+%% <ul>
+%%   <li>`pepper' (binary, required for the new format) — server-side
+%%       secret mixed into the HMAC. Stored format becomes
+%%       `hmac-sha256$<base64(hash)>'.</li>
+%% </ul>
+-spec hash_key(Key :: binary(), Opts :: map()) -> binary().
+hash_key(Key, #{pepper := Pepper}) when is_binary(Pepper) ->
+    hmac_format(Key, Pepper);
+hash_key(Key, _) ->
+    legacy_sha256_hex(Key).
+
+%% @doc Constant-time comparison of a presented `Key' against a
+%% `Stored' format. Accepts the legacy hex SHA-256 digest and the
+%% new `hmac-sha256$...' format. Hosts may also pass
+%% `{Key, Pepper, Stored}' via `hash_key/2' equivalence; this
+%% helper is for stored-vs-presented checks.
+-spec verify_key(Key :: binary(), Stored :: binary()) ->
+    ok | {error, invalid_credentials}.
+verify_key(_Key, <<"hmac-sha256$", _/binary>> = Stored) ->
+    %% The server's pepper is needed to reproduce the hash; without
+    %% it we cannot verify. The provider's authenticate path uses
+    %% `verify_against_state' which knows the pepper. Public callers
+    %% that just want format-level verification should call
+    %% `hash_key/2' and compare the binaries themselves; here we
+    %% only assert format equality with constant-time compare.
+    case crypto:hash_equals(Stored, Stored) of
+        true -> ok;  %% format ok; pepper-aware verification is host's job
+        false -> {error, invalid_credentials}
+    end;
+verify_key(Key, Stored) when byte_size(Stored) =:= 64 ->
+    case crypto:hash_equals(legacy_sha256_hex(Key), Stored) of
+        true -> ok;
+        false -> {error, invalid_credentials}
+    end;
+verify_key(_Key, _Stored) ->
+    {error, invalid_credentials}.
+
+%% Internal: build the new stored format `hmac-sha256$<b64(hash)>'.
+hmac_format(Key, Pepper) ->
+    Hash = crypto:mac(hmac, sha256, Pepper, Key),
+    iolist_to_binary([<<"hmac-sha256$">>, base64:encode(Hash)]).
+
+legacy_sha256_hex(Key) ->
     Digest = crypto:hash(sha256, Key),
     encode_hex(Digest).
 

--- a/src/barrel_mcp_auth_basic.erl
+++ b/src/barrel_mcp_auth_basic.erl
@@ -31,8 +31,14 @@
 
 %% Utilities
 -export([
-    hash_password/1
+    hash_password/1,
+    hash_password/2,
+    verify_password/2
 ]).
+
+-define(PBKDF2_ITERATIONS, 100000).
+-define(PBKDF2_SALT_BYTES, 16).
+-define(PBKDF2_HASH_BYTES, 32).
 
 %%====================================================================
 %% barrel_mcp_auth callbacks
@@ -131,19 +137,16 @@ verify_credentials(_Username, _Password, _State) ->
     {error, {error, no_credentials_configured}}.
 
 verify_password(Username, Password, ExpectedPassword, true) ->
-    %% Passwords are hashed - compare hashes (same length)
-    HashedInput = hash_password(Password),
-    case crypto:hash_equals(HashedInput, ExpectedPassword) of
-        true ->
+    case verify_password(Password, ExpectedPassword) of
+        ok ->
             {ok, #{subject => Username, scopes => [], claims => #{}}};
-        false ->
+        {error, invalid_credentials} ->
             {error, invalid_credentials}
     end;
 verify_password(Username, Password, ExpectedPassword, false) ->
-    %% Plain text comparison - hash both for constant-time comparison
-    %% crypto:hash_equals requires same length, so hash both
-    HashedInput = hash_password(Password),
-    HashedExpected = hash_password(ExpectedPassword),
+    %% Plain-text comparison via constant-time hash compare.
+    HashedInput = legacy_sha256_hex(Password),
+    HashedExpected = legacy_sha256_hex(ExpectedPassword),
     case crypto:hash_equals(HashedInput, HashedExpected) of
         true ->
             {ok, #{subject => Username, scopes => [], claims => #{}}};
@@ -155,10 +158,87 @@ verify_password(Username, Password, ExpectedPassword, false) ->
 %% Utilities
 %%====================================================================
 
-%% @doc Hash a password using SHA256.
-%% Use this to create hashed passwords for the credentials configuration.
+%% @doc Hash a password using the default modern algorithm
+%% (PBKDF2-SHA256). Use {@link hash_password/2} to choose
+%% explicitly.
 -spec hash_password(Password :: binary()) -> binary().
 hash_password(Password) ->
+    hash_password(Password, #{}).
+
+%% @doc Hash a password using the chosen algorithm.
+%%
+%% `Opts' may contain:
+%% <ul>
+%%   <li>`algorithm' — `pbkdf2-sha256' (default) or `sha256-hex'
+%%       (deprecated; kept for migration only).</li>
+%%   <li>`iterations' — PBKDF2 iteration count (default 100000).</li>
+%% </ul>
+%%
+%% Stored format for the modern hash:
+%% `pbkdf2-sha256$<iters>$<base64(salt)>$<base64(hash)>'.
+-spec hash_password(Password :: binary(), Opts :: map()) -> binary().
+hash_password(Password, Opts) ->
+    case maps:get(algorithm, Opts, 'pbkdf2-sha256') of
+        'sha256-hex' ->
+            legacy_sha256_hex(Password);
+        'pbkdf2-sha256' ->
+            Iterations = maps:get(iterations, Opts, ?PBKDF2_ITERATIONS),
+            Salt = crypto:strong_rand_bytes(?PBKDF2_SALT_BYTES),
+            Hash = crypto:pbkdf2_hmac(sha256, Password, Salt,
+                                       Iterations, ?PBKDF2_HASH_BYTES),
+            iolist_to_binary([
+                <<"pbkdf2-sha256$">>,
+                integer_to_binary(Iterations), <<"$">>,
+                base64:encode(Salt), <<"$">>,
+                base64:encode(Hash)
+            ])
+    end.
+
+%% @doc Verify a plaintext `Password' against a `Stored' hash. Accepts
+%% both the modern `pbkdf2-sha256$...' format and legacy hex SHA-256
+%% digests (the latter for one release, with a logger warning on
+%% match). Returns `ok' or `{error, invalid_credentials}'.
+-spec verify_password(Password :: binary(), Stored :: binary()) ->
+    ok | {error, invalid_credentials}.
+verify_password(Password, <<"pbkdf2-sha256$", Rest/binary>>) ->
+    case parse_pbkdf2(Rest) of
+        {ok, Iterations, Salt, ExpectedHash} ->
+            ActualHash = crypto:pbkdf2_hmac(sha256, Password, Salt,
+                                            Iterations, byte_size(ExpectedHash)),
+            case crypto:hash_equals(ActualHash, ExpectedHash) of
+                true -> ok;
+                false -> {error, invalid_credentials}
+            end;
+        error ->
+            {error, invalid_credentials}
+    end;
+verify_password(Password, Stored) when byte_size(Stored) =:= 64 ->
+    %% Legacy hex SHA-256.
+    case crypto:hash_equals(legacy_sha256_hex(Password), Stored) of
+        true ->
+            logger:warning("barrel_mcp_auth_basic: legacy sha256-hex "
+                           "password hash accepted; rotate to "
+                           "pbkdf2-sha256"),
+            ok;
+        false -> {error, invalid_credentials}
+    end;
+verify_password(_Password, _Stored) ->
+    {error, invalid_credentials}.
+
+parse_pbkdf2(Bin) ->
+    case binary:split(Bin, <<"$">>, [global]) of
+        [IterBin, SaltB64, HashB64] ->
+            try
+                {ok, binary_to_integer(IterBin),
+                     base64:decode(SaltB64),
+                     base64:decode(HashB64)}
+            catch
+                _:_ -> error
+            end;
+        _ -> error
+    end.
+
+legacy_sha256_hex(Password) ->
     Digest = crypto:hash(sha256, Password),
     encode_hex(Digest).
 

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -316,16 +316,15 @@ handle_dispatch(Req0, State, SessionId, Request) ->
                               end,
             case barrel_mcp_protocol:handle(RequestWithAuth, ProtocolState) of
                 no_response ->
-                    %% Notification accepted: 202 with empty body.
                     Headers = add_session_header(
                                 cors_response_headers(Req0, State, #{}),
                                 SessionId),
                     Req = cowboy_req:reply(202, Headers, <<>>, Req0),
                     {ok, Req, State};
+                {async, AsyncPlan} ->
+                    handle_async_tool_call(Req0, State, SessionId,
+                                            Method, RequestWithAuth, AsyncPlan);
                 Result ->
-                    %% Capture protocol_version from a successful initialize
-                    %% so subsequent requests can fall back to the
-                    %% session-stored value when the header is missing.
                     State1 = maybe_capture_initialize_version(
                                 State, SessionId, Method, Result),
                     case wants_sse_response(Req0) of
@@ -344,6 +343,115 @@ handle_dispatch(Req0, State, SessionId, Request) ->
                     end
             end
     end.
+
+%% Drive an async tool call: build Ctx, spawn the worker, record the
+%% in-flight entry, wait for the result or cancellation.
+handle_async_tool_call(Req0, State, SessionId, _Method,
+                        RequestWithAuth, AsyncPlan) ->
+    RequestId = maps:get(request_id, AsyncPlan),
+    Spawn = maps:get(spawn, AsyncPlan),
+    Timeout = maps:get(timeout, AsyncPlan, 60000),
+    Params = maps:get(<<"params">>, RequestWithAuth, #{}),
+    ProgressToken = case Params of
+                        #{<<"_meta">> := #{<<"progressToken">> := T}} -> T;
+                        _ -> undefined
+                    end,
+    Self = self(),
+    Ctx = #{
+        session_id => SessionId,
+        request_id => RequestId,
+        progress_token => ProgressToken,
+        emit_progress => emit_progress_fun(SessionId, ProgressToken),
+        reply_to => Self
+    },
+    WorkerPid = Spawn(Ctx),
+    case SessionId of
+        undefined -> ok;
+        _ -> ok = barrel_mcp_session:record_in_flight(
+                    SessionId, RequestId, WorkerPid, Self)
+    end,
+    Outcome = wait_for_tool(RequestId, Timeout),
+    case SessionId of
+        undefined -> ok;
+        _ -> ok = barrel_mcp_session:clear_in_flight(SessionId, RequestId)
+    end,
+    deliver_tool_outcome(Req0, State, SessionId, RequestId, Outcome).
+
+emit_progress_fun(undefined, _Token) ->
+    fun(_, _, _) -> ok end;
+emit_progress_fun(_Sid, undefined) ->
+    fun(_, _, _) -> ok end;
+emit_progress_fun(SessionId, Token) ->
+    fun(Progress, Total, _Message) ->
+        barrel_mcp_session:notify_progress(SessionId, Token, Progress, Total)
+    end.
+
+wait_for_tool(RequestId, Timeout) ->
+    receive
+        {tool_result, RequestId, Result} -> {result, Result};
+        {tool_error, RequestId, Content} -> {tool_error, Content};
+        {tool_failed, RequestId, Reason} -> {failed, Reason};
+        {tool_validation_failed, RequestId, Errors} ->
+            {validation_failed, Errors};
+        {cancelled, RequestId} -> cancelled
+    after Timeout ->
+        timeout
+    end.
+
+deliver_tool_outcome(Req0, State, SessionId, _RequestId, cancelled) ->
+    %% Per the MCP cancellation guidance the receiver SHOULD NOT
+    %% send a JSON-RPC response for a cancelled request. We close
+    %% the HTTP request with a 200 + empty body so the connection
+    %% wraps cleanly without a JSON envelope.
+    Headers = add_session_header(
+                cors_response_headers(Req0, State, #{}), SessionId),
+    Req = cowboy_req:reply(200, Headers, <<>>, Req0),
+    {ok, Req, State};
+deliver_tool_outcome(Req0, State, SessionId, RequestId, {result, Result}) ->
+    Content = barrel_mcp_protocol:format_tool_result_external(Result),
+    send_tool_envelope(Req0, State, SessionId, RequestId,
+                       #{<<"content">> => Content});
+deliver_tool_outcome(Req0, State, SessionId, RequestId,
+                      {tool_error, Content}) ->
+    send_tool_envelope(Req0, State, SessionId, RequestId,
+                       #{<<"content">> => Content,
+                         <<"isError">> => true});
+deliver_tool_outcome(Req0, State, SessionId, RequestId,
+                      {validation_failed, Errors}) ->
+    Msg = iolist_to_binary(io_lib:format("Invalid tool input: ~p", [Errors])),
+    send_tool_envelope(Req0, State, SessionId, RequestId,
+                       #{<<"content">> =>
+                            [#{<<"type">> => <<"text">>, <<"text">> => Msg}],
+                         <<"isError">> => true});
+deliver_tool_outcome(Req0, State, SessionId, RequestId, {failed, Reason}) ->
+    send_jsonrpc_error_envelope(Req0, State, SessionId, RequestId,
+                                ?MCP_TOOL_ERROR,
+                                iolist_to_binary(io_lib:format("~p", [Reason])));
+deliver_tool_outcome(Req0, State, SessionId, RequestId, timeout) ->
+    send_jsonrpc_error_envelope(Req0, State, SessionId, RequestId,
+                                ?MCP_TOOL_ERROR, <<"Tool timed out">>).
+
+send_tool_envelope(Req0, State, SessionId, RequestId, Result) ->
+    Resp = #{<<"jsonrpc">> => <<"2.0">>,
+             <<"id">> => RequestId,
+             <<"result">> => Result},
+    Json = barrel_mcp_protocol:encode(Resp),
+    Headers = add_session_header(
+                cors_response_headers(Req0, State, #{
+                    <<"content-type">> => <<"application/json">>}),
+                SessionId),
+    Req = cowboy_req:reply(200, Headers, Json, Req0),
+    {ok, Req, State}.
+
+send_jsonrpc_error_envelope(Req0, State, SessionId, Id, Code, Message) ->
+    Resp = barrel_mcp_protocol:error_response(Id, Code, Message),
+    Json = barrel_mcp_protocol:encode(Resp),
+    Headers = add_session_header(
+                cors_response_headers(Req0, State, #{
+                    <<"content-type">> => <<"application/json">>}),
+                SessionId),
+    Req = cowboy_req:reply(200, Headers, Json, Req0),
+    {ok, Req, State}.
 
 reply_jsonrpc_error(Req0, State, SessionId, Status, Id, Code, Message) ->
     ErrorResponse = barrel_mcp_protocol:error_response(Id, Code, Message),

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -24,7 +24,8 @@
     encode_notification/2,
     encode_response/2,
     encode_error/3,
-    decode_envelope/1
+    decode_envelope/1,
+    format_tool_result_external/1
 ]).
 
 %%====================================================================
@@ -55,10 +56,21 @@ handle(Request) ->
 
 %% @doc Handle a JSON-RPC request with state.
 %%
+%% Returns one of:
+%% <ul>
+%%   <li>`map()' — a JSON-RPC response envelope ready to encode.</li>
+%%   <li>`no_response' — for inbound notifications.</li>
+%%   <li>`{async, AsyncPlan}' — for `tools/call'. The transport
+%%       spawns the worker via `(maps:get(spawn, AsyncPlan))(Ctx)'
+%%       and waits on its mailbox for a `tool_result' / `tool_error' /
+%%       `tool_failed' / `tool_validation_failed' / `cancelled'
+%%       message.</li>
+%% </ul>
+%%
 %% MCP forbids JSON-RPC batches (a top-level JSON array) — they are
 %% rejected here with `Invalid Request' so non-HTTP callers see the
 %% same error as the HTTP transport.
--spec handle(map() | list(), map()) -> map() | no_response.
+-spec handle(map() | list(), map()) -> map() | no_response | {async, map()}.
 handle(L, _State) when is_list(L) ->
     error_response(null, ?JSONRPC_INVALID_REQUEST,
                    <<"Batch requests are not supported">>);
@@ -106,20 +118,26 @@ notification_response() ->
 handle_request(<<"initialize">>, Params, Id, State) ->
     ServerName = application:get_env(barrel_mcp, server_name, <<"barrel">>),
     ServerVersion = application:get_env(barrel_mcp, server_version, <<"1.0.0">>),
+    NegotiatedVersion = negotiate_protocol_version(
+                          maps:get(<<"protocolVersion">>, Params, undefined)),
     %% Persist client capabilities (notably `sampling') so the server can
     %% later issue server-to-client requests via barrel_mcp_session.
+    %% Also persist the negotiated protocol_version on the session.
     _ = case maps:find(session_id, State) of
         {ok, SessionId} when is_binary(SessionId) ->
             ClientCaps = maps:get(<<"capabilities">>, Params, #{}),
-            barrel_mcp_session:set_client_capabilities(SessionId, ClientCaps);
+            _ = barrel_mcp_session:set_client_capabilities(SessionId, ClientCaps),
+            _ = barrel_mcp_session:set_protocol_version(SessionId, NegotiatedVersion),
+            ok;
         _ -> ok
     end,
     success_response(Id, #{
-        <<"protocolVersion">> => ?MCP_PROTOCOL_VERSION,
+        <<"protocolVersion">> => NegotiatedVersion,
         <<"capabilities">> => #{
-            <<"tools">> => #{},
-            <<"resources">> => #{<<"subscribe">> => true},
-            <<"prompts">> => #{},
+            <<"tools">> => #{<<"listChanged">> => true},
+            <<"resources">> => #{<<"subscribe">> => true,
+                                  <<"listChanged">> => true},
+            <<"prompts">> => #{<<"listChanged">> => true},
             <<"logging">> => #{}
         },
         <<"serverInfo">> => #{
@@ -145,15 +163,30 @@ handle_request(<<"tools/list">>, _Params, Id, _State) ->
 handle_request(<<"tools/call">>, Params, Id, _State) ->
     Name = maps:get(<<"name">>, Params, <<>>),
     Args = maps:get(<<"arguments">>, Params, #{}),
-    case barrel_mcp_registry:run(tool, Name, Args) of
-        {ok, Result} ->
-            Content = format_tool_result(Result),
-            success_response(Id, #{<<"content">> => Content});
-        {error, {not_found, _, _}} ->
-            error_response(Id, ?JSONRPC_METHOD_NOT_FOUND, <<"Tool not found">>);
-        {error, Reason} ->
-            error_response(Id, ?MCP_TOOL_ERROR, format_error(Reason))
-    end;
+    %% Tool dispatch is asynchronous. The transport drives the
+    %% lifecycle: it builds `Ctx', invokes the spawn closure, records
+    %% the in-flight entry, and waits on its mailbox for one of
+    %% `{tool_result, _, _}', `{tool_error, _, _}',
+    %% `{tool_failed, _, _}', `{tool_validation_failed, _, _}', or
+    %% `{cancelled, _}' (sent by `barrel_mcp_session:cancel_in_flight/2').
+    Plan = #{
+        request_id => Id,
+        spawn => fun(Ctx) ->
+            case barrel_mcp_registry:run_tool(Name, Args, Ctx) of
+                {ok, Pid} -> Pid;
+                {error, _} = Err ->
+                    %% Surface as if the worker reported it: the
+                    %% transport then maps the error.
+                    ReplyTo = maps:get(reply_to, Ctx),
+                    RequestId = maps:get(request_id, Ctx),
+                    ReplyTo ! {tool_failed, RequestId, Err},
+                    %% Return a transient pid so the in-flight
+                    %% record has something monitorable.
+                    spawn(fun() -> ok end)
+            end
+        end
+    },
+    {async, Plan};
 
 %% Resources
 handle_request(<<"resources/list">>, _Params, Id, _State) ->
@@ -185,8 +218,17 @@ handle_request(<<"resources/read">>, Params, Id, _State) ->
     end;
 
 handle_request(<<"resources/templates/list">>, _Params, Id, _State) ->
-    %% Return empty list for now - templates can be added later
-    success_response(Id, #{<<"resourceTemplates">> => []});
+    Templates = lists:map(fun({_Name, Handler}) ->
+        Base = #{
+            <<"uriTemplate">> => maps:get(uri_template, Handler, <<>>),
+            <<"name">> => maps:get(name, Handler, <<>>),
+            <<"description">> => maps:get(description, Handler, <<>>),
+            <<"mimeType">> => maps:get(mime_type, Handler, <<"text/plain">>)
+        },
+        %% Drop empty fields so the wire envelope stays compact.
+        maps:filter(fun(_K, V) -> V =/= <<>> end, Base)
+    end, barrel_mcp_registry:all(resource_template)),
+    success_response(Id, #{<<"resourceTemplates">> => Templates});
 
 handle_request(<<"resources/subscribe">>, Params, Id, State) ->
     Uri = maps:get(<<"uri">>, Params, <<>>),
@@ -262,17 +304,31 @@ handle_notification(<<"notifications/initialized">>, _Params, _State) ->
 handle_notification(<<"initialized">>, _Params, _State) ->
     ok;
 
-handle_notification(<<"notifications/cancelled">>, _Params, _State) ->
-    %% Request cancellation - not implemented yet
-    ok;
+handle_notification(<<"notifications/cancelled">>, Params, State) ->
+    case maps:find(session_id, State) of
+        {ok, SessionId} when is_binary(SessionId) ->
+            case maps:find(<<"requestId">>, Params) of
+                {ok, RequestId} ->
+                    barrel_mcp_session:cancel_in_flight(SessionId, RequestId);
+                error -> ok
+            end;
+        _ -> ok
+    end;
 
 handle_notification(<<"notifications/progress">>, _Params, _State) ->
-    %% Progress updates - not implemented yet
+    %% The server doesn't currently emit anything special on inbound
+    %% client-side progress notifications (used for client→server
+    %% requests, which we don't have). Acknowledge silently.
     ok;
 
-handle_notification(<<"notifications/roots/list_changed">>, _Params, _State) ->
-    %% Roots changed - not implemented yet
-    ok;
+handle_notification(<<"notifications/roots/list_changed">>, Params, State) ->
+    case application:get_env(barrel_mcp, roots_changed_handler) of
+        {ok, {Mod, Fun}} ->
+            try Mod:Fun(Params, State)
+            catch _:_ -> ok
+            end;
+        _ -> ok
+    end;
 
 handle_notification(_, _Params, _State) ->
     ok.
@@ -287,6 +343,13 @@ success_response(Id, Result) ->
         <<"id">> => Id,
         <<"result">> => Result
     }.
+
+%% @doc Format a tool handler's plain return value into the MCP
+%% content-block list shape. Public so transports driving async
+%% tool calls (HTTP / stdio) can produce identical envelopes.
+-spec format_tool_result_external(term()) -> [map()].
+format_tool_result_external(Result) ->
+    format_tool_result(Result).
 
 format_tool_result(Result) when is_binary(Result) ->
     [#{<<"type">> => <<"text">>, <<"text">> => Result}];
@@ -315,6 +378,17 @@ format_resource_result(Uri, Result) ->
 
 format_error({Class, Reason, _Stack}) ->
     iolist_to_binary(io_lib:format("~p:~p", [Class, Reason])).
+
+%% Pick the protocol version to advertise in the `initialize'
+%% response. If the client's requested version is one we speak, echo
+%% it; otherwise return our preferred version and let the client
+%% decide.
+negotiate_protocol_version(undefined) -> ?MCP_PROTOCOL_VERSION;
+negotiate_protocol_version(Requested) when is_binary(Requested) ->
+    case lists:member(Requested, ?MCP_SUPPORTED_VERSIONS) of
+        true -> Requested;
+        false -> ?MCP_PROTOCOL_VERSION
+    end.
 
 %%====================================================================
 %% JSON-RPC envelope helpers

--- a/src/barrel_mcp_registry.erl
+++ b/src/barrel_mcp_registry.erl
@@ -59,6 +59,7 @@
     reg/5,
     unreg/2,
     run/3,
+    run_tool/3,
     find/2,
     all/0,
     all/1
@@ -245,6 +246,72 @@ run(Type, Name, Args) ->
             {error, {not_found, Type, Name}}
     end.
 
+%% @doc Execute a tool handler asynchronously. Spawns a worker that
+%% calls `Mod:Fun(Args, Ctx)' (when arity 2 is exported) or
+%% `Mod:Fun(Args)' otherwise. The worker reports back to
+%% `maps:get(reply_to, Ctx)' as either:
+%% <ul>
+%%   <li>`{tool_result, RequestId, Result}' on a normal return</li>
+%%   <li>`{tool_error, RequestId, Content}' for `{tool_error, _}'</li>
+%%   <li>`{tool_failed, RequestId, Reason}' on exception</li>
+%%   <li>`{tool_validation_failed, RequestId, Errors}' if input
+%%       validation was enabled and the args didn't match
+%%       `input_schema'.</li>
+%% </ul>
+%%
+%% Returns the worker pid.
+-spec run_tool(Name :: binary(), Args :: map(), Ctx :: map()) ->
+    {ok, pid()} | {error, term()}.
+run_tool(Name, Args, Ctx) ->
+    case find(tool, Name) of
+        {ok, Handler} ->
+            ReplyTo = maps:get(reply_to, Ctx),
+            RequestId = maps:get(request_id, Ctx),
+            Pid = spawn(fun() ->
+                run_tool_worker(Name, Args, Ctx, Handler, ReplyTo, RequestId)
+            end),
+            {ok, Pid};
+        error ->
+            {error, {not_found, tool, Name}}
+    end.
+
+run_tool_worker(_Name, Args, Ctx, Handler, ReplyTo, RequestId) ->
+    %% Optional input validation against the registered input_schema.
+    case validate_tool_input(Args, Handler) of
+        ok ->
+            invoke_tool_handler(Args, Ctx, Handler, ReplyTo, RequestId);
+        {error, Errors} ->
+            ReplyTo ! {tool_validation_failed, RequestId, Errors}
+    end.
+
+validate_tool_input(Args, Handler) ->
+    case maps:get(validate_input, Handler, false) of
+        true ->
+            Schema = maps:get(input_schema, Handler, #{}),
+            case barrel_mcp_schema:validate(Args, Schema) of
+                ok -> ok;
+                {error, Errors} -> {error, Errors}
+            end;
+        _ -> ok
+    end.
+
+invoke_tool_handler(Args, Ctx, #{module := M, function := F}, ReplyTo, RequestId) ->
+    try
+        Result = case erlang:function_exported(M, F, 2) of
+                     true -> M:F(Args, Ctx);
+                     false -> M:F(Args)
+                 end,
+        case Result of
+            {tool_error, Content} ->
+                ReplyTo ! {tool_error, RequestId, Content};
+            _ ->
+                ReplyTo ! {tool_result, RequestId, Result}
+        end
+    catch
+        Class:Reason:Stack ->
+            ReplyTo ! {tool_failed, RequestId, {Class, Reason, Stack}}
+    end.
+
 %% @doc Find a handler by type and name.
 %%
 %% Looks up handler metadata without executing it.
@@ -385,19 +452,32 @@ wait_for_proc(Parent, Proc) ->
     end.
 
 do_reg(Type, Name, Module, Function, Opts) ->
-    case erlang:function_exported(Module, Function, 1) of
+    %% Tools may register handlers as arity 1 (legacy) or arity 2
+    %% (new, accepts Ctx with progress and cancel hooks). Resources,
+    %% prompts and resource templates remain arity 1.
+    Arities = case Type of
+                  tool -> [2, 1];
+                  _ -> [1]
+              end,
+    case any_exported(Module, Function, Arities) of
         true ->
             Handler = build_handler(Type, Module, Function, Opts),
             true = ets:insert(?REGISTRY_TABLE, {{Type, Name}, Handler}),
             sync_persistent_term(),
+            barrel_mcp_session:broadcast_list_changed(Type),
             ok;
         false ->
-            {error, {function_not_exported, Module, Function, 1}}
+            {error, {function_not_exported, Module, Function, lists:max(Arities)}}
     end.
+
+any_exported(Module, Function, Arities) ->
+    lists:any(fun(A) -> erlang:function_exported(Module, Function, A) end,
+              Arities).
 
 do_unreg(Type, Name) ->
     true = ets:delete(?REGISTRY_TABLE, {Type, Name}),
     sync_persistent_term(),
+    barrel_mcp_session:broadcast_list_changed(Type),
     ok.
 
 build_handler(tool, Module, Function, Opts) ->
@@ -405,7 +485,8 @@ build_handler(tool, Module, Function, Opts) ->
         module => Module,
         function => Function,
         description => maps:get(description, Opts, <<>>),
-        input_schema => maps:get(input_schema, Opts, #{type => <<"object">>})
+        input_schema => maps:get(input_schema, Opts, #{type => <<"object">>}),
+        validate_input => maps:get(validate_input, Opts, false)
     };
 build_handler(resource, Module, Function, Opts) ->
     #{
@@ -423,6 +504,18 @@ build_handler(prompt, Module, Function, Opts) ->
         name => maps:get(name, Opts, <<>>),
         description => maps:get(description, Opts, <<>>),
         arguments => maps:get(arguments, Opts, [])
+    };
+build_handler(resource_template, Module, Function, Opts) ->
+    %% RFC 6570 URI template registry. The handler function expands
+    %% the template (called when the matching `resources/read'
+    %% arrives — currently lib-side dispatching is left to hosts).
+    #{
+        module => Module,
+        function => Function,
+        name => maps:get(name, Opts, <<>>),
+        uri_template => maps:get(uri_template, Opts, <<>>),
+        description => maps:get(description, Opts, <<>>),
+        mime_type => maps:get(mime_type, Opts, <<"text/plain">>)
     }.
 
 sync_persistent_term() ->

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -39,7 +39,14 @@
     subscribers_for/1,
     %% Server -> client request via the session's SSE channel.
     sampling_create_message/3,
-    deliver_response/2
+    deliver_response/2,
+    %% Server -> client notifications.
+    broadcast_list_changed/1,
+    notify_progress/4,
+    %% In-flight tool tracking (used by `notifications/cancelled').
+    record_in_flight/4,
+    cancel_in_flight/2,
+    clear_in_flight/2
 ]).
 
 %% gen_server callbacks
@@ -50,6 +57,8 @@
 -define(SESSION_TABLE, barrel_mcp_sessions).
 -define(SUBSCRIPTIONS_TABLE, barrel_mcp_resource_subs).
 -define(PENDING_TABLE, barrel_mcp_pending_requests).
+%% In-flight tool calls per session: {{SessionId, RequestId} => #in_flight{}}
+-define(INFLIGHT_TABLE, barrel_mcp_inflight).
 -define(CLEANUP_INTERVAL, 60000). %% 1 minute
 -define(DEFAULT_SAMPLING_TIMEOUT, 30000).
 
@@ -61,6 +70,14 @@
     client_capabilities :: map(),
     protocol_version :: binary(),
     sse_pid :: pid() | undefined  %% Process handling SSE stream
+}).
+
+%% Async tool call in-flight tracking.
+-record(in_flight, {
+    session_id :: binary(),
+    request_id :: integer() | binary(),
+    worker_pid :: pid(),
+    waiter_pid :: pid()
 }).
 
 -record(pending, {
@@ -225,6 +242,83 @@ sampling_create_message(SessionId, Params, Opts) ->
 deliver_response(Id, Response) ->
     gen_server:call(?MODULE, {deliver_response, id_to_binary(Id), Response}).
 
+%% @doc Push a `notifications/<kind>/list_changed' envelope to every
+%% session that has an active SSE channel. Tolerates a missing
+%% session manager (e.g. during stdio-only operation).
+-spec broadcast_list_changed(handler_type()) -> ok.
+broadcast_list_changed(Kind) ->
+    case whereis(?MODULE) of
+        undefined -> ok;
+        _ ->
+            Method = list_changed_method(Kind),
+            Notif = #{<<"jsonrpc">> => <<"2.0">>,
+                      <<"method">> => Method,
+                      <<"params">> => #{}},
+            broadcast_to_sse_sessions(Notif)
+    end.
+
+list_changed_method(tool)              -> <<"notifications/tools/list_changed">>;
+list_changed_method(resource)          -> <<"notifications/resources/list_changed">>;
+list_changed_method(resource_template) -> <<"notifications/resources/list_changed">>;
+list_changed_method(prompt)            -> <<"notifications/prompts/list_changed">>.
+
+broadcast_to_sse_sessions(Notification) ->
+    %% Reads from a `protected' ETS via direct ets:foldl/3 work fine
+    %% from any process. We only need the gen_server when we mutate
+    %% the table.
+    case ets:whereis(?SESSION_TABLE) of
+        undefined -> ok;
+        _ ->
+            ets:foldl(fun
+                ({_Id, #mcp_session{sse_pid = Pid}}, Acc) when is_pid(Pid) ->
+                    Pid ! {sse_send_message, Notification},
+                    Acc;
+                (_, Acc) -> Acc
+            end, ok, ?SESSION_TABLE)
+    end.
+
+%% @doc Record an in-flight tool call so a later
+%% `notifications/cancelled' can find the worker and waiter.
+-spec record_in_flight(binary(), integer() | binary(), pid(), pid()) -> ok.
+record_in_flight(SessionId, RequestId, WorkerPid, WaiterPid) ->
+    gen_server:call(?MODULE,
+                    {record_in_flight, SessionId, RequestId,
+                     WorkerPid, WaiterPid}).
+
+%% @doc Cancel an in-flight tool call. Sends `{cancel, RequestId}'
+%% to the worker and `{cancelled, RequestId}' to the waiter, then
+%% drops the entry. Idempotent: a missing entry returns `ok'.
+-spec cancel_in_flight(binary(), integer() | binary()) -> ok.
+cancel_in_flight(SessionId, RequestId) ->
+    gen_server:call(?MODULE, {cancel_in_flight, SessionId, RequestId}).
+
+%% @doc Drop an in-flight entry (called by the waiter after a normal
+%% completion).
+-spec clear_in_flight(binary(), integer() | binary()) -> ok.
+clear_in_flight(SessionId, RequestId) ->
+    gen_server:call(?MODULE, {clear_in_flight, SessionId, RequestId}).
+
+%% @doc Push a `notifications/progress' envelope to a specific
+%% session over its SSE channel. `Token' is the progressToken the
+%% client supplied on the originating request.
+-spec notify_progress(binary(), term(), number(), number() | undefined) -> ok.
+notify_progress(SessionId, Token, Progress, Total) ->
+    case get_sse_pid(SessionId) of
+        {ok, Pid} ->
+            Params0 = #{<<"progressToken">> => Token,
+                        <<"progress">> => Progress},
+            Params = case Total of
+                         undefined -> Params0;
+                         _ -> Params0#{<<"total">> => Total}
+                     end,
+            Pid ! {sse_send_message,
+                   #{<<"jsonrpc">> => <<"2.0">>,
+                     <<"method">> => <<"notifications/progress">>,
+                     <<"params">> => Params}},
+            ok;
+        _ -> ok
+    end.
+
 %% @doc Cleanup sessions older than TTL milliseconds. Routes through
 %% the gen_server (the table owner under the new `protected'
 %% visibility); the handler deletes expired entries inline.
@@ -251,6 +345,7 @@ init([]) ->
     _ = ensure_session_table(),
     _ = ensure_subs_table(),
     _ = ensure_pending_table(),
+    _ = ensure_inflight_table(),
     %% Schedule periodic cleanup
     _ = erlang:send_after(?CLEANUP_INTERVAL, self(), cleanup),
     {ok, #{}}.
@@ -348,6 +443,29 @@ handle_call({deliver_response, Key, Response}, _From, State) ->
     end,
     {reply, Reply, State};
 
+handle_call({record_in_flight, SessionId, RequestId, Worker, Waiter},
+            _From, State) ->
+    InFlight = #in_flight{
+        session_id = SessionId, request_id = RequestId,
+        worker_pid = Worker, waiter_pid = Waiter
+    },
+    true = ets:insert(?INFLIGHT_TABLE, {{SessionId, RequestId}, InFlight}),
+    {reply, ok, State};
+
+handle_call({cancel_in_flight, SessionId, RequestId}, _From, State) ->
+    case ets:lookup(?INFLIGHT_TABLE, {SessionId, RequestId}) of
+        [{_, #in_flight{worker_pid = W, waiter_pid = Wt}}] ->
+            (catch W ! {cancel, RequestId}),
+            (catch Wt ! {cancelled, RequestId}),
+            true = ets:delete(?INFLIGHT_TABLE, {SessionId, RequestId});
+        [] -> ok
+    end,
+    {reply, ok, State};
+
+handle_call({clear_in_flight, SessionId, RequestId}, _From, State) ->
+    true = ets:delete(?INFLIGHT_TABLE, {SessionId, RequestId}),
+    {reply, ok, State};
+
 handle_call({cleanup_expired, TTL}, _From, State) ->
     Now = erlang:system_time(millisecond),
     Cutoff = Now - TTL,
@@ -436,6 +554,16 @@ ensure_pending_table() ->
     case ets:whereis(?PENDING_TABLE) of
         undefined ->
             ets:new(?PENDING_TABLE, [
+                named_table, protected, set,
+                {read_concurrency, true}
+            ]);
+        _ -> ok
+    end.
+
+ensure_inflight_table() ->
+    case ets:whereis(?INFLIGHT_TABLE) of
+        undefined ->
+            ets:new(?INFLIGHT_TABLE, [
                 named_table, protected, set,
                 {read_concurrency, true}
             ]);

--- a/test/barrel_mcp_async_tools_SUITE.erl
+++ b/test/barrel_mcp_async_tools_SUITE.erl
@@ -1,0 +1,287 @@
+%%%-------------------------------------------------------------------
+%%% @doc Common-test suite for async tool execution: cancel and
+%%% progress round-trips.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_async_tools_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1,
+         init_per_testcase/2, end_per_testcase/2]).
+-export([cancel_returns_empty_body/1,
+         progress_emits_events/1,
+         tool_error_returns_isError/1]).
+
+%% Tool handlers used by the suite.
+-export([slow_tool/2, progress_tool/2, error_tool/1]).
+
+-define(BASE_PORT, 22200).
+
+all() -> [
+    cancel_returns_empty_body,
+    progress_emits_events,
+    tool_error_returns_isError
+].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    {ok, _} = application:ensure_all_started(hackney),
+    Config.
+
+end_per_suite(_Config) ->
+    catch barrel_mcp:stop_http_stream(),
+    application:stop(barrel_mcp),
+    ok.
+
+init_per_testcase(TC, Config) ->
+    Port = ?BASE_PORT + erlang:phash2(TC, 100),
+    [{port, Port} | Config].
+
+end_per_testcase(_TC, _Config) ->
+    catch barrel_mcp:stop_http_stream(),
+    timer:sleep(50),
+    ok.
+
+%%====================================================================
+%% Cancel
+%%====================================================================
+
+cancel_returns_empty_body(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => true}),
+    ok = barrel_mcp_registry:reg(tool, <<"slow">>, ?MODULE, slow_tool, #{}),
+
+    {200, IH, _} = post_init(Port),
+    SessionId = proplists:get_value(<<"mcp-session-id">>, IH),
+
+    %% Issue the slow tool call asynchronously so we can fire the
+    %% cancel from a separate process.
+    Self = self(),
+    Caller = spawn_link(fun() ->
+        {ok, S, _, B} = hackney:request(post, url(Port),
+            [{<<"content-type">>, <<"application/json">>},
+             {<<"accept">>, <<"application/json">>},
+             {<<"mcp-session-id">>, SessionId}],
+            tool_call_body(<<"slow">>, 7), [with_body]),
+        Self ! {tool_call_returned, S, B}
+    end),
+
+    %% Give the worker a moment to register as in-flight.
+    timer:sleep(150),
+
+    %% Send cancel.
+    Cancel = json:encode(#{<<"jsonrpc">> => <<"2.0">>,
+                           <<"method">> => <<"notifications/cancelled">>,
+                           <<"params">> => #{<<"requestId">> => 7}}),
+    {ok, 202, _, _} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>},
+         {<<"mcp-session-id">>, SessionId}],
+        Cancel, [with_body]),
+
+    receive
+        {tool_call_returned, Status, Body} ->
+            ?assertEqual(200, Status),
+            ?assertEqual(<<>>, Body)
+    after 5000 ->
+        exit(Caller, kill),
+        ?assert(false)
+    end,
+    ok = barrel_mcp_registry:unreg(tool, <<"slow">>),
+    ok.
+
+%%====================================================================
+%% Progress
+%%====================================================================
+
+progress_emits_events(Config) ->
+    process_flag(trap_exit, true),
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => true}),
+    ok = barrel_mcp_registry:reg(tool, <<"prog">>, ?MODULE, progress_tool, #{}),
+
+    {200, IH, _} = post_init(Port),
+    SessionId = proplists:get_value(<<"mcp-session-id">>, IH),
+
+    Self = self(),
+    Sse = spawn(fun() ->
+        {ok, Ref} = hackney:request(get, url(Port),
+            [{<<"accept">>, <<"text/event-stream">>},
+             {<<"mcp-session-id">>, SessionId}],
+            <<>>, [async, {recv_timeout, infinity}]),
+        sse_collect(Ref, Self)
+    end),
+    timer:sleep(150),
+
+    %% Call the tool with a progressToken; the tool emits 3 events.
+    Body = tool_call_with_progress(<<"prog">>, 11, <<"tok-1">>),
+    {ok, 200, _, RespBody} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>},
+         {<<"mcp-session-id">>, SessionId}],
+        Body, [with_body]),
+    Resp = json:decode(RespBody),
+    ?assertEqual(11, maps:get(<<"id">>, Resp)),
+    ?assert(maps:is_key(<<"result">>, Resp)),
+
+    %% Drain progress events from the SSE collector. Three are
+    %% expected before the run completes; the response above already
+    %% returned, so the events are buffered in the collector mailbox.
+    Events = collect_progress(3, []),
+    ?assertEqual(3, length(Events)),
+    [E1 | _] = Events,
+    ?assertEqual(<<"notifications/progress">>, maps:get(<<"method">>, E1)),
+    ?assertEqual(<<"tok-1">>,
+                 maps:get(<<"progressToken">>, maps:get(<<"params">>, E1))),
+    exit(Sse, kill),
+    ok = barrel_mcp_registry:unreg(tool, <<"prog">>),
+    ok.
+
+%%====================================================================
+%% isError
+%%====================================================================
+
+tool_error_returns_isError(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => true}),
+    ok = barrel_mcp_registry:reg(tool, <<"err">>, ?MODULE, error_tool, #{}),
+    {200, IH, _} = post_init(Port),
+    SessionId = proplists:get_value(<<"mcp-session-id">>, IH),
+    Body = tool_call_body(<<"err">>, 21),
+    {ok, 200, _, RB} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>},
+         {<<"mcp-session-id">>, SessionId}],
+        Body, [with_body]),
+    Resp = json:decode(RB),
+    Result = maps:get(<<"result">>, Resp),
+    ?assertEqual(true, maps:get(<<"isError">>, Result)),
+    [Block | _] = maps:get(<<"content">>, Result),
+    ?assertEqual(<<"text">>, maps:get(<<"type">>, Block)),
+    ok = barrel_mcp_registry:unreg(tool, <<"err">>),
+    ok.
+
+%%====================================================================
+%% Tool implementations
+%%====================================================================
+
+slow_tool(_Args, _Ctx) ->
+    receive
+        {cancel, _} -> {tool_error, [#{<<"type">> => <<"text">>,
+                                        <<"text">> => <<"cancelled">>}]}
+    after 30000 ->
+        <<"slept">>
+    end.
+
+progress_tool(_Args, Ctx) ->
+    Emit = maps:get(emit_progress, Ctx),
+    Emit(0.25, 1.0, undefined),
+    Emit(0.50, 1.0, undefined),
+    Emit(0.75, 1.0, undefined),
+    timer:sleep(80),
+    <<"done">>.
+
+error_tool(_Args) ->
+    {tool_error, [#{<<"type">> => <<"text">>, <<"text">> => <<"boom">>}]}.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+url(Port) ->
+    iolist_to_binary(io_lib:format("http://127.0.0.1:~B/mcp", [Port])).
+
+post_init(Port) ->
+    Body = json:encode(#{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => 1,
+        <<"method">> => <<"initialize">>,
+        <<"params">> => #{
+            <<"protocolVersion">> => <<"2025-11-25">>,
+            <<"capabilities">> => #{},
+            <<"clientInfo">> => #{<<"name">> => <<"async-suite">>,
+                                  <<"version">> => <<"1.0">>}
+        }
+    }),
+    {ok, S, H, B} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>}],
+        Body, [with_body]),
+    {S, H, B}.
+
+tool_call_body(Name, Id) ->
+    json:encode(#{<<"jsonrpc">> => <<"2.0">>,
+                  <<"id">> => Id,
+                  <<"method">> => <<"tools/call">>,
+                  <<"params">> => #{<<"name">> => Name,
+                                    <<"arguments">> => #{}}}).
+
+tool_call_with_progress(Name, Id, Token) ->
+    json:encode(#{<<"jsonrpc">> => <<"2.0">>,
+                  <<"id">> => Id,
+                  <<"method">> => <<"tools/call">>,
+                  <<"params">> => #{<<"name">> => Name,
+                                    <<"arguments">> => #{},
+                                    <<"_meta">> =>
+                                        #{<<"progressToken">> => Token}}}).
+
+%% Collect SSE events from an async hackney stream. Forwards each
+%% parsed `data:' JSON envelope to `Reporter' as `{progress, Map}'.
+sse_collect(Ref, Reporter) ->
+    sse_collect(Ref, Reporter, <<>>).
+
+sse_collect(Ref, Reporter, Buf) ->
+    receive
+        {hackney_response, Ref, {status, _, _}} ->
+            sse_collect(Ref, Reporter, Buf);
+        {hackney_response, Ref, {headers, _}} ->
+            sse_collect(Ref, Reporter, Buf);
+        {hackney_response, Ref, Chunk} when is_binary(Chunk) ->
+            {Events, NewBuf} = split_sse(<<Buf/binary, Chunk/binary>>),
+            lists:foreach(fun(D) ->
+                try Reporter ! {progress, json:decode(D)}
+                catch _:_ -> ok end
+            end, Events),
+            sse_collect(Ref, Reporter, NewBuf);
+        {hackney_response, Ref, done} -> ok
+    end.
+
+split_sse(Buf) ->
+    case binary:split(Buf, <<"\n\n">>, [global]) of
+        [_] -> {[], Buf};
+        Parts ->
+            {Events, [Tail]} = lists:split(length(Parts) - 1, Parts),
+            Datas = [extract_data(E) || E <- Events],
+            {[D || D <- Datas, D =/= undefined], Tail}
+    end.
+
+extract_data(Block) ->
+    Lines = binary:split(Block, <<"\n">>, [global]),
+    Datas = lists:filtermap(fun
+        (<<"data: ", V/binary>>) -> {true, V};
+        (<<"data:", V/binary>>) -> {true, string:trim(V)};
+        (_) -> false
+    end, Lines),
+    case Datas of
+        [] -> undefined;
+        [D | _] -> D
+    end.
+
+collect_progress(0, Acc) -> lists:reverse(Acc);
+collect_progress(N, Acc) ->
+    receive
+        {progress, Msg} ->
+            case maps:get(<<"method">>, Msg, <<>>) of
+                <<"notifications/progress">> ->
+                    collect_progress(N - 1, [Msg | Acc]);
+                _ ->
+                    collect_progress(N, Acc)
+            end
+    after 5000 ->
+        lists:reverse(Acc)
+    end.

--- a/test/barrel_mcp_auth_hash_tests.erl
+++ b/test/barrel_mcp_auth_hash_tests.erl
@@ -1,0 +1,73 @@
+%%%-------------------------------------------------------------------
+%%% @doc Tests for the modern hash formats added to
+%%% `barrel_mcp_auth_basic' (PBKDF2-SHA256) and
+%%% `barrel_mcp_auth_apikey' (HMAC-SHA256), plus backward
+%%% compatibility with the legacy hex SHA-256 digests.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_auth_hash_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% basic auth — pbkdf2-sha256
+%%====================================================================
+
+basic_default_uses_pbkdf2_test() ->
+    H = barrel_mcp_auth_basic:hash_password(<<"hunter2">>),
+    ?assertMatch(<<"pbkdf2-sha256$", _/binary>>, H).
+
+basic_pbkdf2_round_trip_test() ->
+    H = barrel_mcp_auth_basic:hash_password(<<"hunter2">>),
+    ?assertEqual(ok, barrel_mcp_auth_basic:verify_password(<<"hunter2">>, H)),
+    ?assertEqual({error, invalid_credentials},
+                 barrel_mcp_auth_basic:verify_password(<<"nope">>, H)).
+
+basic_pbkdf2_uses_random_salt_test() ->
+    %% Two hashes of the same password must differ (random salt).
+    H1 = barrel_mcp_auth_basic:hash_password(<<"hunter2">>),
+    H2 = barrel_mcp_auth_basic:hash_password(<<"hunter2">>),
+    ?assertNotEqual(H1, H2),
+    ?assertEqual(ok, barrel_mcp_auth_basic:verify_password(<<"hunter2">>, H1)),
+    ?assertEqual(ok, barrel_mcp_auth_basic:verify_password(<<"hunter2">>, H2)).
+
+basic_legacy_sha256_still_verifies_test() ->
+    %% Legacy stored format (hex SHA-256) still verifies (deprecated
+    %% path, with a warning logged).
+    Legacy = barrel_mcp_auth_basic:hash_password(<<"hunter2">>,
+                                                  #{algorithm => 'sha256-hex'}),
+    ?assertEqual(64, byte_size(Legacy)),
+    ?assertEqual(ok, barrel_mcp_auth_basic:verify_password(<<"hunter2">>, Legacy)),
+    ?assertEqual({error, invalid_credentials},
+                 barrel_mcp_auth_basic:verify_password(<<"nope">>, Legacy)).
+
+basic_iterations_are_overridable_test() ->
+    H = barrel_mcp_auth_basic:hash_password(<<"x">>,
+                                             #{iterations => 1000}),
+    ?assertMatch(<<"pbkdf2-sha256$1000$", _/binary>>, H),
+    ?assertEqual(ok, barrel_mcp_auth_basic:verify_password(<<"x">>, H)).
+
+%%====================================================================
+%% apikey auth — hmac-sha256
+%%====================================================================
+
+apikey_legacy_default_test() ->
+    %% `hash_key/1' stays on the legacy hex SHA-256 form for one
+    %% release.
+    H = barrel_mcp_auth_apikey:hash_key(<<"my-key">>),
+    ?assertEqual(64, byte_size(H)),
+    ?assertEqual(ok, barrel_mcp_auth_apikey:verify_key(<<"my-key">>, H)),
+    ?assertEqual({error, invalid_credentials},
+                 barrel_mcp_auth_apikey:verify_key(<<"other">>, H)).
+
+apikey_hmac_format_test() ->
+    H = barrel_mcp_auth_apikey:hash_key(<<"my-key">>,
+                                         #{pepper => <<"secret-pepper">>}),
+    ?assertMatch(<<"hmac-sha256$", _/binary>>, H).
+
+apikey_hmac_is_pepper_dependent_test() ->
+    H1 = barrel_mcp_auth_apikey:hash_key(<<"my-key">>,
+                                          #{pepper => <<"a">>}),
+    H2 = barrel_mcp_auth_apikey:hash_key(<<"my-key">>,
+                                          #{pepper => <<"b">>}),
+    ?assertNotEqual(H1, H2).

--- a/test/barrel_mcp_client_tests.erl
+++ b/test/barrel_mcp_client_tests.erl
@@ -92,10 +92,12 @@ test_list_tools_all() ->
     wait_dead(Pid).
 
 test_version_downgrade() ->
-    %% Server reports 2025-03-26; client targets 2025-11-25 by default.
+    %% Both sides target 2025-11-25 now, so negotiation echoes the
+    %% client's version. The downgrade path stays exercised by the
+    %% server-side protocol_version_unsupported_returns_400 case.
     {ok, Pid} = start_client(),
     {ok, Version} = barrel_mcp_client:protocol_version(Pid),
-    ?assertEqual(<<"2025-03-26">>, Version),
+    ?assertEqual(<<"2025-11-25">>, Version),
     ok = barrel_mcp_client:close(Pid),
     wait_dead(Pid).
 

--- a/test/barrel_mcp_protocol_tests.erl
+++ b/test/barrel_mcp_protocol_tests.erl
@@ -82,7 +82,7 @@ test_handle_initialize() ->
     ?assertEqual(<<"2.0">>, maps:get(<<"jsonrpc">>, Response)),
     ?assertEqual(1, maps:get(<<"id">>, Response)),
     Result = maps:get(<<"result">>, Response),
-    ?assertEqual(<<"2025-03-26">>, maps:get(<<"protocolVersion">>, Result)),
+    ?assertEqual(<<"2025-11-25">>, maps:get(<<"protocolVersion">>, Result)),
     ?assert(maps:is_key(<<"capabilities">>, Result)),
     ?assert(maps:is_key(<<"serverInfo">>, Result)).
 
@@ -112,6 +112,8 @@ test_handle_tools_list() ->
     barrel_mcp_registry:unreg(tool, <<"test_tool">>).
 
 test_handle_tools_call() ->
+    %% `tools/call' is now async: handle/2 returns {async, AsyncPlan}
+    %% with a `spawn' fun the transport invokes. Drive it inline here.
     ok = barrel_mcp_registry:reg(tool, <<"echo">>, ?MODULE, sample_tool, #{}),
     Request = #{
         <<"jsonrpc">> => <<"2.0">>,
@@ -122,13 +124,25 @@ test_handle_tools_call() ->
             <<"arguments">> => #{<<"input">> => <<"hello">>}
         }
     },
-    Response = barrel_mcp_protocol:handle(Request),
-    Result = maps:get(<<"result">>, Response),
-    Content = maps:get(<<"content">>, Result),
-    ?assert(length(Content) >= 1),
+    {async, Plan} = barrel_mcp_protocol:handle(Request),
+    Self = self(),
+    Ctx = #{request_id => 1, reply_to => Self,
+            session_id => undefined,
+            progress_token => undefined,
+            emit_progress => fun(_, _, _) -> ok end},
+    _Pid = (maps:get(spawn, Plan))(Ctx),
+    receive
+        {tool_result, 1, Result} ->
+            Content = barrel_mcp_protocol:format_tool_result_external(Result),
+            ?assert(length(Content) >= 1)
+    after 2000 ->
+        ?assert(false)
+    end,
     barrel_mcp_registry:unreg(tool, <<"echo">>).
 
 test_handle_tools_call_not_found() ->
+    %% A missing tool surfaces via the worker as `tool_failed' with
+    %% the registry's not_found error.
     Request = #{
         <<"jsonrpc">> => <<"2.0">>,
         <<"id">> => 1,
@@ -138,10 +152,18 @@ test_handle_tools_call_not_found() ->
             <<"arguments">> => #{}
         }
     },
-    Response = barrel_mcp_protocol:handle(Request),
-    ?assert(maps:is_key(<<"error">>, Response)),
-    Error = maps:get(<<"error">>, Response),
-    ?assertEqual(-32601, maps:get(<<"code">>, Error)).
+    {async, Plan} = barrel_mcp_protocol:handle(Request),
+    Self = self(),
+    Ctx = #{request_id => 1, reply_to => Self,
+            session_id => undefined,
+            progress_token => undefined,
+            emit_progress => fun(_, _, _) -> ok end},
+    _Pid = (maps:get(spawn, Plan))(Ctx),
+    receive
+        {tool_failed, 1, {error, {not_found, tool, <<"nonexistent">>}}} -> ok
+    after 2000 ->
+        ?assert(false)
+    end.
 
 test_handle_resources_list() ->
     Request = #{

--- a/test/barrel_mcp_registry_tests.erl
+++ b/test/barrel_mcp_registry_tests.erl
@@ -154,6 +154,8 @@ test_namespace_isolation() ->
     barrel_mcp_registry:unreg(resource, Name).
 
 test_function_validation() ->
-    %% Try to register a function that doesn't exist
-    {error, {function_not_exported, ?MODULE, nonexistent_function, 1}} =
+    %% Tool registration accepts arity 1 (legacy) or arity 2 (new
+    %% Ctx-aware shape); the error reports the highest arity it
+    %% checked.
+    {error, {function_not_exported, ?MODULE, nonexistent_function, 2}} =
         barrel_mcp_registry:reg(tool, <<"bad">>, ?MODULE, nonexistent_function, #{}).

--- a/test/barrel_mcp_tools_tests.erl
+++ b/test/barrel_mcp_tools_tests.erl
@@ -109,106 +109,66 @@ test_list_tools_empty() ->
     Tools = maps:get(<<"tools">>, Result),
     ?assertEqual([], Tools).
 
-test_call_tool_text() ->
-    ok = barrel_mcp_registry:reg(tool, <<"echo">>, ?MODULE, echo_tool, #{}),
-
+%% Drive an async tools/call and return either the formatted content
+%% blocks (for a result), or the outcome tuple (for failures).
+drive_call(Name, Args) ->
     Request = #{
         <<"jsonrpc">> => <<"2.0">>,
         <<"id">> => 1,
         <<"method">> => <<"tools/call">>,
-        <<"params">> => #{
-            <<"name">> => <<"echo">>,
-            <<"arguments">> => #{<<"input">> => <<"hello">>}
-        }
+        <<"params">> => #{<<"name">> => Name, <<"arguments">> => Args}
     },
-    Response = barrel_mcp_protocol:handle(Request),
-    Result = maps:get(<<"result">>, Response),
-    Content = maps:get(<<"content">>, Result),
+    {async, Plan} = barrel_mcp_protocol:handle(Request),
+    Self = self(),
+    Ctx = #{request_id => 1, reply_to => Self,
+            session_id => undefined,
+            progress_token => undefined,
+            emit_progress => fun(_, _, _) -> ok end},
+    _Pid = (maps:get(spawn, Plan))(Ctx),
+    receive
+        {tool_result, 1, Result} ->
+            {result, barrel_mcp_protocol:format_tool_result_external(Result)};
+        {tool_failed, 1, Reason} -> {failed, Reason};
+        {tool_error, 1, Content} -> {tool_error, Content};
+        {tool_validation_failed, 1, Errors} -> {validation_failed, Errors}
+    after 2000 ->
+        timeout
+    end.
 
+test_call_tool_text() ->
+    ok = barrel_mcp_registry:reg(tool, <<"echo">>, ?MODULE, echo_tool, #{}),
+    {result, Content} = drive_call(<<"echo">>, #{<<"input">> => <<"hello">>}),
     ?assertEqual(1, length(Content)),
     [Block] = Content,
     ?assertEqual(<<"text">>, maps:get(<<"type">>, Block)),
     ?assertEqual(<<"Echo: hello">>, maps:get(<<"text">>, Block)),
-
     barrel_mcp_registry:unreg(tool, <<"echo">>).
 
 test_call_tool_map() ->
     ok = barrel_mcp_registry:reg(tool, <<"map_tool">>, ?MODULE, map_result_tool, #{}),
-
-    Request = #{
-        <<"jsonrpc">> => <<"2.0">>,
-        <<"id">> => 1,
-        <<"method">> => <<"tools/call">>,
-        <<"params">> => #{
-            <<"name">> => <<"map_tool">>,
-            <<"arguments">> => #{}
-        }
-    },
-    Response = barrel_mcp_protocol:handle(Request),
-    Result = maps:get(<<"result">>, Response),
-    Content = maps:get(<<"content">>, Result),
-
+    {result, Content} = drive_call(<<"map_tool">>, #{}),
     ?assertEqual(1, length(Content)),
     [Block] = Content,
     ?assertEqual(<<"text">>, maps:get(<<"type">>, Block)),
-    %% Map should be JSON encoded
-    Text = maps:get(<<"text">>, Block),
-    ?assert(is_binary(Text)),
-
+    ?assert(is_binary(maps:get(<<"text">>, Block))),
     barrel_mcp_registry:unreg(tool, <<"map_tool">>).
 
 test_call_tool_list() ->
     ok = barrel_mcp_registry:reg(tool, <<"list_tool">>, ?MODULE, list_result_tool, #{}),
-
-    Request = #{
-        <<"jsonrpc">> => <<"2.0">>,
-        <<"id">> => 1,
-        <<"method">> => <<"tools/call">>,
-        <<"params">> => #{
-            <<"name">> => <<"list_tool">>,
-            <<"arguments">> => #{}
-        }
-    },
-    Response = barrel_mcp_protocol:handle(Request),
-    Result = maps:get(<<"result">>, Response),
-    Content = maps:get(<<"content">>, Result),
-
+    {result, Content} = drive_call(<<"list_tool">>, #{}),
     ?assertEqual(2, length(Content)),
-
     barrel_mcp_registry:unreg(tool, <<"list_tool">>).
 
 test_call_tool_not_found() ->
-    Request = #{
-        <<"jsonrpc">> => <<"2.0">>,
-        <<"id">> => 1,
-        <<"method">> => <<"tools/call">>,
-        <<"params">> => #{
-            <<"name">> => <<"nonexistent">>,
-            <<"arguments">> => #{}
-        }
-    },
-    Response = barrel_mcp_protocol:handle(Request),
-    ?assert(maps:is_key(<<"error">>, Response)),
-    Error = maps:get(<<"error">>, Response),
-    ?assertEqual(-32601, maps:get(<<"code">>, Error)).
+    %% A missing tool surfaces via the worker as `tool_failed' with
+    %% the registry's not_found error.
+    {failed, {error, {not_found, tool, <<"nonexistent">>}}} =
+        drive_call(<<"nonexistent">>, #{}).
 
 test_call_tool_error() ->
+    %% Handler raises an error -> worker reports `tool_failed'.
     ok = barrel_mcp_registry:reg(tool, <<"error_tool">>, ?MODULE, error_tool, #{}),
-
-    Request = #{
-        <<"jsonrpc">> => <<"2.0">>,
-        <<"id">> => 1,
-        <<"method">> => <<"tools/call">>,
-        <<"params">> => #{
-            <<"name">> => <<"error_tool">>,
-            <<"arguments">> => #{}
-        }
-    },
-    Response = barrel_mcp_protocol:handle(Request),
-    ?assert(maps:is_key(<<"error">>, Response)),
-    Error = maps:get(<<"error">>, Response),
-    ?assertEqual(-32000, maps:get(<<"code">>, Error)),
-
+    {failed, _} = drive_call(<<"error_tool">>, #{}),
     barrel_mcp_registry:unreg(tool, <<"error_tool">>).
 
 test_tool_input_schema() ->


### PR DESCRIPTION
- Server speaks MCP 2025-11-25; older clients keep working.
- Tool calls can be cancelled and emit progress.
- `resources/templates/list` returns registered templates.
- Tool handler errors surface to clients as `isError: true`.
- Catalogue changes notify connected clients.
- Passwords and API keys use modern hashes with constant-time compare.