### PR TITLE
Critical correctness + security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Critical correctness and security fixes
+
+- **API-key auth verification.** `barrel_mcp_auth_apikey:verify_key/2` no longer returns `ok` for any HMAC-formatted stored value (it was self-comparing `Stored` with itself). The 2-arity helper now rejects HMAC formats with `{error, pepper_required}`; a new `verify_key/3` takes the pepper and does a constant-time HMAC compare. The provider state now keeps `pepper`, so `hash_keys => true` with a configured pepper actually verifies HMAC keys end to end.
+- **Async tools/call works on stdio and legacy HTTP.** `barrel_mcp_protocol:handle/2` returns `{async, AsyncPlan}` for `tools/call`; both transports now drive the plan via the new `barrel_mcp_protocol:drive_async_plan/2` helper. Tool calls over stdio went from broken to functional.
+- **Session cleanup no longer self-calls.** The cleanup timer in `barrel_mcp_session` previously routed through `gen_server:call(?MODULE, ...)` from inside its own `handle_info` and would deadlock. The cleanup is now inlined in `handle_info(cleanup, _)`.
+- **Basic auth unknown-user timing.** The unknown-user fake check now runs the same PBKDF2 work as the configured-user path via a precomputed dummy hash. Previously the configured `hash_passwords => false` path used a fast SHA-256 compare while the unknown-user path always did PBKDF2, leaking username existence.
+- **Streamable HTTP: Accept strictness.** POST clients must list both `application/json` and `text/event-stream` (or `*/*`). `application/json` alone now returns 406.
+- **Streamable HTTP: initialize with unknown session id → 404.** Previously silently created a fresh session; now forces the client to re-initialize without a session header.
+- **Legacy HTTP transport hardened.** Reuses the Streamable HTTP `validate_origin/2`, `cors_response_headers/3`, and `extract_headers/2` helpers. No more wildcard `Access-Control-Allow-Origin`; auth headers come from the configured provider's `auth_headers/1` callback (custom `header_name` flows through CORS and into header extraction).
+- **`tasks/cancel` actually stops the worker.** Long-running tools now record their worker pid on the task; `tasks/cancel` sends `{cancel, RequestId}` to the worker before transitioning the stored status. Cooperative arity-2 handlers can abort cleanly; arity-1 handlers still run to completion but their result is dropped because the task is in a terminal state.
+
 ### Spec parity additives
 
 - Long-running tools return a `taskId` immediately; clients track them via `tasks/list`, `tasks/get`, `tasks/cancel` and `notifications/tasks/changed`. Opt in with `reg_tool/4`'s `long_running => true`.

--- a/src/barrel_mcp_auth_apikey.erl
+++ b/src/barrel_mcp_auth_apikey.erl
@@ -33,7 +33,8 @@
 -export([
     hash_key/1,
     hash_key/2,
-    verify_key/2
+    verify_key/2,
+    verify_key/3
 ]).
 
 %%====================================================================
@@ -48,7 +49,8 @@ init(Opts) ->
         keys => Keys,
         verifier => maps:get(verifier, Opts, undefined),
         header_name => maps:get(header_name, Opts, <<"x-api-key">>),
-        hash_keys => maps:get(hash_keys, Opts, false)
+        hash_keys => maps:get(hash_keys, Opts, false),
+        pepper => maps:get(pepper, Opts, undefined)
     },
     {ok, State}.
 
@@ -171,29 +173,49 @@ hash_key(Key, _) ->
     legacy_sha256_hex(Key).
 
 %% @doc Constant-time comparison of a presented `Key' against a
-%% `Stored' format. Accepts the legacy hex SHA-256 digest and the
-%% new `hmac-sha256$...' format. Hosts may also pass
-%% `{Key, Pepper, Stored}' via `hash_key/2' equivalence; this
-%% helper is for stored-vs-presented checks.
+%% `Stored' digest. Accepts only the legacy hex SHA-256 format —
+%% the modern `hmac-sha256$...' format requires the server-side
+%% pepper, which {@link verify_key/3} takes explicitly. This shim
+%% rejects HMAC-format inputs so callers don't accidentally treat
+%% them as verified.
 -spec verify_key(Key :: binary(), Stored :: binary()) ->
-    ok | {error, invalid_credentials}.
-verify_key(_Key, <<"hmac-sha256$", _/binary>> = Stored) ->
-    %% The server's pepper is needed to reproduce the hash; without
-    %% it we cannot verify. The provider's authenticate path uses
-    %% `verify_against_state' which knows the pepper. Public callers
-    %% that just want format-level verification should call
-    %% `hash_key/2' and compare the binaries themselves; here we
-    %% only assert format equality with constant-time compare.
-    case crypto:hash_equals(Stored, Stored) of
-        true -> ok;  %% format ok; pepper-aware verification is host's job
-        false -> {error, invalid_credentials}
-    end;
+    ok | {error, invalid_credentials} | {error, pepper_required}.
+verify_key(_Key, <<"hmac-sha256$", _/binary>>) ->
+    {error, pepper_required};
 verify_key(Key, Stored) when byte_size(Stored) =:= 64 ->
     case crypto:hash_equals(legacy_sha256_hex(Key), Stored) of
         true -> ok;
         false -> {error, invalid_credentials}
     end;
 verify_key(_Key, _Stored) ->
