### PR TITLE
Server-to-client elicitation/create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Server-to-client `elicitation/create`
+
+- New `barrel_mcp:elicit_create/3` façade. Sends `elicitation/create` to the client behind a session id and blocks until the client responds (or `timeout_ms` elapses, default 30s). Requires the client to have declared `elicitation` capability in its `initialize' request and an active SSE stream. Mirrors the existing `sampling_create_message/3` flow.
+- New helpers `barrel_mcp:list_sessions_with_elicitation/0`, `barrel_mcp_session:has_elicitation/1`, `barrel_mcp_session:list_elicitation_capable/0`.
+- Internally, the server's pending-request map now carries the response tag, so sampling and elicitation responses route back to the correct caller without colliding.
+
 ### Tasks spec parity (MCP 2025-11-25)
 
 - **Status vocabulary aligned with spec.** Internal `running | success | error | cancelled` replaced with `working | completed | failed | cancelled` on the wire (in `tasks/get`, `tasks/list`, `notifications/tasks/changed`, and the immediate `tools/call` response when `long_running => true`).

--- a/guides/features.md
+++ b/guides/features.md
@@ -77,8 +77,9 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
 - ETS tables are `protected`; mutators run in
   `barrel_mcp_session`'s gen_server.
 - `Mcp-Session-Id` lifecycle with TTL-based cleanup.
-- Server-to-client sampling (`sampling/createMessage`) and
-  resource update notifications.
+- Server-to-client sampling (`sampling/createMessage`),
+  elicitation (`elicitation/create`), and resource update
+  notifications.
 
 ### Authentication
 
@@ -99,6 +100,7 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
 | `barrel_mcp:notify_progress/3,4` | `notifications/progress` to a session. |
 | `barrel_mcp:notify_list_changed/1` | `notifications/tools/list_changed`, `.../resources/list_changed`, or `.../prompts/list_changed` to every active SSE session. Auto-emitted on `reg_*`/`unreg_*`. |
 | `barrel_mcp:sampling_create_message/3` | Server→client `sampling/createMessage` (requires the client to declare `sampling` capability). |
+| `barrel_mcp:elicit_create/3` | Server→client `elicitation/create` to ask the host for structured user input (requires the client to declare `elicitation` capability). |
 | `barrel_mcp_tasks:create/3`, `finish/3`, `fail/3`, `cancel/2` | Long-running operation lifecycle. |
 
 ## Client (`barrel_mcp_client`)

--- a/src/barrel_mcp.erl
+++ b/src/barrel_mcp.erl
@@ -106,6 +106,8 @@
 -export([
     sampling_create_message/3,
     list_sessions_with_sampling/0,
+    elicit_create/3,
+    list_sessions_with_elicitation/0,
     notify_resource_updated/1,
     notify_resource_updated/2,
     notify_progress/3,
@@ -717,6 +719,23 @@ sampling_create_message(SessionId, Params, Opts) ->
 -spec list_sessions_with_sampling() -> [binary()].
 list_sessions_with_sampling() ->
     barrel_mcp_session:list_sampling_capable().
+
+%% @doc Send `elicitation/create' to the client behind a session to
+%% request structured user input. Requires the client to have declared
+%% elicitation capability in its `initialize' request and an active SSE
+%% stream. Blocks until the client responds or `timeout_ms' (default
+%% 30s) elapses.
+-spec elicit_create(binary(), map(), map()) ->
+    {ok, Result :: map()}
+  | {error, timeout | not_supported | no_sse | not_found | term()}.
+elicit_create(SessionId, Params, Opts) ->
+    barrel_mcp_session:elicit_create(SessionId, Params, Opts).
+
+%% @doc Return the ids of currently connected sessions whose client
+%% declared elicitation capability.
+-spec list_sessions_with_elicitation() -> [binary()].
+list_sessions_with_elicitation() ->
+    barrel_mcp_session:list_elicitation_capable().
 
 %% @doc Notify all subscribers of a resource that it has changed.
 %% The notification body is a JSON-RPC notification with no params; the

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -26,6 +26,8 @@
     set_client_capabilities/2,
     has_sampling/1,
     list_sampling_capable/0,
