### PR TITLE
Document the recently shipped server features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,38 @@
 # barrel_mcp
 
-MCP (Model Context Protocol) library for Erlang. Implements the MCP specification for both server and client modes, including the Streamable HTTP transport (protocol 2025-03-26) for Claude Code integration.
+MCP (Model Context Protocol) library for Erlang. Implements the
+MCP specification (protocol `2025-11-25` with downward negotiation
+through `2024-11-05`) for both server and client modes, including
+the Streamable HTTP transport for Claude Code and any other MCP
+client.
 
 ## Features
 
-- **Full MCP Protocol Support**: Tools, Resources, Prompts, and Sampling
-- **Multiple Transports**: Streamable HTTP (Claude Code), HTTP (Cowboy), and stdio (Claude Desktop)
-- **Pluggable Authentication**: Bearer JWT, API keys, Basic auth, or custom providers
-- **Supervised Registry**: gen_statem-based registry with atomic operations
-- **Fast Reads**: ETS + persistent_term for O(1) handler lookups (no process call)
-- **Ready/Not-Ready States**: Flexible initialization pattern
-- **Client Library**: Connect to external MCP servers
-- **Zero-dependency JSON**: Uses OTP 27+ built-in `json` module
+- **Full MCP Protocol**: tools, resources, resource templates,
+  prompts, completions, sampling, **tasks** (long-running
+  operations), notifications (`*/list_changed`, `progress`,
+  `cancelled`, `resources/updated`, `tasks/changed`,
+  `replay_truncated`).
+- **Tool handlers**: arity 1 or arity 2 (`(Args, Ctx)`) with
+  `Ctx`-driven progress and cancel hooks. Return shapes:
+  plain content, `{tool_error, ...}` (→ `isError: true`), or
+  `{structured, Data, ...}` (→ `structuredContent`).
+- **Schema validation**: opt-in `validate_input` /
+  `validate_output` against registered JSON Schemas
+  (`barrel_mcp_schema`).
+- **Transports**: Streamable HTTP (Claude Code), legacy HTTP
+  (Cowboy), stdio (Claude Desktop). Streamable HTTP defaults to
+  `127.0.0.1`, validates `Origin`, and replays SSE events via
+  `Last-Event-ID`.
+- **Authentication**: bearer (JWT/opaque), API keys (peppered
+  HMAC-SHA-256), basic (PBKDF2-SHA256), custom providers.
+  Constant-time hash comparison; legacy SHA-256 hex digests still
+  verify for one release.
+- **Client library** (`barrel_mcp_client`): supervised
+  `gen_statem` with stdio + Streamable HTTP transports, OAuth 2.1
+  + PKCE, federation registry (one connection per server id),
+  pagination, schema pre-flight.
+- **Zero JSON dependency**: uses OTP 27+ built-in `json` module.
 
 ## Installation
 

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -139,12 +139,16 @@ barrel_mcp:start_http(#{
 
 ### Hashed Keys (Recommended for Production)
 
-Store hashed keys to protect against database leaks:
+The recommended format is a peppered HMAC-SHA-256 digest. The
+`pepper` is a server-side secret mixed into the hash so a leak of
+the stored hash table on its own isn't enough to forge keys.
 
 ```erlang
-%% Generate hashed keys (do this once, store the hash)
-Hash1 = barrel_mcp_auth_apikey:hash_key(<<"ak_prod_abc123">>),
-Hash2 = barrel_mcp_auth_apikey:hash_key(<<"ak_prod_xyz789">>),
+Pepper = <<"random-32-byte-pepper-loaded-from-env">>,
+Hash1 = barrel_mcp_auth_apikey:hash_key(<<"ak_prod_abc123">>,
+                                         #{pepper => Pepper}),
+Hash2 = barrel_mcp_auth_apikey:hash_key(<<"ak_prod_xyz789">>,
+                                         #{pepper => Pepper}),
 
 barrel_mcp:start_http(#{
     port => 9090,
@@ -155,11 +159,30 @@ barrel_mcp:start_http(#{
                 Hash1 => #{subject => <<"service-a">>},
                 Hash2 => #{subject => <<"service-b">>}
             },
-            hash_keys => true  %% Enable hash comparison
+            hash_keys => true,
+            pepper => Pepper
         }
     }
 }).
 ```
+
+Stored values look like
+`<<"hmac-sha256$<base64-encoded-hash>">>`.
+
+For verification outside the auth pipeline (config tooling,
+tests), use `barrel_mcp_auth_apikey:verify_key/2` — it does a
+constant-time comparison and accepts both the new format and
+legacy unsalted hex SHA-256 digests for one release.
+
+#### Migrating from legacy SHA-256
+
+`hash_key/1` (no pepper) still produces the legacy hex SHA-256
+format and is still accepted by the verifier. To migrate:
+
+1. Generate a `pepper` and load it from a secret store.
+2. Re-hash each existing key with `hash_key/2`.
+3. Replace the entries in your `keys` map.
+4. Drop the legacy entries.
 
 ### Custom Header Name
 
@@ -221,10 +244,15 @@ barrel_mcp:start_http(#{
 
 ### Hashed Passwords
 
+`hash_password/1,2` defaults to **PBKDF2-SHA256** (100k
+iterations, random 16-byte salt). Stored values look like
+`<<"pbkdf2-sha256$<iters>$<base64(salt)>$<base64(hash)>">>`.
+
 ```erlang
-%% Hash passwords (store these, not plain text)
+%% Hash passwords once, store the resulting binary, use that in
+%% the credentials map.
 AdminHash = barrel_mcp_auth_basic:hash_password(<<"secret123">>),
-UserHash = barrel_mcp_auth_basic:hash_password(<<"viewer456">>),
+UserHash  = barrel_mcp_auth_basic:hash_password(<<"viewer456">>),
 
 barrel_mcp:start_http(#{
     port => 9090,
@@ -232,7 +260,7 @@ barrel_mcp:start_http(#{
         provider => barrel_mcp_auth_basic,
         provider_opts => #{
             credentials => #{
-                <<"admin">> => AdminHash,
+                <<"admin">>    => AdminHash,
                 <<"readonly">> => UserHash
             },
             hash_passwords => true
@@ -240,6 +268,17 @@ barrel_mcp:start_http(#{
     }
 }).
 ```
+
+`hash_password/2` accepts an options map:
+
+- `algorithm` — `pbkdf2-sha256` (default) or `sha256-hex` (legacy,
+  for migration only).
+- `iterations` — PBKDF2 iteration count (default 100000).
+
+The verification path is the public `verify_password/2`. It
+accepts the modern format and legacy hex SHA-256 digests for one
+release; the legacy code path logs a deprecation warning on every
+match.
 
 ### With Scopes and Metadata
 

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -192,6 +192,34 @@ timeout).
 The full echo-client example lives in
 [`examples/echo_client/src/echo_client.erl`](https://github.com/barrel-platform/barrel_mcp/tree/main/examples/echo_client/src/echo_client.erl).
 
+### Tool results
+
+`call_tool/3,4` returns the server's `result` map. Three shapes
+the spec allows:
+
+```erlang
+classify(#{<<"isError">> := true} = R) ->
+    {error, maps:get(<<"content">>, R)};
+classify(#{<<"structuredContent">> := Data} = R) ->
+    {structured, Data, maps:get(<<"content">>, R, [])};
+classify(#{<<"content">> := Content}) ->
+    {ok, Content}.
+```
+
+- `isError: true` → the tool reported a domain-level failure
+  (validation, business rule). The `content` is human-readable.
+- `structuredContent` → typed payload, optionally paired with
+  human-readable `content` blocks. When the tool registered an
+  `outputSchema`, the typed payload conforms to it.
+- Plain `content` → standard MCP content blocks.
+
+### Tasks
+
+If the server registered the tool with `long_running => true`,
+`call_tool` returns immediately with `#{<<"taskId">> := Id,
+<<"status">> := <<"running">>}`. Track progress with the methods
+in section 12.
+
 ---
 
 ## 8. Read and subscribe to resources
@@ -317,7 +345,7 @@ handle_request(<<"sampling/createMessage">>, Params, State) ->
 
 ---
 
-## 12. Notifications
+## 12. Notifications and tasks
 
 The handler's `handle_notification/3` callback receives every inbound
 notification with its raw `params` map. Common methods:
@@ -327,12 +355,37 @@ notification with its raw `params` map. Common methods:
 - `notifications/progress` — also dispatched to the caller of the
   request that owns the progress token (see section 7).
 - `notifications/tools/list_changed`, `.../resources/list_changed`,
-  `.../prompts/list_changed` — surface only via the handler.
-- `notifications/message` — server logging stream. Surface in the
-  handler.
+  `.../prompts/list_changed` — catalogue updated; re-fetch or
+  invalidate caches.
+- `notifications/tasks/changed` — a long-running task transitioned
+  state. The full task record is in `params`.
+- `notifications/message` — server logging stream.
+- `notifications/replay_truncated` — your `Last-Event-ID` was
+  outside the server's replay window; resync rather than trust the
+  partial stream.
 
 The handler is the right place to integrate with your application's
 metrics, logs, or UI.
+
+### Task methods
+
+When a tool was registered as `long_running` on the server, the
+initial `call_tool` returns a `taskId`. Track it via the
+`tasks/*` request methods (see the spec for shapes; on the wire
+they are `tasks/list`, `tasks/get`, `tasks/cancel`). The client's
+public API exposes them as direct `request/3` calls:
+
+```erlang
+poll_task(Pid, TaskId) ->
+    %% `tasks/get' is just another spec method; until the client
+    %% adds a typed wrapper you can call it via the request shape.
+    barrel_mcp_client:request(Pid, <<"tasks/get">>,
+                              #{<<"taskId">> => TaskId}).
+```
+
+When you registered a `progress_token` on the originating call,
+the same task usually emits `notifications/progress` updates that
+arrive through your handler, so polling is rarely required.
 
 ---
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -5,15 +5,101 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
 
 ## Server
 
-- HTTP transport (`barrel_mcp_http`) — JSON-RPC over POST.
-- Streamable HTTP transport (`barrel_mcp_http_stream`) — protocol
-  `2025-03-26`. POST (JSON or SSE), GET (SSE), DELETE, OPTIONS.
+### Transports
+
+- HTTP transport (`barrel_mcp_http`) — JSON-RPC over POST. Legacy.
+- Streamable HTTP transport (`barrel_mcp_http_stream`) — MCP
+  `2025-11-25` with downward negotiation to `2025-06-18`,
+  `2025-03-26`, `2024-11-05`. POST (JSON or SSE), GET (SSE),
+  DELETE, OPTIONS. Default bind `127.0.0.1`; public binds require
+  `allowed_origins`. `Origin` is validated structurally on every
+  method (POST/GET/DELETE/OPTIONS); literal `Origin: null` is
+  rejected unless explicitly allowed. CORS echoes the validated
+  origin (no wildcard); `Access-Control-Allow-Headers` is derived
+  from the configured auth provider.
 - stdio transport (`barrel_mcp_stdio`).
-- Tool / resource / prompt registries.
-- Session management with `Mcp-Session-Id` and TTL.
-- Authentication providers: bearer, API key, basic, custom.
-- Server-to-client sampling (`sampling/createMessage`) and resource
-  update notifications.
+
+### Wire-level conformance
+
+- POSTed JSON-RPC requests return either a JSON envelope or an SSE
+  stream. Notifications and POSTed responses to server-initiated
+  requests return HTTP 202 with empty body.
+- Missing `Mcp-Session-Id` on a non-`initialize` request → 400;
+  unknown id → 404.
+- `MCP-Protocol-Version` validated server-side: missing falls back
+  to the session-stored negotiated version; unsupported → 400.
+- JSON-RPC `id` must be string or integer; `null` and other shapes
+  rejected with -32600. Top-level JSON arrays (batches) explicitly
+  rejected — MCP removed batching.
+- `notifications/cancelled` aborts the in-flight tool call; the
+  cancelled HTTP request closes with 200 and an empty body (no
+  JSON-RPC envelope, per spec).
+- Per-session SSE ring buffer (default 256 entries) for
+  `Last-Event-ID` replay; out-of-window ids surface a synthetic
+  `notifications/replay_truncated` event.
+
+### Registries
+
+- **Tools** — handlers may be arity 1 or arity 2. Arity-2
+  handlers receive a `Ctx` map with `session_id`, `request_id`,
+  `progress_token`, and an `emit_progress` function.
+- **Resources** — text/binary content, MIME types,
+  `notifications/resources/updated` for live updates.
+- **Resource templates** — RFC 6570 URI templates, surfaced via
+  `resources/templates/list`.
+- **Prompts** — multi-message conversation templates with
+  arguments.
+- **Completions** — keyed by `{prompt, Name, Arg}` or
+  `{resource_template, Uri, Arg}`; advertised via the
+  `completions` capability when at least one is registered.
+- All registrations accept optional `title` and `icons`.
+
+### Tool features
+
+- Return shapes: plain (text / map / list / image), `{tool_error,
+  Content}` (→ `isError: true`), `{structured, Data}` /
+  `{structured, Data, Content}` (→ `structuredContent`).
+- `validate_input` and `validate_output` opt-in schema validation
+  via `barrel_mcp_schema`.
+- `long_running => true` returns a `taskId` immediately and runs
+  the worker in the background. Backed by `barrel_mcp_tasks` —
+  surfaces `tasks/list`, `tasks/get`, `tasks/cancel`, and
+  `notifications/tasks/changed`.
+- Cancellation: cooperative arity-2 handlers see
+  `{cancel, RequestId}` in their mailbox; arity-1 handlers run to
+  completion but their result is discarded.
+- Progress: handlers call `(maps:get(emit_progress, Ctx))(Done,
+  Total, MessageOrUndef)`; out-of-band code can use
+  `barrel_mcp:notify_progress/3,4`.
+
+### Sessions
+
+- ETS tables are `protected`; mutators run in
+  `barrel_mcp_session`'s gen_server.
+- `Mcp-Session-Id` lifecycle with TTL-based cleanup.
+- Server-to-client sampling (`sampling/createMessage`) and
+  resource update notifications.
+
+### Authentication
+
+- Providers: `barrel_mcp_auth_bearer`, `barrel_mcp_auth_apikey`,
+  `barrel_mcp_auth_basic`, `barrel_mcp_auth_none`,
+  `barrel_mcp_auth_custom`.
+- Hashing: `barrel_mcp_auth_basic:hash_password/1,2` defaults to
+  PBKDF2-SHA256 (100k iterations, 16-byte salt).
+  `barrel_mcp_auth_apikey:hash_key/2` produces a peppered HMAC-SHA-256
+  digest. Both verifiers accept legacy hex SHA-256 digests for one
+  release. All comparisons are constant-time.
+
+### Server-to-client primitives
+
+| Façade | Effect |
+| --- | --- |
+| `barrel_mcp:notify_resource_updated/1,2` | `notifications/resources/updated` to every subscriber. |
+| `barrel_mcp:notify_progress/3,4` | `notifications/progress` to a session. |
+| `barrel_mcp:notify_list_changed/1` | `notifications/tools/list_changed`, `.../resources/list_changed`, or `.../prompts/list_changed` to every active SSE session. Auto-emitted on `reg_*`/`unreg_*`. |
+| `barrel_mcp:sampling_create_message/3` | Server→client `sampling/createMessage` (requires the client to declare `sampling` capability). |
+| `barrel_mcp_tasks:create/3`, `finish/3`, `fail/3`, `cancel/2` | Long-running operation lifecycle. |
 
 ## Client (`barrel_mcp_client`)
 
@@ -105,7 +191,8 @@ end.
 
 ### Roadmap
 
-- Resumable Streamable HTTP via `Last-Event-ID` (transport buffers
-  the last id but does not yet replay missed events on reconnect).
 - Periodic deadline timer for in-flight requests beyond the per-call
   timeout (today timeouts fire only when configured per-request).
+- Client-side `Last-Event-ID` resume (server-side replay is shipped;
+  client transport tracks the last id but does not yet replay on
+  reconnect from its own state).

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -41,7 +41,10 @@ Tools are functions that can be called by MCP clients (like Claude):
 -module(my_tools).
 -export([greet/1]).
 
-%% Tool handler - receives arguments as a map
+%% Arity-1 handler — gets only the call arguments. The simplest
+%% shape; pick this when you don't need progress, cancellation, or
+%% session context. For arity-2 handlers (with a Ctx parameter),
+%% see the Tools guide.
 greet(Args) ->
     Name = maps:get(<<"name">>, Args, <<"World">>),
     <<"Hello, ", Name/binary, "!">>.
@@ -67,8 +70,17 @@ barrel_mcp:reg_tool(<<"greet">>, my_tools, greet, #{
 ### 2. Start the HTTP Server
 
 ```erlang
-{ok, _} = barrel_mcp:start_http(#{port => 9090}).
+{ok, _} = barrel_mcp:start_http_stream(#{port => 9090}).
 ```
+
+The Streamable HTTP server binds to `127.0.0.1` by default and
+validates the `Origin` header on every request. Public binds (any
+non-loopback IP) require an explicit `allowed_origins` — see the
+[Streamable HTTP guide](http-stream.md) for the security defaults.
+
+The legacy plain-HTTP transport (`start_http/1`, JSON-RPC only,
+protocol `2024-11-05`) is still available for clients that don't
+speak the Streamable HTTP transport.
 
 ### 3. Test Your Server
 
@@ -111,8 +123,10 @@ For Claude Desktop integration, use the stdio transport:
 
 ## Next Steps
 
-- [Tools, Resources & Prompts](tools-resources-prompts.md) - Learn about MCP primitives
-- [Authentication](authentication.md) - Secure your MCP server
-- [Building a client](building-a-client.md) - Task-oriented walkthrough for hosting MCP clients (recommended)
-- [Client internals](internals.md) - Architecture and behaviour contracts
+- [Tools, Resources & Prompts](tools-resources-prompts.md) — handler shapes (arity 1 / arity 2 with `Ctx`), tool errors, structured output, long-running tasks, completions, resource templates, server notifications.
+- [Streamable HTTP transport](http-stream.md) — security defaults, CORS, `Origin` validation, response codes, replay.
+- [Authentication](authentication.md) — bearer / API key / basic, modern hash formats.
+- [Features matrix](features.md) — what's supported on the wire.
+- [Building a client](building-a-client.md) — task-oriented walkthrough for hosting MCP clients.
+- [Client internals](internals.md) — architecture and behaviour contracts.
 - [MCP Client (reference)](client.md) - Older API reference, kept for cross-linking

--- a/guides/http-stream.md
+++ b/guides/http-stream.md
@@ -1,17 +1,24 @@
 # Streamable HTTP Transport
 
-MCP Streamable HTTP transport (protocol 2025-03-26) for Claude Code integration.
+MCP Streamable HTTP transport for Claude Code (and any other MCP
+client speaking the same protocol).
 
 ## Overview
 
-The Streamable HTTP transport implements the MCP protocol version 2025-03-26, which is the transport expected by Claude Code's `--transport http` option.
+The Streamable HTTP transport implements MCP `2025-11-25` and
+negotiates downward to `2025-06-18`, `2025-03-26`, and
+`2024-11-05` based on the client's `initialize` request. It is the
+transport expected by Claude Code's `--transport http` option.
 
 This transport supports:
-- **POST** for client requests with JSON or SSE streaming responses
-- **GET** for server-to-client notification streams (SSE)
-- **DELETE** for session termination
-- **OPTIONS** for CORS preflight
-- **Session management** via `Mcp-Session-Id` header
+
+- **POST** for client requests with JSON or SSE streaming responses.
+- **GET** for server-to-client notification streams (SSE).
+- **DELETE** for session termination.
+- **OPTIONS** for CORS preflight.
+- **Session management** via `Mcp-Session-Id` header.
+- **Replay on reconnect** via `Last-Event-ID`.
+- **Origin validation** with operator-controlled allow-list.
 
 ## Starting the Server
 
@@ -52,11 +59,38 @@ barrel_mcp:start_http_stream(#{
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `port` | `pos_integer()` | `9090` | Port number |
-| `ip` | `inet:ip_address()` | `{0,0,0,0}` | IP address to bind |
-| `auth` | `map()` | `#{}` | Authentication configuration |
-| `session_enabled` | `boolean()` | `true` | Enable session management |
-| `ssl` | `map()` | `undefined` | TLS configuration |
+| `port` | `pos_integer()` | `9090` | Port number. |
+| `ip` | `inet:ip_address()` | `{127,0,0,1}` | Bind address. **Default is loopback.** Public binds require `allowed_origins` (see below). |
+| `auth` | `map()` | `#{}` | Authentication configuration. |
+| `session_enabled` | `boolean()` | `true` | Enable session management. |
+| `ssl` | `map()` | `undefined` | TLS configuration. |
+| `allowed_origins` | `[binary()] \| any` | loopback set on loopback bind; required on public bind | List of allowed `Origin` values, structurally matched (scheme + host + port). Use `any` to disable validation. The literal `<<"null">>` may be included to allow sandboxed-frame origins. |
+| `allow_missing_origin` | `boolean()` | `true` on loopback, `false` otherwise | Whether to accept requests with no `Origin` header. Non-browser clients typically don't send one. |
+| `sse_buffer_size` | `pos_integer()` | `256` | Per-session ring buffer of recent SSE events for `Last-Event-ID` replay. |
+
+### Security defaults
+
+The transport binds to `127.0.0.1` by default. Public binds (any
+non-loopback IP) require an explicit `allowed_origins`; the start
+function refuses with `{error, allowed_origins_required}`
+otherwise. This avoids accidental exposure to DNS-rebinding and
+CORS-style attacks.
+
+```erlang
+%% Public bind — must list allowed origins explicitly.
+{ok, _} = barrel_mcp:start_http_stream(#{
+    port => 9090,
+    ip => {0, 0, 0, 0},
+    allowed_origins => [<<"https://app.example.com">>]
+}).
+```
+
+CORS responses echo the validated `Origin` (no wildcard) and add
+`Vary: Origin`. The `Access-Control-Allow-Headers` list is
+derived from the configured auth provider via the optional
+`auth_headers/1` callback on `barrel_mcp_auth`, so a custom
+`header_name` on `barrel_mcp_auth_apikey` flows through both the
+preflight allow-list and the request handler's header extraction.
 
 ## Claude Code Integration
 
@@ -205,14 +239,43 @@ Then use HTTPS URL with Claude Code:
 claude mcp add my-server --transport http https://my-server.example.com:9443/mcp
 ```
 
-## CORS
+## CORS and request validation
 
-The server includes CORS headers for browser-based clients:
+The server validates `Origin` on every request method (POST, GET,
+DELETE, OPTIONS) and replies with 403 on mismatch. When the
+request's `Origin` validates, the response includes:
 
-- `Access-Control-Allow-Origin: *`
+- `Access-Control-Allow-Origin: <validated origin>`
+- `Vary: Origin`
 - `Access-Control-Allow-Methods: POST, GET, DELETE, OPTIONS`
-- `Access-Control-Allow-Headers: content-type, authorization, x-api-key, mcp-session-id, accept`
-- `Access-Control-Expose-Headers: www-authenticate, mcp-session-id`
+- `Access-Control-Allow-Headers: content-type, accept,
+  mcp-session-id, mcp-protocol-version, last-event-id` plus any
+  auth headers declared by the configured provider.
+- `Access-Control-Expose-Headers: www-authenticate,
+  mcp-session-id, mcp-protocol-version`
+
+When the request has no `Origin` header (typical of non-browser
+clients) and `allow_missing_origin` is `true`, the response omits
+`Access-Control-Allow-Origin` entirely rather than synthesising a
+value.
+
+## Wire-level conformance
+
+The transport implements MCP `2025-11-25` conformance points
+explicitly:
+
+| Wire | Behaviour |
+| --- | --- |
+| `MCP-Protocol-Version` request header | Required after init. Unsupported value → 400; missing falls back to the session-stored negotiated version; pre-init missing assumes `2025-03-26`. |
+| `Mcp-Session-Id` request header | Required on every non-`initialize` request when `session_enabled` is true. Missing → 400; unknown id → 404. `initialize` is the only request that creates a session. |
+| Notifications and posted server-bound responses | HTTP 202 Accepted, empty body. |
+| JSON-RPC ids | Must be string or integer. `null` or any other shape → -32600 Invalid Request. |
+| JSON-RPC batches | Top-level JSON arrays explicitly rejected with -32600 (MCP removed batching). |
+| `notifications/cancelled` | Cancels the in-flight tool call; the originating HTTP request closes with 200 and an empty body (no JSON-RPC envelope, per spec). |
+
+The session, subscription, and pending-request ETS tables are
+`protected`; mutators run in the session manager so a non-owning
+process cannot tamper with the table.
 
 ## Protocol Differences
 
@@ -220,12 +283,13 @@ The server includes CORS headers for browser-based clients:
 
 | Feature | Legacy (`start_http`) | Streamable (`start_http_stream`) |
 |---------|----------------------|----------------------------------|
-| Protocol Version | 2024-11-05 | 2025-03-26 |
+| Protocol Version | 2024-11-05 | 2025-11-25 (negotiates downward) |
 | Claude Code | Not supported | Supported |
 | Sessions | No | Yes |
 | SSE Responses | No | Yes |
 | GET for streams | No | Yes |
 | DELETE for cleanup | No | Yes |
+| Origin validation | Yes | Yes |
 
 ### When to Use
 

--- a/guides/stdio.md
+++ b/guides/stdio.md
@@ -7,10 +7,17 @@ transport used by Claude Desktop and other MCP clients that spawn server process
 
 Unlike HTTP transport, stdio transport:
 
-- Uses newline-delimited JSON-RPC messages
-- Runs as a child process spawned by the MCP client
-- Is ideal for local integrations (no network overhead)
-- Is the primary transport for Claude Desktop
+- Uses newline-delimited JSON-RPC messages.
+- Runs as a child process spawned by the MCP client.
+- Is ideal for local integrations (no network overhead).
+- Is the primary transport for Claude Desktop.
+
+The same registries (tools, resources, prompts, resource
+templates, completions, tasks) work over stdio. Tool handlers may
+be arity 1 or arity 2 (`(Args, Ctx)`) — the `emit_progress` and
+cancellation hooks in `Ctx` interleave on stdout in stdio just
+like they do on the SSE channel for HTTP. See the
+[Tools guide](tools-resources-prompts.md) for the handler shape.
 
 ## Quick Start
 

--- a/guides/tools-resources-prompts.md
+++ b/guides/tools-resources-prompts.md
@@ -70,25 +70,25 @@ barrel_mcp:reg_tool(<<"calculate">>, my_tools, calculate, #{
 
 ### Tool Return Values
 
-Tools can return different types:
+Tools can return any of:
 
 ```erlang
-%% Binary - returned as text content
+%% Binary -> single text content block.
 text_tool(_Args) ->
     <<"Hello, World!">>.
 
-%% Map - automatically JSON encoded
+%% Map -> JSON-encoded text content block.
 json_tool(_Args) ->
     #{<<"key">> => <<"value">>, <<"count">> => 42}.
 
-%% List of content blocks - for multiple outputs
+%% List of content blocks -> verbatim.
 multi_tool(_Args) ->
     [
         #{<<"type">> => <<"text">>, <<"text">> => <<"First result">>},
         #{<<"type">> => <<"text">>, <<"text">> => <<"Second result">>}
     ].
 
-%% Image content
+%% Image content block.
 image_tool(_Args) ->
     ImageData = base64:encode(read_image_file()),
     #{
@@ -96,23 +96,109 @@ image_tool(_Args) ->
         <<"data">> => ImageData,
         <<"mimeType">> => <<"image/png">>
     }.
+
+%% Tool-level error: rendered as `{ "isError": true, "content": [...] }'
+%% on the wire. Use this for failures that are part of the tool's
+%% domain (validation, business rules) rather than infrastructure.
+flaky_tool(_Args) ->
+    {tool_error, [#{<<"type">> => <<"text">>,
+                    <<"text">> => <<"Quota exceeded">>}]}.
+
+%% Structured output: machine-readable data plus optional human-readable
+%% content blocks. Surfaces as `structuredContent' on the wire.
+%% Pair with the `output_schema' option to validate the data shape.
+weather(_Args) ->
+    {structured, #{<<"tempF">> => 72, <<"sky">> => <<"clear">>},
+     [#{<<"type">> => <<"text">>, <<"text">> => <<"72°F, clear">>}]}.
 ```
 
-### Error Handling
+`{tool_error, Content}` and `{structured, Data, Content}` are the
+recommended shapes. Plain returns still work; raised exceptions are
+caught and surfaced as a JSON-RPC error to the client.
 
-Return errors for graceful failure:
+### Async handlers (`Ctx`-aware)
+
+Tools may be exported as arity 2 instead of arity 1. The second
+argument is a context map the runtime fills in:
 
 ```erlang
-safe_divide(Args) ->
-    A = maps:get(<<"a">>, Args),
-    B = maps:get(<<"b">>, Args),
-    case B of
-        0 -> error(division_by_zero);
-        _ -> #{<<"result">> => A / B}
-    end.
+%% (Args, Ctx) -> Result. Ctx holds:
+%%   session_id     :: binary() | undefined,
+%%   request_id     :: integer() | binary(),
+%%   progress_token :: binary() | undefined,
+%%   emit_progress  :: fun((Done, Total, Message | undefined) -> ok)
+download(Args, Ctx) ->
+    Url = maps:get(<<"url">>, Args),
+    Emit = maps:get(emit_progress, Ctx),
+    Emit(0.0, 1.0, undefined),
+    {ok, Body} = fetch(Url),
+    Emit(1.0, 1.0, undefined),
+    Body.
 ```
 
-Errors are caught and returned as MCP error responses.
+Arity-2 handlers are needed for tools that:
+
+- emit `notifications/progress` updates,
+- cooperate with `notifications/cancelled` (the worker receives
+  `{cancel, RequestId}` in its mailbox),
+- need the calling session id for server→client primitives.
+
+Arity-1 handlers continue to work; pick whichever arity you need.
+
+### Long-running tools (tasks)
+
+Set `long_running => true` on `reg_tool/4` and the tool returns
+immediately to the client with a `taskId`. The handler keeps
+running in the background and the runtime stores its eventual
+outcome on the task. Clients track progress via `tasks/get`,
+`tasks/list`, or `notifications/tasks/changed`.
+
+```erlang
+barrel_mcp:reg_tool(<<"render_video">>, my_tools, render_video, #{
+    long_running => true,
+    description => <<"Render a video on the GPU farm">>
+}).
+```
+
+The same handler shape (arity 1 or arity 2) applies. Long-running
+handlers may emit progress just like any other tool.
+
+### Schema validation
+
+Two opt-in flags on `reg_tool/4`:
+
+```erlang
+barrel_mcp:reg_tool(<<"search">>, my_tools, search, #{
+    input_schema => #{<<"type">> => <<"object">>,
+                       <<"required">> => [<<"query">>]},
+    output_schema => #{<<"type">> => <<"object">>,
+                        <<"required">> => [<<"results">>]},
+    validate_input  => true,
+    validate_output => true
+}).
+```
+
+`validate_input` checks the call's `arguments` against
+`input_schema` before invoking the handler. `validate_output`
+checks the structured `Data` from `{structured, Data, _}` returns
+against `output_schema`. Failures surface to the client as
+`isError: true` content. The validator subset is documented under
+`barrel_mcp_schema`.
+
+### Metadata: `title` and `icons`
+
+Every registration accepts a human-readable `title` and a list of
+`icons` (each `#{src, sizes?, mime_type?}`). Both surface in the
+matching `*/list` response. Empty fields are omitted from the
+wire.
+
+```erlang
+barrel_mcp:reg_tool(<<"search">>, my_tools, search, #{
+    title => <<"Knowledge Base Search">>,
+    icons => [#{<<"src">> => <<"https://example.com/icon.png">>,
+                 <<"sizes">> => <<"32x32">>}]
+}).
+```
 
 ### Managing Tools
 
@@ -348,6 +434,87 @@ PromptResult = barrel_mcp:get_prompt(<<"summarize">>, #{
 %% Unregister
 barrel_mcp:unreg_prompt(<<"summarize">>).
 ```
+
+## Resource Templates
+
+URI templates (RFC 6570) advertise families of resources without
+enumerating every URI. Register one handler per template:
+
+```erlang
+barrel_mcp:reg_resource_template(<<"file">>, my_resources, read_file_uri, #{
+    name => <<"File Reader">>,
+    uri_template => <<"file:///{path}">>,
+    description => <<"Read any file on the local FS">>,
+    mime_type => <<"text/plain">>
+}).
+```
+
+`barrel_mcp:list_resource_templates/0` lists registrations.
+Templates surface on the wire via `resources/templates/list`. The
+matching `resources/read` request still goes through your normal
+resource handler (or directly through the template handler if you
+implement URI parsing yourself).
+
+## Completions
+
+Completion handlers suggest values for a prompt argument or a
+resource-template argument. Register them keyed by the parent
+plus the argument name:
+
+```erlang
+suggest_lengths(<<"sh">>, _Ctx) -> {ok, [<<"short">>]};
+suggest_lengths(_, _Ctx)        -> {ok, [<<"short">>, <<"medium">>, <<"long">>]}.
+
+barrel_mcp:reg_completion(
+    {prompt, <<"summarize">>, <<"length">>},
+    my_completions, suggest_lengths, #{}).
+```
+
+Handlers are arity 2: `(PartialValue, Ctx)`. Return one of:
+
+- `{ok, [Suggestion]}` — full list.
+- `{ok, [Suggestion], #{has_more => true}}` — more available; the
+  client can issue another `completion/complete` to drill in.
+
+The `completions` capability is advertised in `initialize` as soon
+as at least one completion handler is registered.
+
+## Tasks (long-running operations)
+
+The `barrel_mcp_tasks` module backs the `tasks/list`, `tasks/get`,
+and `tasks/cancel` MCP methods, plus the
+`notifications/tasks/changed` notifications.
+
+You don't usually call this module directly: registering a tool
+with `long_running => true` (see above) wires the lifecycle for
+you. The collector process records the worker's eventual outcome
+as a task transition (`running` → `success | error | cancelled`)
+and emits the matching notification on the session's SSE channel.
+
+Hosts that drive their own long-running operations outside the
+tool path can use the public API:
+
+```erlang
+{ok, TaskId} = barrel_mcp_tasks:create(SessionId, <<"reindex">>, #{}),
+%% later:
+ok = barrel_mcp_tasks:finish(SessionId, TaskId, #{<<"reindexed">> => 12000}).
+```
+
+Tasks are evicted from memory one hour after they reach a terminal
+state (success / error / cancelled).
+
+## Server → client notifications
+
+Every notification the server can emit goes through the session's
+SSE channel:
+
+| Notification | Façade |
+| --- | --- |
+| `notifications/resources/updated` | `barrel_mcp:notify_resource_updated/1,2` |
+| `notifications/tools/list_changed`<br>`notifications/resources/list_changed`<br>`notifications/prompts/list_changed` | `barrel_mcp:notify_list_changed/1` (tool, resource, prompt). `reg_tool/4`/`unreg_tool/1` and friends emit it automatically; call the façade if you mutate the catalogue out of band. |
+| `notifications/progress` | `barrel_mcp:notify_progress/3,4` (or via `Ctx` from an arity-2 tool handler). |
+| `notifications/tasks/changed` | Emitted by `barrel_mcp_tasks` on every status transition. |
+| `notifications/message` (logging) | Emitted by `barrel_mcp_session` when a host calls `logger`-style helpers. |
 
 ## Handler Best Practices
 


### PR DESCRIPTION
- Tools guide covers arity-2 handlers with `Ctx`, the new `tool_error` / `structured` return shapes, schema validation, long-running tasks, resource templates, completions, and the server-to-client notification surface.
- Streamable HTTP guide reflects the security defaults (loopback bind, `Origin` validation, `allowed_origins`, CORS without wildcard, response codes, `Last-Event-ID` replay, JSON-RPC strictness).
- Authentication guide documents PBKDF2-SHA256 password hashes and peppered HMAC-SHA256 API key hashes, with a migration note for legacy SHA-256 hex.
- `features.md` matrix updated to MCP `2025-11-25` and includes the full server surface (tasks, completions, structured output, list-changed notifications).
- Getting-started recommends `start_http_stream`, points at the new sections.
- Building-a-client covers tool result classification (`isError`, `structuredContent`) and task notifications.