+    {error, invalid_credentials}.
+
+%% @doc Constant-time comparison of a presented `Key' against a
+%% `Stored' digest, with the server-side `Pepper' used for the
+%% `hmac-sha256$...' format. The `Pepper' is ignored for legacy
+%% hex SHA-256 digests (they were produced without a pepper). Use
+%% this from any code that owns the pepper (config tooling,
+%% tests) — the auth provider's internal authenticate path goes
+%% through `verify_against_state/2' which already has the pepper
+%% in state.
+-spec verify_key(Key :: binary(), Stored :: binary(),
+                 Pepper :: binary() | undefined) ->
+    ok | {error, invalid_credentials}.
+verify_key(Key, <<"hmac-sha256$", _/binary>> = Stored, Pepper)
+  when is_binary(Pepper) ->
+    Computed = hmac_format(Key, Pepper),
+    case crypto:hash_equals(Computed, Stored) of
+        true -> ok;
+        false -> {error, invalid_credentials}
+    end;
+verify_key(_Key, <<"hmac-sha256$", _/binary>>, undefined) ->
+    {error, invalid_credentials};
+verify_key(Key, Stored, _Pepper) when byte_size(Stored) =:= 64 ->
+    case crypto:hash_equals(legacy_sha256_hex(Key), Stored) of
+        true -> ok;
+        false -> {error, invalid_credentials}
+    end;
+verify_key(_Key, _Stored, _Pepper) ->
     {error, invalid_credentials}.
 
 %% Internal: build the new stored format `hmac-sha256$<b64(hash)>'.

--- a/src/barrel_mcp_auth_basic.erl
+++ b/src/barrel_mcp_auth_basic.erl
@@ -109,18 +109,18 @@ verify_credentials(Username, Password, #{verifier := Verifier})
     end;
 verify_credentials(Username, Password, #{credentials := Creds, hash_passwords := HashPwd})
   when map_size(Creds) > 0 ->
-    %% Lookup in credentials map
+    %% Lookup in credentials map. The unknown-user path runs the
+    %% same verify_password/2 work as the configured-user path so
+    %% timing doesn't leak username existence.
     case maps:get(Username, Creds, undefined) of
         undefined ->
-            %% Constant-time fake check to prevent timing attacks
-            _ = hash_password(Password),
+            _ = verify_password(Password, dummy_hash()),
             {error, invalid_credentials};
         ExpectedPassword when is_binary(ExpectedPassword) ->
             verify_password(Username, Password, ExpectedPassword, HashPwd);
         #{password := ExpectedPassword} = Info ->
             case verify_password(Username, Password, ExpectedPassword, HashPwd) of
                 {ok, _} ->
-                    %% Build auth info from stored info
                     AuthInfo = #{
                         subject => Username,
                         scopes => maps:get(scopes, Info, []),
@@ -241,6 +241,20 @@ parse_pbkdf2(Bin) ->
 legacy_sha256_hex(Password) ->
     Digest = crypto:hash(sha256, Password),
     encode_hex(Digest).
+
+%% Lazily-built PBKDF2 hash used as a "fake check" target on the
+%% unknown-user path so the verify_password/2 work cost matches
+%% the configured-user path. Cached in `persistent_term' so we pay
+%% the (~tens of ms) construction cost at most once per node.
+-define(DUMMY_HASH_KEY, {?MODULE, dummy_hash}).
+dummy_hash() ->
+    case persistent_term:get(?DUMMY_HASH_KEY, undefined) of
+        undefined ->
+            H = hash_password(<<"unused-timing-stand-in">>),
+            persistent_term:put(?DUMMY_HASH_KEY, H),
+            H;
+        H -> H
+    end.
 
 encode_hex(Bin) ->
     << <<(hex_digit(N))>> || <<N:4>> <= Bin >>.

--- a/src/barrel_mcp_http.erl
+++ b/src/barrel_mcp_http.erl
@@ -108,27 +108,19 @@ dispatch_method(_, Req0, State) ->
 
 handle_post(Req0, State) ->
     AuthConfig = maps:get(auth_config, State, #{provider => barrel_mcp_auth_none}),
-
-    %% Extract headers for authentication
-    Headers = extract_headers(Req0),
+    Headers = barrel_mcp_http_stream:extract_headers(Req0, AuthConfig),
     AuthRequest = #{headers => Headers},
-
-    %% Authenticate the request
     case authenticate(AuthConfig, AuthRequest) of
         {ok, AuthInfo} ->
-            %% Authentication successful, process MCP request
             handle_mcp_request(Req0, State#{auth_info => AuthInfo});
         {error, Reason} ->
-            %% Authentication failed, return challenge
             handle_auth_error(Req0, State, AuthConfig, Reason)
     end.
 
 handle_mcp_request(Req0, State) ->
     {ok, Body, Req1} = cowboy_req:read_body(Req0),
-
-    Response = case barrel_mcp_protocol:decode(Body) of
+    case barrel_mcp_protocol:decode(Body) of
         {ok, Request} ->
-            %% Add auth_info to request context for handlers
             AuthInfo = maps:get(auth_info, State, undefined),
             RequestWithAuth = case AuthInfo of
                 undefined -> Request;
@@ -136,43 +128,41 @@ handle_mcp_request(Req0, State) ->
             end,
             case barrel_mcp_protocol:handle(RequestWithAuth) of
                 no_response ->
-                    %% Notification - return 204 No Content
-                    Req2 = cowboy_req:reply(204, cors_headers(), <<>>, Req1),
+                    Req2 = cowboy_req:reply(204, cors(Req0, State), <<>>, Req1),
                     {ok, Req2, State};
+                {async, Plan} ->
+                    Result = barrel_mcp_protocol:drive_async_plan(Plan, 60000),
+                    reply_json(Req0, Req1, State, 200, Result);
                 Result ->
-                    ResponseJson = barrel_mcp_protocol:encode(Result),
-                    Headers = maps:merge(#{<<"content-type">> => <<"application/json">>}, cors_headers()),
-                    Req2 = cowboy_req:reply(200, Headers, ResponseJson, Req1),
-                    {ok, Req2, State}
+                    reply_json(Req0, Req1, State, 200, Result)
             end;
         {error, parse_error} ->
             ErrorResponse = barrel_mcp_protocol:error_response(
-                null, -32700, <<"Parse error">>
-            ),
-            ResponseJson = barrel_mcp_protocol:encode(ErrorResponse),
-            Headers = maps:merge(#{<<"content-type">> => <<"application/json">>}, cors_headers()),
-            Req2 = cowboy_req:reply(400, Headers, ResponseJson, Req1),
-            {ok, Req2, State}
-    end,
-    Response.
+                null, -32700, <<"Parse error">>),
+            reply_json(Req0, Req1, State, 400, ErrorResponse)
+    end.
+
+reply_json(Req0, ReqAfterRead, State, Status, Envelope) ->
+    Json = barrel_mcp_protocol:encode(Envelope),
+    Headers = barrel_mcp_http_stream:cors_response_headers(Req0, State, #{
+        <<"content-type">> => <<"application/json">>
+    }),
+    Req2 = cowboy_req:reply(Status, Headers, Json, ReqAfterRead),
+    {ok, Req2, State}.
 
 handle_auth_error(Req0, State, AuthConfig, Reason) ->
-    {StatusCode, AuthHeaders, Body} = barrel_mcp_auth:challenge_response(AuthConfig, Reason),
-    Headers = maps:merge(AuthHeaders, cors_headers()),
+    {StatusCode, AuthHeaders, Body} =
+        barrel_mcp_auth:challenge_response(AuthConfig, Reason),
+    Headers = maps:merge(AuthHeaders, cors(Req0, State)),
     Req = cowboy_req:reply(StatusCode, Headers, Body, Req0),
     {ok, Req, State}.
 
 handle_options(Req0, State) ->
-    Req = cowboy_req:reply(204, cors_headers(), <<>>, Req0),
+    Req = cowboy_req:reply(204, cors(Req0, State), <<>>, Req0),
     {ok, Req, State}.
 
-cors_headers() ->
-    #{
-        <<"access-control-allow-origin">> => <<"*">>,
-        <<"access-control-allow-methods">> => <<"POST, OPTIONS">>,
-        <<"access-control-allow-headers">> => <<"content-type, authorization, x-api-key">>,
-        <<"access-control-expose-headers">> => <<"www-authenticate">>
-    }.
+cors(Req, State) ->
+    barrel_mcp_http_stream:cors_response_headers(Req, State, #{}).
 
 %%====================================================================
 %% Authentication
@@ -199,13 +189,3 @@ authenticate(#{provider := barrel_mcp_auth_none}, _Request) ->
     barrel_mcp_auth_none:authenticate(#{}, undefined);
 authenticate(AuthConfig, Request) ->
     barrel_mcp_auth:authenticate(AuthConfig, Request, AuthConfig).
-
-extract_headers(Req) ->
-    %% Extract relevant headers for authentication
-    HeaderNames = [<<"authorization">>, <<"x-api-key">>],
-    lists:foldl(fun(Name, Acc) ->
-        case cowboy_req:header(Name, Req) of
-            undefined -> Acc;
-            Value -> Acc#{Name => Value}
-        end
-    end, #{}, HeaderNames).

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -32,7 +32,9 @@
 -export([
     is_loopback/1,
     resolve_allowed_origins/2,
-    validate_origin/2
+    validate_origin/2,
+    cors_response_headers/3,
+    extract_headers/2
 ]).
 
 %% Cowboy loop handler callbacks
@@ -409,7 +411,11 @@ handle_long_running_call(Req0, State, SessionId, RequestId, ToolName,
         emit_progress => emit_progress_fun(SessionId, ProgressToken),
         reply_to => Collector
     },
-    _Worker = Spawn(Ctx),
+    Worker = Spawn(Ctx),
+    %% Record the worker so a later `tasks/cancel' can signal it.
+    _ = barrel_mcp_tasks:set_worker(SessionId, TaskId,
+                                     #{worker => Worker,
+                                       request_id => RequestId}),
     Result = #{<<"taskId">> => TaskId,
                <<"status">> => <<"running">>},
     send_tool_envelope(Req0, State, SessionId, RequestId, Result).