+    has_elicitation/1,
+    list_elicitation_capable/0,
     %% Negotiated protocol version (after `initialize').
     set_protocol_version/2,
     get_protocol_version/1,
@@ -39,6 +41,7 @@
     subscribers_for/1,
     %% Server -> client request via the session's SSE channel.
     sampling_create_message/3,
+    elicit_create/3,
     deliver_response/2,
     %% Server -> client notifications.
     broadcast_list_changed/1,
@@ -92,7 +95,8 @@
     session_id :: binary(),
     caller :: pid(),
     caller_ref :: reference(),
-    expires_at :: integer()
+    expires_at :: integer(),
+    tag = sampling_response :: atom()
 }).
 
 %%====================================================================
@@ -194,6 +198,27 @@ list_sampling_capable() ->
         end
     end, [], ?SESSION_TABLE).
 
+%% @doc Whether a session declared elicitation capability in its
+%% initialize request.
+-spec has_elicitation(binary()) -> boolean().
+has_elicitation(SessionId) ->
+    case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, #mcp_session{client_capabilities = Caps}}] ->
+            maps:is_key(<<"elicitation">>, Caps);
+        [] ->
+            false
+    end.
+
+%% @doc List session ids whose client declared elicitation capability.
+-spec list_elicitation_capable() -> [binary()].
+list_elicitation_capable() ->
+    ets:foldl(fun({Id, #mcp_session{client_capabilities = Caps}}, Acc) ->
+        case maps:is_key(<<"elicitation">>, Caps) of
+            true -> [Id | Acc];
+            false -> Acc
+        end
+    end, [], ?SESSION_TABLE).
+
 %% @doc Set the SSE process pid for a session.
 -spec set_sse_pid(binary(), pid() | undefined) -> ok | {error, not_found}.
 set_sse_pid(SessionId, Pid) ->
@@ -239,6 +264,22 @@ sampling_create_message(SessionId, Params, Opts) ->
             case get_sse_pid(SessionId) of
                 {error, _} = E -> E;
                 {ok, Pid} -> do_sampling(SessionId, Pid, Params, Opts)
+            end
+    end.
+
+%% @doc Send `elicitation/create' to the client behind a session and wait
+%% for the response. The session must (a) exist, (b) have an active
+%% sse_pid, and (c) have declared elicitation capability in initialize.
+-spec elicit_create(binary(), map(), map()) ->
+    {ok, map()}
+  | {error, timeout | not_supported | no_sse | not_found | term()}.
+elicit_create(SessionId, Params, Opts) ->
+    case has_elicitation(SessionId) of
+        false -> {error, not_supported};
+        true ->
+            case get_sse_pid(SessionId) of
+                {error, _} = E -> E;
+                {ok, Pid} -> do_elicit(SessionId, Pid, Params, Opts)
             end
     end.
 
@@ -482,9 +523,9 @@ handle_call({discard_pending, RequestId}, _From, State) ->
 
 handle_call({deliver_response, Key, Response}, _From, State) ->
     Reply = case ets:lookup(?PENDING_TABLE, Key) of
-        [{_, #pending{caller = Caller, caller_ref = Ref}}] ->
+        [{_, #pending{caller = Caller, caller_ref = Ref, tag = Tag}}] ->
             true = ets:delete(?PENDING_TABLE, Key),
-            Caller ! {sampling_response, Ref, Response},
+            Caller ! {Tag, Ref, Response},
             ok;
         [] ->
             {error, unknown_id}
@@ -650,7 +691,7 @@ ensure_inflight_table() ->
 
 do_sampling(SessionId, SsePid, Params, Opts) ->
     Timeout = maps:get(timeout_ms, Opts, ?DEFAULT_SAMPLING_TIMEOUT),
-    RequestId = generate_request_id(),
+    RequestId = generate_request_id(<<"sampling-">>),
     Ref = make_ref(),
     ok = gen_server:call(?MODULE,
         {register_pending, RequestId, #pending{
@@ -658,7 +699,8 @@ do_sampling(SessionId, SsePid, Params, Opts) ->
             session_id = SessionId,
             caller = self(),
             caller_ref = Ref,
-            expires_at = erlang:system_time(millisecond) + Timeout
+            expires_at = erlang:system_time(millisecond) + Timeout,
+            tag = sampling_response
         }}),
     Request = #{
         <<"jsonrpc">> => <<"2.0">>,
@@ -678,8 +720,39 @@ do_sampling(SessionId, SsePid, Params, Opts) ->
         {error, timeout}
     end.
 
-generate_request_id() ->
-    <<"sampling-", (integer_to_binary(erlang:unique_integer([positive])))/binary>>.
+do_elicit(SessionId, SsePid, Params, Opts) ->
+    Timeout = maps:get(timeout_ms, Opts, ?DEFAULT_SAMPLING_TIMEOUT),
+    RequestId = generate_request_id(<<"elicit-">>),
+    Ref = make_ref(),
+    ok = gen_server:call(?MODULE,
+        {register_pending, RequestId, #pending{
+            id = RequestId,
+            session_id = SessionId,
+            caller = self(),
+            caller_ref = Ref,
+            expires_at = erlang:system_time(millisecond) + Timeout,
+            tag = elicitation_response
+        }}),
+    Request = #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => RequestId,
+        <<"method">> => <<"elicitation/create">>,
+        <<"params">> => Params
+    },
+    SsePid ! {sse_send_message, Request},
+    receive
+        {elicitation_response, Ref, #{<<"result">> := Result}} ->
+            {ok, Result};
+        {elicitation_response, Ref, #{<<"error">> := Err}} ->
+            {error, {client_error, Err}}
+    after Timeout ->
+        _ = gen_server:call(?MODULE, {discard_pending, RequestId}),
+        {error, timeout}
+    end.
+
+generate_request_id(Prefix) ->
+    <<Prefix/binary,
+      (integer_to_binary(erlang:unique_integer([positive])))/binary>>.
 
 id_to_binary(Id) when is_binary(Id) -> Id;
 id_to_binary(Id) when is_integer(Id) -> integer_to_binary(Id);

--- a/test/barrel_mcp_sampling_tests.erl
+++ b/test/barrel_mcp_sampling_tests.erl
@@ -163,6 +163,76 @@ test_sampling_timeout() ->
     exit(Pid, kill).
 
 %% ============================================================================
+%% elicit_create round-trip
+%% ============================================================================
+
+elicit_round_trip_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"declines without elicitation capability",
+             fun test_elicit_not_supported/0},
+            {"happy path: response routed to caller",
+             fun test_elicit_round_trip/0},
+            {"timeout when no response arrives",
+             fun test_elicit_timeout/0}
+        ]
+    end}.
+
+test_elicit_not_supported() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ?assertEqual({error, not_supported},
+                 barrel_mcp:elicit_create(S1, #{}, #{})).
+
+test_elicit_round_trip() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ok = barrel_mcp_session:set_client_capabilities(
+        S1, #{<<"elicitation">> => #{}}),
+    Self = self(),
+    Pid = spawn(fun() -> sampling_responder(Self) end),
+    ok = barrel_mcp_session:set_sse_pid(S1, Pid),
+    spawn(fun() ->
+        Self ! {result, barrel_mcp:elicit_create(
+            S1,
+            #{<<"message">> => <<"Pick a colour">>,
+              <<"requestedSchema">> => #{<<"type">> => <<"object">>}},
+            #{timeout_ms => 2000})}
+    end),
+    Request = receive
+        {got_message, Msg} -> Msg
+    after 1000 -> ?assert(false), undefined
+    end,
+    Id = maps:get(<<"id">>, Request),
+    ?assertEqual(<<"elicitation/create">>,
+                 maps:get(<<"method">>, Request)),
+    ok = barrel_mcp_session:deliver_response(Id, #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => Id,
+        <<"result">> => #{<<"action">> => <<"accept">>,
+                          <<"content">> => #{<<"colour">> => <<"blue">>}}
+    }),
+    receive
+        {result, {ok, Result}} ->
+            ?assertEqual(<<"accept">>, maps:get(<<"action">>, Result)),
+            ?assertEqual(<<"blue">>,
+                         maps:get(<<"colour">>,
+                                  maps:get(<<"content">>, Result)))
+    after 2000 ->
+        ?assert(false)
+    end,
+    exit(Pid, kill).
+
+test_elicit_timeout() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ok = barrel_mcp_session:set_client_capabilities(
+        S1, #{<<"elicitation">> => #{}}),
+    Pid = spawn(fun() -> idle_loop() end),
+    ok = barrel_mcp_session:set_sse_pid(S1, Pid),
+    ?assertEqual({error, timeout},
+                 barrel_mcp:elicit_create(
+                     S1, #{}, #{timeout_ms => 100})),
+    exit(Pid, kill).
+
+%% ============================================================================
 %% Helpers
 %% ============================================================================
 


### PR DESCRIPTION
## Summary

Adds the spec's companion to `sampling/createMessage`. Servers can ask the connected client (host) to elicit structured user input via `elicitation/create`.

- New `barrel_mcp:elicit_create/3` façade. Blocks until the client responds or `timeout_ms` (default 30s) elapses.
- New helpers `barrel_mcp:list_sessions_with_elicitation/0`, `barrel_mcp_session:has_elicitation/1`, `barrel_mcp_session:list_elicitation_capable/0`.
- Pending-request map now carries the response tag so sampling and elicitation responses route to the correct caller without colliding.
- Round-trip, timeout, and not-supported eunit coverage. All existing tests + dialyzer green.

Requires the client to have declared `elicitation` capability in its `initialize` request and an active SSE stream. The client routes inbound `elicitation/create` through the existing `barrel_mcp_client_handler` callback module — no client change needed.