### PR TITLE
Tasks spec parity (MCP 2025-11-25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tasks spec parity (MCP 2025-11-25)
+
+- **Status vocabulary aligned with spec.** Internal `running | success | error | cancelled` replaced with `working | completed | failed | cancelled` on the wire (in `tasks/get`, `tasks/list`, `notifications/tasks/changed`, and the immediate `tools/call` response when `long_running => true`).
+- **RFC 3339 timestamps.** `createdAt` and `updatedAt` are emitted as ISO 8601 strings via `calendar:system_time_to_rfc3339/1` instead of integer milliseconds.
+- **`tasks/result` method.** New JSON-RPC method to fetch the recorded result for a `completed` task (or the recorded error for `failed`); returns `Task not yet complete` for `working`, `Task cancelled` for `cancelled`, and `Task not found` otherwise. New client wrapper `barrel_mcp_client:tasks_result/2`.
+- **Tasks capability shape.** Advertised as `#{list, get, cancel, result, listChanged}` instead of the bare `#{listChanged}` placeholder.
+
 ### Critical correctness and security fixes
 
 - **API-key auth verification.** `barrel_mcp_auth_apikey:verify_key/2` no longer returns `ok` for any HMAC-formatted stored value (it was self-comparing `Stored` with itself). The 2-arity helper now rejects HMAC formats with `{error, pepper_required}`; a new `verify_key/3` takes the pepper and does a constant-time HMAC compare. The provider state now keeps `pepper`, so `hash_keys => true` with a configured pepper actually verifies HMAC keys end to end.

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -217,7 +217,7 @@ classify(#{<<"content">> := Content}) ->
 
 If the server registered the tool with `long_running => true`,
 `call_tool` returns immediately with `#{<<"taskId">> := Id,
-<<"status">> := <<"running">>}`. Track progress with the methods
+<<"status">> := <<"working">>}`. Track progress with the methods
 in section 12.
 
 ---
@@ -417,13 +417,22 @@ list_tasks(Pid) ->
 
 abort_task(Pid, TaskId) ->
     barrel_mcp_client:tasks_cancel(Pid, TaskId).
+
+fetch_task_result(Pid, TaskId) ->
+    %% Returns the recorded result for a `completed' task, or an
+    %% error for `failed' / `cancelled' / still-`working' tasks.
+    barrel_mcp_client:tasks_result(Pid, TaskId).
 ```
+
+Status values on the wire are `working`, `completed`, `failed`,
+and `cancelled`; `createdAt` and `updatedAt` are RFC 3339 strings.
 
 When you registered a `progress_token` on the originating call,
 the same task usually emits `notifications/progress` updates that
-arrive through your handler, so polling is rarely required —
-prefer subscribing to `notifications/tasks/changed` in the
-handler over busy-polling `tasks_get/2`.
+arrive through your handler, so polling is rarely required. Prefer
+subscribing to `notifications/tasks/changed` in the handler over
+busy-polling `tasks_get/2`, then fetch the payload once with
+`tasks_result/2` when the status reaches `completed`.
 
 ---
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -123,7 +123,10 @@ by the spec.
   `resources/templates/list`, `resources/subscribe`,
   `resources/unsubscribe`, `prompts/list`, `prompts/get`,
   `completion/complete`, `logging/setLevel`, `ping`,
-  `tasks/list`, `tasks/get`, `tasks/cancel`.
+  `tasks/list`, `tasks/get`, `tasks/cancel`, `tasks/result`.
+- Task statuses on the wire: `working`, `completed`, `failed`,
+  `cancelled`. Task timestamps (`createdAt`, `updatedAt`) are
+  RFC 3339 strings.
 - Pagination via `cursor` / `nextCursor`. Single page by default
   (`want_cursor => true` to follow paging by hand). The sugar helpers
   `list_tools_all/1`, `list_resources_all/1`,

--- a/guides/tools-resources-prompts.md
+++ b/guides/tools-resources-prompts.md
@@ -482,14 +482,16 @@ as at least one completion handler is registered.
 ## Tasks (long-running operations)
 
 The `barrel_mcp_tasks` module backs the `tasks/list`, `tasks/get`,
-and `tasks/cancel` MCP methods, plus the
+`tasks/cancel`, and `tasks/result` MCP methods, plus the
 `notifications/tasks/changed` notifications.
 
 You don't usually call this module directly: registering a tool
 with `long_running => true` (see above) wires the lifecycle for
 you. The collector process records the worker's eventual outcome
-as a task transition (`running` → `success | error | cancelled`)
+as a task transition (`working` → `completed | failed | cancelled`)
 and emits the matching notification on the session's SSE channel.
+Status values match the MCP 2025-11-25 wire vocabulary, and
+`createdAt` / `updatedAt` are emitted as RFC 3339 strings.
 
 Hosts that drive their own long-running operations outside the
 tool path can use the public API:
@@ -501,7 +503,7 @@ ok = barrel_mcp_tasks:finish(SessionId, TaskId, #{<<"reindexed">> => 12000}).
 ```
 
 Tasks are evicted from memory one hour after they reach a terminal
-state (success / error / cancelled).
+state (completed / failed / cancelled).
 
 ## Server → client notifications
 

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -63,6 +63,7 @@
     tasks_list_all/1,
     tasks_get/2,
     tasks_cancel/2,
+    tasks_result/2,
     %% Misc
     complete/3,
     set_log_level/2,
@@ -322,6 +323,14 @@ tasks_get(Pid, TaskId) ->
 -spec tasks_cancel(pid(), binary()) -> {ok, map()} | {error, term()}.
 tasks_cancel(Pid, TaskId) ->
     request(Pid, <<"tasks/cancel">>, #{<<"taskId">> => TaskId}).
+
+%% @doc Fetch the final result of a completed task. Returns the
+%% task's stored `result' map; for `failed' tasks returns
+%% `{error, {Code, Message}}'; for tasks still `working' returns
+%% `{error, {_, <<"Task not yet complete">>}}'.
+-spec tasks_result(pid(), binary()) -> {ok, map()} | {error, term()}.
+tasks_result(Pid, TaskId) ->
+    request(Pid, <<"tasks/result">>, #{<<"taskId">> => TaskId}).
 
 %% @doc Send a `ping' request and wait for the response.
 -spec ping(pid()) -> {ok, map()} | {error, term()}.

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -417,7 +417,7 @@ handle_long_running_call(Req0, State, SessionId, RequestId, ToolName,
                                      #{worker => Worker,
                                        request_id => RequestId}),
     Result = #{<<"taskId">> => TaskId,
-               <<"status">> => <<"running">>},
+               <<"status">> => <<"working">>},
     send_tool_envelope(Req0, State, SessionId, RequestId, Result).
 
 %% Tiny worker that funnels tool outcomes into the task registry.

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -138,7 +138,13 @@ handle_request(<<"initialize">>, Params, Id, State) ->
                               <<"listChanged">> => true},
         <<"prompts">> => #{<<"listChanged">> => true},
         <<"logging">> => #{},