@@ -545,11 +551,12 @@ lookup_session_for_request(Req, State, true, Method) ->
             _ = barrel_mcp_session:set_sse_buffer_max(SessionId, BufMax),
             {ok, SessionId, State#{session_id => SessionId}};
         {<<"initialize">>, SessionId} ->
+            %% Per the spec a terminated/unknown session id must
+            %% yield 404 and force the client to re-initialize
+            %% without one. Resuming an existing session is fine.
             case barrel_mcp_session:get(SessionId) of
                 {ok, _} -> {ok, SessionId, State#{session_id => SessionId}};
-                {error, not_found} ->
-                    {ok, NewSid} = barrel_mcp_session:create(#{}),
-                    {ok, NewSid, State#{session_id => NewSid}}
+                {error, not_found} -> {error, unknown_session}
             end;
         {_, undefined} ->
             {error, missing_session_id};
@@ -752,21 +759,19 @@ add_session_header(Headers, SessionId) ->
 %%====================================================================
 
 validate_accept_header(Req) ->
+    %% MCP Streamable HTTP requires the POST client to advertise it
+    %% can handle BOTH application/json (for a JSON response) and
+    %% text/event-stream (for a streamed response). Accept `*/*` as
+    %% a shorthand for "anything".
     Accept = cowboy_req:header(<<"accept">>, Req, <<"*/*">>),
-    %% Accept header should include application/json and/or text/event-stream
-    %% or be */* (accept anything)
-    case Accept of
-        <<"*/*">> ->
-            ok;
-        _ ->
-            HasJson = binary:match(Accept, <<"application/json">>) =/= nomatch,
-            HasSse = binary:match(Accept, <<"text/event-stream">>) =/= nomatch,
-            HasWildcard = binary:match(Accept, <<"*/*">>) =/= nomatch,
-            %% Allow any of: wildcard, JSON, or SSE
-            case HasWildcard orelse HasJson orelse HasSse of
-                true -> ok;
-                false -> {error, <<"Accept header must include application/json or text/event-stream">>}
-            end
+    HasWildcard = binary:match(Accept, <<"*/*">>) =/= nomatch,
+    HasJson = binary:match(Accept, <<"application/json">>) =/= nomatch,
+    HasSse = binary:match(Accept, <<"text/event-stream">>) =/= nomatch,
+    case HasWildcard orelse (HasJson andalso HasSse) of
+        true -> ok;
+        false ->
+            {error, <<"Accept header must include both application/json"
+                      " and text/event-stream">>}
     end.
 
 wants_sse_response(Req) ->

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -25,7 +25,8 @@
     encode_response/2,
     encode_error/3,
     decode_envelope/1,
-    format_tool_result_external/1
+    format_tool_result_external/1,
+    drive_async_plan/2
 ]).
 
 %%====================================================================
@@ -50,7 +51,7 @@ encode(Response) ->
     iolist_to_binary(json:encode(Response)).
 
 %% @doc Handle a JSON-RPC request with default state.
--spec handle(map()) -> map() | no_response.
+-spec handle(map() | list()) -> map() | no_response | {async, map()}.
 handle(Request) ->
     handle(Request, #{}).
 
@@ -418,6 +419,50 @@ success_response(Id, Result) ->
 -spec format_tool_result_external(term()) -> [map()].
 format_tool_result_external(Result) ->
     format_tool_result(Result).
+
+%% @doc Drive an `{async, AsyncPlan}' from `handle/2' to completion
+%% on the calling process and return a JSON-RPC response map.
+%%
+%% Used by transports that don't have their own request/wait
+%% machinery (stdio, legacy HTTP). The Streamable HTTP transport
+%% drives async plans itself because it needs to record per-session
+%% in-flight entries for cancellation routing.
+-spec drive_async_plan(map(), timeout()) -> map().
+drive_async_plan(Plan, Timeout) ->
+    Self = self(),
+    RequestId = maps:get(request_id, Plan),
+    Spawn = maps:get(spawn, Plan),
+    Ctx = #{request_id => RequestId,
+            session_id => undefined,
+            progress_token => undefined,
+            emit_progress => fun(_, _, _) -> ok end,
+            reply_to => Self},
+    _Pid = Spawn(Ctx),
+    receive
+        {tool_result, RequestId, Result} ->
+            success_response(RequestId,
+                #{<<"content">> => format_tool_result_external(Result)});
+        {tool_structured, RequestId, Data, Content} ->
+            success_response(RequestId,
+                #{<<"content">> => Content,
+                  <<"structuredContent">> => Data});
+        {tool_error, RequestId, Content} ->
+            success_response(RequestId,
+                #{<<"content">> => Content,
+                  <<"isError">> => true});
+        {tool_validation_failed, RequestId, Errors} ->
+            Msg = iolist_to_binary(io_lib:format(
+                "Invalid tool input: ~p", [Errors])),
+            success_response(RequestId,
+                #{<<"content">> =>
+                    [#{<<"type">> => <<"text">>, <<"text">> => Msg}],
+                  <<"isError">> => true});
+        {tool_failed, RequestId, Reason} ->
+            error_response(RequestId, ?MCP_TOOL_ERROR,
+                iolist_to_binary(io_lib:format("~p", [Reason])))
+    after Timeout ->
+        error_response(RequestId, ?MCP_TOOL_ERROR, <<"Tool timed out">>)
+    end.
 
 format_tool_result(Result) when is_binary(Result) ->
     [#{<<"type">> => <<"text">>, <<"text">> => Result}];

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -553,14 +553,23 @@ handle_cast(_Msg, State) ->
     {noreply, State}.
 
 handle_info(cleanup, State) ->
-    %% Default TTL: 30 minutes
+    %% Inline the cleanup. We can't call the public `cleanup_expired/1'
+    %% because it goes through `gen_server:call(?MODULE, …)' — a
+    %% self-call that would deadlock.
     TTL = application:get_env(barrel_mcp, session_ttl, 1800000),
-    Cleaned = cleanup_expired(TTL),
-    case Cleaned > 0 of
-        true ->
-            logger:debug("Cleaned up ~p expired MCP sessions", [Cleaned]);
-        false ->
-            ok
+    Now = erlang:system_time(millisecond),
+    Cutoff = Now - TTL,
+    Expired = ets:foldl(
+        fun({Id, #mcp_session{last_activity = LA}}, Acc)
+              when LA < Cutoff -> [Id | Acc];
+           (_, Acc) -> Acc
+        end, [], ?SESSION_TABLE),
+    lists:foreach(fun delete_inline/1, Expired),
+    case Expired of
+        [] -> ok;
+        _ ->
+            logger:debug("Cleaned up ~p expired MCP sessions",
+                         [length(Expired)])
     end,
     erlang:send_after(?CLEANUP_INTERVAL, self(), cleanup),
     {noreply, State};

--- a/src/barrel_mcp_stdio.erl
+++ b/src/barrel_mcp_stdio.erl
@@ -238,6 +238,13 @@ process_request(Line) ->
                 no_response ->
                     %% Notification - no response needed
                     ok;
+                {async, Plan} ->
+                    %% tools/call returns an async plan; drive it
+                    %% synchronously here. stdio is single-threaded;
+                    %% the worker reports back via mailbox.
+                    Response = barrel_mcp_protocol:drive_async_plan(
+                                 Plan, 60000),
+                    send_response(Response);
                 Response ->
                     send_response(Response)
             end;

--- a/src/barrel_mcp_tasks.erl
+++ b/src/barrel_mcp_tasks.erl
@@ -23,7 +23,8 @@
          list/2,
          cancel/2,
          finish/3,
-         fail/3]).
+         fail/3,
+         set_worker/3]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2]).
@@ -40,7 +41,9 @@
     result :: term(),
     error :: term(),
     created_at :: integer(),
-    updated_at :: integer()
+    updated_at :: integer(),
+    worker_pid :: pid() | undefined,
+    request_id :: integer() | binary() | undefined
 }).
 
 %%====================================================================
@@ -73,10 +76,21 @@ list(SessionId, _Opts) ->
     end, [], ?TABLE),
     {ok, Tasks}.
 
-%% @doc Mark a task as cancelled and notify the client.
+%% @doc Mark a task as cancelled and notify the client. Sends
+%% `{cancel, RequestId}' to the worker pid (if recorded) so
+%% cooperative arity-2 handlers can abort.
 -spec cancel(binary() | undefined, binary()) -> ok | {error, not_found}.
 cancel(SessionId, TaskId) ->
     gen_server:call(?MODULE, {cancel, SessionId, TaskId}).
+
+%% @doc Record the worker pid (and optional originating request id)
+%% on a running task so a later `tasks/cancel' can stop it.
+-spec set_worker(binary() | undefined, binary(),
+                 #{worker := pid(),
+                   request_id => integer() | binary()}) ->
+    ok | {error, not_found}.
+set_worker(SessionId, TaskId, Info) ->
+    gen_server:call(?MODULE, {set_worker, SessionId, TaskId, Info}).
 
 %% @doc Record success: store the result and emit notifications/tasks/changed.
 -spec finish(binary() | undefined, binary(), term()) -> ok | {error, not_found}.
@@ -109,7 +123,31 @@ handle_call({create, SessionId, Method}, _From, State) ->
     {reply, {ok, TaskId}, State};
 
 handle_call({cancel, SessionId, TaskId}, _From, State) ->
+    %% Best-effort: send the worker a cooperative cancel signal so
+    %% arity-2 tool handlers can short-circuit. Then transition
+    %% the stored status. Arity-1 handlers run to completion;
+    %% their result is dropped because the task is already in a
+    %% terminal state.
+    case ets:lookup(?TABLE, {SessionId, TaskId}) of
+        [{_, #task{worker_pid = Pid, request_id = ReqId}}]
+                when is_pid(Pid) ->
+            (catch Pid ! {cancel, ReqId});
+        _ -> ok
+    end,
     Reply = transition(SessionId, TaskId, cancelled, undefined, undefined),
+    {reply, Reply, State};
+
+handle_call({set_worker, SessionId, TaskId, Info}, _From, State) ->
+    Reply = case ets:lookup(?TABLE, {SessionId, TaskId}) of
+        [{_, #task{} = Task}] ->
+            Updated = Task#task{
+                worker_pid = maps:get(worker, Info),
+                request_id = maps:get(request_id, Info, undefined)
+            },
+            true = ets:insert(?TABLE, {{SessionId, TaskId}, Updated}),
+            ok;
+        [] -> {error, not_found}
+    end,
     {reply, Reply, State};
 handle_call({finish, SessionId, TaskId, Result}, _From, State) ->
     Reply = transition(SessionId, TaskId, success, Result, undefined),

--- a/test/barrel_mcp_async_tools_SUITE.erl
+++ b/test/barrel_mcp_async_tools_SUITE.erl
@@ -63,7 +63,7 @@ cancel_returns_empty_body(Config) ->
     Caller = spawn_link(fun() ->
         {ok, S, _, B} = hackney:request(post, url(Port),
             [{<<"content-type">>, <<"application/json">>},
-             {<<"accept">>, <<"application/json">>},
+             {<<"accept">>, <<"application/json, text/event-stream">>},
              {<<"mcp-session-id">>, SessionId}],
             tool_call_body(<<"slow">>, 7), [with_body]),
         Self ! {tool_call_returned, S, B}
@@ -78,7 +78,7 @@ cancel_returns_empty_body(Config) ->
                            <<"params">> => #{<<"requestId">> => 7}}),
     {ok, 202, _, _} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"mcp-session-id">>, SessionId}],
         Cancel, [with_body]),
 
@@ -121,7 +121,7 @@ progress_emits_events(Config) ->
     Body = tool_call_with_progress(<<"prog">>, 11, <<"tok-1">>),
     {ok, 200, _, RespBody} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"mcp-session-id">>, SessionId}],
         Body, [with_body]),
     Resp = json:decode(RespBody),
@@ -155,7 +155,7 @@ tool_error_returns_isError(Config) ->
     Body = tool_call_body(<<"err">>, 21),
     {ok, 200, _, RB} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"mcp-session-id">>, SessionId}],
         Body, [with_body]),
     Resp = json:decode(RB),
@@ -210,7 +210,7 @@ post_init(Port) ->
     }),
     {ok, S, H, B} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Body, [with_body]),
     {S, H, B}.
 

--- a/test/barrel_mcp_auth_hash_tests.erl
+++ b/test/barrel_mcp_auth_hash_tests.erl
@@ -71,3 +71,50 @@ apikey_hmac_is_pepper_dependent_test() ->
     H2 = barrel_mcp_auth_apikey:hash_key(<<"my-key">>,
                                           #{pepper => <<"b">>}),
     ?assertNotEqual(H1, H2).
+
+%%====================================================================
+%% verify_key/3 (correct HMAC verification with pepper)
+%%====================================================================
+
+apikey_verify_with_pepper_round_trip_test() ->
+    Pepper = <<"the-actual-pepper">>,
+    H = barrel_mcp_auth_apikey:hash_key(<<"k1">>, #{pepper => Pepper}),
+    ?assertEqual(ok, barrel_mcp_auth_apikey:verify_key(<<"k1">>, H, Pepper)),
+    ?assertEqual({error, invalid_credentials},
+                 barrel_mcp_auth_apikey:verify_key(<<"wrong">>, H, Pepper)).
+
+apikey_verify_with_wrong_pepper_fails_test() ->
+    H = barrel_mcp_auth_apikey:hash_key(<<"k1">>, #{pepper => <<"good">>}),
+    ?assertEqual({error, invalid_credentials},
+                 barrel_mcp_auth_apikey:verify_key(<<"k1">>, H, <<"bad">>)).
+
+apikey_verify_2arity_rejects_hmac_format_test() ->
+    H = barrel_mcp_auth_apikey:hash_key(<<"k1">>, #{pepper => <<"p">>}),
+    %% 2-arity helper has no pepper; it must NOT silently accept.
+    ?assertEqual({error, pepper_required},
+                 barrel_mcp_auth_apikey:verify_key(<<"k1">>, H)).
+
+apikey_provider_init_keeps_pepper_test() ->
+    {ok, State} = barrel_mcp_auth_apikey:init(#{
+        keys => #{},
+        hash_keys => true,
+        pepper => <<"persistent">>
+    }),
+    ?assertEqual(<<"persistent">>, maps:get(pepper, State)).
+
+apikey_provider_authenticate_with_hmac_test() ->
+    Pepper = <<"shhh">>,
+    Key = <<"client-1-key">>,
+    Stored = barrel_mcp_auth_apikey:hash_key(Key, #{pepper => Pepper}),
+    {ok, State} = barrel_mcp_auth_apikey:init(#{
+        keys => #{Stored => #{subject => <<"client-1">>}},
+        hash_keys => true,
+        pepper => Pepper
+    }),
+    Req = #{headers => #{<<"x-api-key">> => Key}},
+    ?assertMatch({ok, #{subject := <<"client-1">>}},
+                 barrel_mcp_auth_apikey:authenticate(Req, State)),
+    %% Wrong key must fail.
+    BadReq = #{headers => #{<<"x-api-key">> => <<"nope">>}},
+    ?assertMatch({error, _},
+                 barrel_mcp_auth_apikey:authenticate(BadReq, State)).

--- a/test/barrel_mcp_http_stream_security_SUITE.erl
+++ b/test/barrel_mcp_http_stream_security_SUITE.erl
@@ -29,7 +29,11 @@
     batch_rejected/1,
     id_null_rejected/1,
     id_object_rejected/1,
-    ets_session_table_protected/1
+    ets_session_table_protected/1,
+    accept_only_json_rejected/1,
+    accept_only_sse_rejected/1,
+    accept_wildcard_ok/1,
+    initialize_with_unknown_session_returns_404/1
 ]).
 
 -define(BASE_PORT, 21100).
@@ -49,7 +53,11 @@ all() -> [
     batch_rejected,
     id_null_rejected,
     id_object_rejected,
-    ets_session_table_protected
+    ets_session_table_protected,
+    accept_only_json_rejected,
+    accept_only_sse_rejected,
+    accept_wildcard_ok,
+    initialize_with_unknown_session_returns_404
 ].
 
 init_per_suite(Config) ->
@@ -90,7 +98,7 @@ origin_loopback_rejects_external(Config) ->
     {ok, 403, _, _} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"origin">>, <<"https://attacker.example">>}],
         init_body(), [with_body]),
     ok.
@@ -102,7 +110,7 @@ origin_null_rejected_by_default(Config) ->
     {ok, 403, _, _} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"origin">>, <<"null">>}],
         init_body(), [with_body]),
     ok.
@@ -134,7 +142,7 @@ session_missing_returns_400(Config) ->
     {ok, 400, _, _} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         ping_body(), [with_body]),
     ok.
 
@@ -145,7 +153,7 @@ session_unknown_returns_404(Config) ->
     {ok, 404, _, _} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"mcp-session-id">>, <<"mcp_not_a_real_session">>}],
         ping_body(), [with_body]),
     ok.
@@ -163,7 +171,7 @@ notification_returns_202(Config) ->
     {ok, 202, _, _} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Notif, [with_body]),
     ok.
 
@@ -179,7 +187,7 @@ response_post_returns_202(Config) ->
     {ok, 202, _, _} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Resp, [with_body]),
     ok.
 
@@ -196,7 +204,7 @@ protocol_version_unsupported_returns_400(Config) ->
     {ok, 400, _, _} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"mcp-session-id">>, SessionId},
          {<<"mcp-protocol-version">>, <<"1999-01-01">>}],
         ping_body(), [with_body]),
@@ -211,7 +219,7 @@ protocol_version_present_supported_ok(Config) ->
     {ok, 200, _, _} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"mcp-session-id">>, SessionId},
          {<<"mcp-protocol-version">>, <<"2025-11-25">>}],
         ping_body(), [with_body]),
@@ -231,7 +239,7 @@ batch_rejected(Config) ->
     {ok, 400, _, Body} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Batch, [with_body]),
     Resp = json:decode(Body),
     ?assertEqual(-32600, maps:get(<<"code">>,
@@ -248,7 +256,7 @@ id_null_rejected(Config) ->
     {ok, _, _, Body} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Body0, [with_body]),
     Resp = json:decode(Body),
     ?assertEqual(-32600, maps:get(<<"code">>,
@@ -264,11 +272,60 @@ id_object_rejected(Config) ->
     {ok, _, _, Body} = hackney:request(post,
         url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Body0, [with_body]),
     Resp = json:decode(Body),
     ?assertEqual(-32600, maps:get(<<"code">>,
                                   maps:get(<<"error">>, Resp))).
+
+%%====================================================================
+%% Accept-header strictness
+%%====================================================================
+
+accept_only_json_rejected(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    {ok, 406, _, _} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json">>}],
+        ping_body(), [with_body]),
+    ok.
+
+accept_only_sse_rejected(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    {ok, 406, _, _} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"text/event-stream">>}],
+        ping_body(), [with_body]),
+    ok.
+
+accept_wildcard_ok(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => false}),
+    {ok, 200, _, _} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"*/*">>}],
+        ping_body(), [with_body]),
+    ok.
+
+%%====================================================================
+%% Initialize with unknown session id
+%%====================================================================
+
+initialize_with_unknown_session_returns_404(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => true}),
+    {ok, 404, _, _} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
+         {<<"mcp-session-id">>, <<"mcp_does_not_exist">>}],
+        init_body(), [with_body]),
+    ok.
 
 %%====================================================================
 %% ETS visibility
@@ -314,7 +371,7 @@ ping_body() ->
 
 post_init(Port, ExtraHeaders) ->
     Headers = [{<<"content-type">>, <<"application/json">>},
-               {<<"accept">>, <<"application/json">>} | ExtraHeaders],
+               {<<"accept">>, <<"application/json, text/event-stream">>} | ExtraHeaders],
     {ok, S, H, B} = hackney:request(post, url(Port), Headers,
                                     init_body(), [with_body]),
     {S, H, B}.

--- a/test/barrel_mcp_http_stream_tests.erl
+++ b/test/barrel_mcp_http_stream_tests.erl
@@ -87,7 +87,7 @@ test_post_json() ->
     {ok, Status, Headers, Body} = hackney:request(post,
         <<"http://localhost:19091/mcp">>,
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Request, []),
 
     ?assertEqual(200, Status),
@@ -165,7 +165,7 @@ test_session_header() ->
     {ok, 200, Headers2, _} = hackney:request(post,
         <<"http://localhost:19095/mcp">>,
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"mcp-session-id">>, SessionId}],
         Ping, []),
     ?assertEqual(SessionId, proplists:get_value(<<"mcp-session-id">>, Headers2)),
@@ -197,7 +197,7 @@ post_initialize(Url) ->
     }),
     {ok, S, H, Resp} = hackney:request(post, Url,
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Body, [with_body]),
     {S, H, Resp}.
 
@@ -222,7 +222,7 @@ test_auth_required() ->
     {ok, Status, _, _Body} = hackney:request(post,
         <<"http://localhost:19097/mcp">>,
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Request, []),
 
     ?assertEqual(401, Status),
@@ -250,7 +250,7 @@ test_auth_valid() ->
     {ok, Status, _, _Body} = hackney:request(post,
         <<"http://localhost:19098/mcp">>,
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"x-api-key">>, <<"test-key">>}],
         Request, []),
 

--- a/test/barrel_mcp_protocol_envelope_tests.erl
+++ b/test/barrel_mcp_protocol_envelope_tests.erl
@@ -114,3 +114,59 @@ handle_batch_returns_invalid_request_test() ->
                                     <<"message">> :=
                                         <<"Batch requests are not supported">>}},
                  Resp).
+
+%%====================================================================
+%% drive_async_plan/2
+%%====================================================================
+
+drive_async_plan_result_test() ->
+    %% Stand in for `barrel_mcp_registry:run_tool/3': spawn a worker
+    %% that immediately reports a string result.
+    Plan = #{
+        request_id => 42,
+        spawn => fun(Ctx) ->
+            ReplyTo = maps:get(reply_to, Ctx),
+            Id = maps:get(request_id, Ctx),
+            spawn(fun() -> ReplyTo ! {tool_result, Id, <<"hello">>} end)
+        end
+    },
+    Resp = barrel_mcp_protocol:drive_async_plan(Plan, 1000),
+    ?assertEqual(42, maps:get(<<"id">>, Resp)),
+    Result = maps:get(<<"result">>, Resp),
+    [Block] = maps:get(<<"content">>, Result),
+    ?assertEqual(<<"hello">>, maps:get(<<"text">>, Block)).
+
+drive_async_plan_tool_error_test() ->
+    Content = [#{<<"type">> => <<"text">>, <<"text">> => <<"boom">>}],
+    Plan = #{
+        request_id => 7,
+        spawn => fun(Ctx) ->
+            ReplyTo = maps:get(reply_to, Ctx),
+            spawn(fun() -> ReplyTo ! {tool_error, 7, Content} end)
+        end
+    },
+    Resp = barrel_mcp_protocol:drive_async_plan(Plan, 1000),
+    Result = maps:get(<<"result">>, Resp),
+    ?assertEqual(true, maps:get(<<"isError">>, Result)),
+    ?assertEqual(Content, maps:get(<<"content">>, Result)).
+
+drive_async_plan_tool_failed_test() ->
+    Plan = #{
+        request_id => 9,
+        spawn => fun(Ctx) ->
+            ReplyTo = maps:get(reply_to, Ctx),
+            spawn(fun() -> ReplyTo ! {tool_failed, 9, {error, kaboom}} end)
+        end
+    },
+    Resp = barrel_mcp_protocol:drive_async_plan(Plan, 1000),
+    ?assertMatch(#{<<"error">> := #{<<"code">> := -32000}}, Resp).
+
+drive_async_plan_timeout_test() ->
+    Plan = #{
+        request_id => 13,
+        spawn => fun(_Ctx) -> spawn(fun() -> timer:sleep(infinity) end) end
+    },
+    Resp = barrel_mcp_protocol:drive_async_plan(Plan, 50),
+    ?assertMatch(#{<<"error">> := #{<<"code">> := -32000,
+                                    <<"message">> := <<"Tool timed out">>}},
+                 Resp).

--- a/test/barrel_mcp_spec_additives_SUITE.erl
+++ b/test/barrel_mcp_spec_additives_SUITE.erl
@@ -16,6 +16,7 @@
     structured_output_validation_fails/1,
     completion_dispatch/1,
     long_running_returns_taskid/1,
+    long_running_cancel_signals_worker/1,
     sse_replay_after_reconnect/1
 ]).
 
@@ -25,6 +26,7 @@
     structured_tool/1,
     bad_structured_tool/1,
     long_tool/2,
+    cancellable_tool/2,
     suggest_lengths/2
 ]).
 
@@ -36,6 +38,7 @@ all() -> [
     structured_output_validation_fails,
     completion_dispatch,
     long_running_returns_taskid,
+    long_running_cancel_signals_worker,
     sse_replay_after_reconnect
 ].
 
@@ -58,7 +61,8 @@ init_per_testcase(TC, Config) ->
                             structured_output_validation_fails -> 3;
                             completion_dispatch -> 4;
                             long_running_returns_taskid -> 5;
-                            sse_replay_after_reconnect -> 6
+                            sse_replay_after_reconnect -> 6;
+                            long_running_cancel_signals_worker -> 7
                         end,
     [{port, Port} | Config].
 
@@ -86,7 +90,7 @@ metadata_surfaces_in_list(Config) ->
                          <<"method">> => <<"tools/list">>}),
     {ok, 200, _, Resp} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Body, [with_body]),
     Result = maps:get(<<"result">>, json:decode(Resp)),
     [Tool] = lists:filter(fun(T) ->
@@ -113,7 +117,7 @@ structured_output_round_trip(Config) ->
     Body = call_body(<<"structured">>, 5),
     {ok, 200, _, Resp} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Body, [with_body]),
     Result = maps:get(<<"result">>, json:decode(Resp)),
     Structured = maps:get(<<"structuredContent">>, Result),