-        <<"tasks">> => #{<<"listChanged">> => true}
+        <<"tasks">> => #{
+            <<"list">> => true,
+            <<"get">> => true,
+            <<"cancel">> => true,
+            <<"result">> => true,
+            <<"listChanged">> => true
+        }
     },
     Caps = maybe_advertise_completions(BaseCaps),
     success_response(Id, #{
@@ -324,6 +330,26 @@ handle_request(<<"tasks/cancel">>, Params, Id, State) ->
     TaskId = maps:get(<<"taskId">>, Params, <<>>),
     case barrel_mcp_tasks:cancel(SessionId, TaskId) of
         ok -> success_response(Id, #{});
+        {error, not_found} ->
+            error_response(Id, ?JSONRPC_INVALID_PARAMS, <<"Task not found">>)
+    end;
+
+handle_request(<<"tasks/result">>, Params, Id, State) ->
+    SessionId = maps:get(session_id, State, undefined),
+    TaskId = maps:get(<<"taskId">>, Params, <<>>),
+    case barrel_mcp_tasks:get(SessionId, TaskId) of
+        {ok, #{<<"status">> := <<"completed">>} = T} ->
+            Result = maps:get(<<"result">>, T, #{}),
+            success_response(Id, Result);
+        {ok, #{<<"status">> := <<"failed">>} = T} ->
+            Err = maps:get(<<"error">>, T, <<"Task failed">>),
+            error_response(Id, ?MCP_TOOL_ERROR, Err);
+        {ok, #{<<"status">> := <<"cancelled">>}} ->
+            error_response(Id, ?JSONRPC_INVALID_PARAMS,
+                           <<"Task cancelled">>);
+        {ok, #{<<"status">> := _}} ->
+            error_response(Id, ?JSONRPC_INVALID_PARAMS,
+                           <<"Task not yet complete">>);
         {error, not_found} ->
             error_response(Id, ?JSONRPC_INVALID_PARAMS, <<"Task not found">>)
     end;

--- a/src/barrel_mcp_tasks.erl
+++ b/src/barrel_mcp_tasks.erl
@@ -37,7 +37,12 @@
     id :: binary(),
     session_id :: binary() | undefined,
     method :: binary(),
-    status :: running | success | error | cancelled,
+    %% Spec vocabulary (MCP 2025-11-25):
+    %%   submitted | working | completed | failed | cancelled
+    %% We don't model `submitted' today (workers start immediately),
+    %% so the initial state is `working' and terminal states are
+    %% `completed', `failed', `cancelled'.
+    status :: working | completed | failed | cancelled,
     result :: term(),
     error :: term(),
     created_at :: integer(),
@@ -116,7 +121,7 @@ handle_call({create, SessionId, Method}, _From, State) ->
     TaskId = generate_id(),
     Task = #task{
         id = TaskId, session_id = SessionId, method = Method,
-        status = running, created_at = Now, updated_at = Now
+        status = working, created_at = Now, updated_at = Now
     },
     true = ets:insert(?TABLE, {{SessionId, TaskId}, Task}),
     notify_changed(SessionId, Task),
@@ -150,10 +155,10 @@ handle_call({set_worker, SessionId, TaskId, Info}, _From, State) ->
     end,
     {reply, Reply, State};
 handle_call({finish, SessionId, TaskId, Result}, _From, State) ->
-    Reply = transition(SessionId, TaskId, success, Result, undefined),
+    Reply = transition(SessionId, TaskId, completed, Result, undefined),
     {reply, Reply, State};
 handle_call({fail, SessionId, TaskId, Reason}, _From, State) ->
-    Reply = transition(SessionId, TaskId, error, undefined, Reason),
+    Reply = transition(SessionId, TaskId, failed, undefined, Reason),
     {reply, Reply, State};
 handle_call(_, _, State) ->
     {reply, {error, unknown_request}, State}.
@@ -164,7 +169,7 @@ handle_info(sweep, State) ->
     Now = erlang:system_time(millisecond),
     Cutoff = Now - ?TASK_TTL,
     Drop = ets:foldl(fun
-        ({_, #task{status = running}}, Acc) -> Acc;
+        ({_, #task{status = working}}, Acc) -> Acc;
         ({Key, #task{updated_at = U}}, Acc) when U < Cutoff -> [Key | Acc];
         (_, Acc) -> Acc
     end, [], ?TABLE),
@@ -194,7 +199,7 @@ generate_id() ->
 
 transition(SessionId, TaskId, Status, Result, Reason) ->
     case ets:lookup(?TABLE, {SessionId, TaskId}) of
-        [{_, #task{status = running} = Task}] ->
+        [{_, #task{status = working} = Task}] ->
             Now = erlang:system_time(millisecond),
             Updated = Task#task{
                 status = Status, result = Result, error = Reason,
@@ -230,20 +235,26 @@ task_to_map(#task{id = Id, session_id = Sid, method = M, status = St,
         <<"taskId">> => Id,
         <<"method">> => M,
         <<"status">> => atom_to_binary(St, utf8),
-        <<"createdAt">> => C,
-        <<"updatedAt">> => U
+        <<"createdAt">> => to_rfc3339(C),
+        <<"updatedAt">> => to_rfc3339(U)
     },
     Base1 = case Sid of undefined -> Base;
                        _ -> Base#{<<"sessionId">> => Sid} end,
-    Base2 = case St =:= success of
+    Base2 = case St =:= completed of
                 true when R =/= undefined -> Base1#{<<"result">> => R};
                 _ -> Base1
             end,
-    case St =:= error of
+    case St =:= failed of
         true when E =/= undefined ->
             Base2#{<<"error">> => format_error(E)};
         _ -> Base2
     end.
+
+to_rfc3339(Ms) when is_integer(Ms) ->
+    iolist_to_binary(
+      calendar:system_time_to_rfc3339(Ms,
+                                      [{unit, millisecond},
+                                       {offset, "Z"}])).
 
 format_error(B) when is_binary(B) -> B;
 format_error(T) -> iolist_to_binary(io_lib:format("~p", [T])).

--- a/test/barrel_mcp_spec_additives_SUITE.erl
+++ b/test/barrel_mcp_spec_additives_SUITE.erl
@@ -198,7 +198,7 @@ long_running_returns_taskid(Config) ->
         Body, [with_body]),
     Result = maps:get(<<"result">>, json:decode(Resp)),
     TaskId = maps:get(<<"taskId">>, Result),
-    ?assertEqual(<<"running">>, maps:get(<<"status">>, Result)),
+    ?assertEqual(<<"working">>, maps:get(<<"status">>, Result)),
     %% Wait for the worker to finish.
     timer:sleep(200),
     {ok, 200, _, GetResp} = hackney:request(post, url(Port),
@@ -210,7 +210,24 @@ long_running_returns_taskid(Config) ->
                       <<"params">> => #{<<"taskId">> => TaskId}}),
         [with_body]),
     GetResult = maps:get(<<"result">>, json:decode(GetResp)),
-    ?assertEqual(<<"success">>, maps:get(<<"status">>, GetResult)),
+    ?assertEqual(<<"completed">>, maps:get(<<"status">>, GetResult)),
+    %% Timestamps are RFC 3339 strings now, not integers.
+    ?assert(is_binary(maps:get(<<"createdAt">>, GetResult))),
+    ?assert(is_binary(maps:get(<<"updatedAt">>, GetResult))),
+    %% tasks/result returns the final payload.
+    {ok, 200, _, ResultResp} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
+         {<<"mcp-session-id">>, SessionId}],
+        json:encode(#{<<"jsonrpc">> => <<"2.0">>, <<"id">> => 11,
+                      <<"method">> => <<"tasks/result">>,
+                      <<"params">> => #{<<"taskId">> => TaskId}}),
+        [with_body]),
+    ResultPayload = maps:get(<<"result">>, json:decode(ResultResp)),
+    %% The long_tool returned <<"done">>; the result map is whatever
+    %% the registry stored — it may be wrapped further by the
+    %% collector. Just assert we got a non-error response.
+    ?assert(is_map(ResultPayload) orelse is_binary(ResultPayload)),
     ok = barrel_mcp_registry:unreg(tool, <<"long">>),
     ok.
 


### PR DESCRIPTION
## Summary

- Status vocabulary on the wire is now `working | completed | failed | cancelled` (matches the MCP 2025-11-25 tasks SEP).
- `createdAt` / `updatedAt` are emitted as RFC 3339 strings via `calendar:system_time_to_rfc3339/1`.
- New `tasks/result` method + `barrel_mcp_client:tasks_result/2`. Returns the recorded payload for a `completed` task; surfaces error responses for `failed` / `cancelled` / still-`working` / unknown task ids.
- Tasks capability advertised as `#{list, get, cancel, result, listChanged}` instead of bare `#{listChanged}`.
- Guides and CHANGELOG updated.

This is a wire-visible behaviour change for clients that hard-coded the old status strings or read timestamps as integers.