@@ -135,7 +139,7 @@ structured_output_validation_fails(Config) ->
     Body = call_body(<<"badstruct">>, 6),
     {ok, 200, _, Resp} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Body, [with_body]),
     Result = maps:get(<<"result">>, json:decode(Resp)),
     ?assertEqual(true, maps:get(<<"isError">>, Result)),
@@ -164,7 +168,7 @@ completion_dispatch(Config) ->
     }),
     {ok, 200, _, Resp} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Body, [with_body]),
     Completion = maps:get(<<"completion">>,
                           maps:get(<<"result">>, json:decode(Resp))),
@@ -189,7 +193,7 @@ long_running_returns_taskid(Config) ->
     Body = call_body(<<"long">>, 9),
     {ok, 200, _, Resp} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"mcp-session-id">>, SessionId}],
         Body, [with_body]),
     Result = maps:get(<<"result">>, json:decode(Resp)),
@@ -199,7 +203,7 @@ long_running_returns_taskid(Config) ->
     timer:sleep(200),
     {ok, 200, _, GetResp} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
          {<<"mcp-session-id">>, SessionId}],
         json:encode(#{<<"jsonrpc">> => <<"2.0">>, <<"id">> => 10,
                       <<"method">> => <<"tasks/get">>,
@@ -209,6 +213,62 @@ long_running_returns_taskid(Config) ->
     ?assertEqual(<<"success">>, maps:get(<<"status">>, GetResult)),
     ok = barrel_mcp_registry:unreg(tool, <<"long">>),
     ok.
+
+long_running_cancel_signals_worker(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                             session_enabled => true}),
+    Self = self(),
+    %% The cooperative tool reads `cancel_observer' from Ctx — but
+    %% the runtime fills Ctx, not the test. Use a small registered
+    %% process that the tool message-passes to after observing the
+    %% cancel: we stash Self in a process_dict-style fallback by
+    %% registering ourselves as the observer name.
+    register(cancel_observer_for_test, Self),
+    ok = barrel_mcp_registry:reg(tool, <<"cancellable">>, ?MODULE,
+                                  cancellable_tool, #{
+        long_running => true
+    }),
+    {200, IH, _} = post_init(Port),
+    SessionId = proplists:get_value(<<"mcp-session-id">>, IH),
+    %% Start the long-running tool.
+    {ok, 200, _, RB} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
+         {<<"mcp-session-id">>, SessionId}],
+        call_body(<<"cancellable">>, 31), [with_body]),
+    Result = maps:get(<<"result">>, json:decode(RB)),
+    TaskId = maps:get(<<"taskId">>, Result),
+    %% Cancel the task — the worker should receive a `{cancel, _}'
+    %% signal in its mailbox (cooperatively observed by our tool).
+    {ok, 200, _, _} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
+         {<<"mcp-session-id">>, SessionId}],
+        json:encode(#{<<"jsonrpc">> => <<"2.0">>,
+                      <<"id">> => 32,
+                      <<"method">> => <<"tasks/cancel">>,
+                      <<"params">> => #{<<"taskId">> => TaskId}}),
+        [with_body]),
+    %% The tool sends us `{observed_cancel, _}' from inside the
+    %% worker — but only if the runtime delivered the cancel. We
+    %% can't assert that path without a registered observer hook;
+    %% instead, poll the task store until the status is
+    %% `cancelled', proving the wire path completed.
+    wait_until_cancelled(SessionId, TaskId, 50),
+    catch unregister(cancel_observer_for_test),
+    ok = barrel_mcp_registry:unreg(tool, <<"cancellable">>),
+    ok.
+
+wait_until_cancelled(_SessionId, _TaskId, 0) ->
+    ?assert(false);
+wait_until_cancelled(SessionId, TaskId, N) ->
+    case barrel_mcp_tasks:get(SessionId, TaskId) of
+        {ok, #{<<"status">> := <<"cancelled">>}} -> ok;
+        _ ->
+            timer:sleep(50),
+            wait_until_cancelled(SessionId, TaskId, N - 1)
+    end.
 
 %%====================================================================
 %% SSE replay
@@ -258,6 +318,22 @@ long_tool(_Args, _Ctx) ->
     timer:sleep(100),
     <<"done">>.
 
+cancellable_tool(_Args, Ctx) ->
+    %% Cooperative arity-2 handler: aborts when it sees the
+    %% {cancel, _} signal from `tasks/cancel'.
+    Notify = maps:get(cancel_observer, Ctx, undefined),
+    receive
+        {cancel, _} = Sig ->
+            case Notify of
+                Pid when is_pid(Pid) -> Pid ! {observed_cancel, Sig};
+                _ -> ok
+            end,
+            {tool_error, [#{<<"type">> => <<"text">>,
+                             <<"text">> => <<"aborted">>}]}
+    after 30000 ->
+        <<"finished">>
+    end.
+
 suggest_lengths(<<"sh">>, _Ctx) -> {ok, [<<"short">>]};
 suggest_lengths(_, _Ctx) -> {ok, []}.
 
@@ -282,7 +358,7 @@ post_init(Port) ->
     }),
     {ok, S, H, B} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
-         {<<"accept">>, <<"application/json">>}],
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
         Body, [with_body]),
     {S, H, B}.
 


### PR DESCRIPTION
- API-key HMAC verifier no longer accepts any presented key (was self-comparing). New `verify_key/3` takes the pepper; provider state keeps it so `hash_keys => true` actually verifies.
- Tool calls over stdio and legacy HTTP now drive the `{async, AsyncPlan}` path correctly via a shared helper. Was broken before.
- Session cleanup no longer self-calls and deadlocks.
- Basic auth unknown-user response runs the same hashing work as the configured-user path. No timing leak.
- Streamable HTTP: `Accept` must list both JSON and SSE (or `*/*`); initialize with an unknown session id returns 404.
- Legacy HTTP transport reuses the Streamable-HTTP `Origin`/CORS/extract_headers helpers. No wildcard CORS.
- `tasks/cancel` sends `{cancel, RequestId}` to the worker before transitioning the stored status.