### PR TITLE
Server-to-client roots/list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Server-to-client `roots/list`
+
+- New `barrel_mcp:roots_list/1,2` façade. Sends `roots/list` to the connected client behind a session id and returns the host's roots. Requires the client to have declared `roots` capability in its `initialize' request and an active SSE stream.
+- New helpers `barrel_mcp:list_sessions_with_roots/0`, `barrel_mcp_session:has_roots/1`, `barrel_mcp_session:list_roots_capable/0`.
+
 ### Server-to-client `elicitation/create`
 
 - New `barrel_mcp:elicit_create/3` façade. Sends `elicitation/create` to the client behind a session id and blocks until the client responds (or `timeout_ms` elapses, default 30s). Requires the client to have declared `elicitation` capability in its `initialize' request and an active SSE stream. Mirrors the existing `sampling_create_message/3` flow.

--- a/guides/features.md
+++ b/guides/features.md
@@ -78,8 +78,8 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
   `barrel_mcp_session`'s gen_server.
 - `Mcp-Session-Id` lifecycle with TTL-based cleanup.
 - Server-to-client sampling (`sampling/createMessage`),
-  elicitation (`elicitation/create`), and resource update
-  notifications.
+  elicitation (`elicitation/create`), roots query (`roots/list`),
+  and resource update notifications.
 
 ### Authentication
 
@@ -101,6 +101,7 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
 | `barrel_mcp:notify_list_changed/1` | `notifications/tools/list_changed`, `.../resources/list_changed`, or `.../prompts/list_changed` to every active SSE session. Auto-emitted on `reg_*`/`unreg_*`. |
 | `barrel_mcp:sampling_create_message/3` | Server→client `sampling/createMessage` (requires the client to declare `sampling` capability). |
 | `barrel_mcp:elicit_create/3` | Server→client `elicitation/create` to ask the host for structured user input (requires the client to declare `elicitation` capability). |
+| `barrel_mcp:roots_list/1,2` | Server→client `roots/list` to enumerate the host's available roots (requires the client to declare `roots` capability). |
 | `barrel_mcp_tasks:create/3`, `finish/3`, `fail/3`, `cancel/2` | Long-running operation lifecycle. |
 
 ## Client (`barrel_mcp_client`)

--- a/src/barrel_mcp.erl
+++ b/src/barrel_mcp.erl
@@ -108,6 +108,9 @@
     list_sessions_with_sampling/0,
     elicit_create/3,
     list_sessions_with_elicitation/0,
+    roots_list/1,
+    roots_list/2,
+    list_sessions_with_roots/0,
     notify_resource_updated/1,
     notify_resource_updated/2,
     notify_progress/3,
@@ -736,6 +739,30 @@ elicit_create(SessionId, Params, Opts) ->
 -spec list_sessions_with_elicitation() -> [binary()].
 list_sessions_with_elicitation() ->
     barrel_mcp_session:list_elicitation_capable().
+
+%% @doc Send `roots/list' to the client behind a session to enumerate
+%% the host's available roots (typically filesystem or workspace roots
+%% the host has authorised the server to operate on). Requires the
+%% client to have declared roots capability in its `initialize' request
+%% and an active SSE stream. Blocks until the client responds or
+%% `timeout_ms' (default 30s) elapses.
+-spec roots_list(binary()) ->
+    {ok, [map()]}
+  | {error, timeout | not_supported | no_sse | not_found | term()}.
+roots_list(SessionId) ->
+    roots_list(SessionId, #{}).
+
+-spec roots_list(binary(), map()) ->
+    {ok, [map()]}
+  | {error, timeout | not_supported | no_sse | not_found | term()}.
+roots_list(SessionId, Opts) ->
+    barrel_mcp_session:roots_list(SessionId, Opts).
+
+%% @doc Return the ids of currently connected sessions whose client
+%% declared roots capability.
+-spec list_sessions_with_roots() -> [binary()].
+list_sessions_with_roots() ->
+    barrel_mcp_session:list_roots_capable().
 
 %% @doc Notify all subscribers of a resource that it has changed.
 %% The notification body is a JSON-RPC notification with no params; the

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -28,6 +28,8 @@
     list_sampling_capable/0,
     has_elicitation/1,
     list_elicitation_capable/0,
+    has_roots/1,
+    list_roots_capable/0,
     %% Negotiated protocol version (after `initialize').
     set_protocol_version/2,
     get_protocol_version/1,
@@ -42,6 +44,7 @@
     %% Server -> client request via the session's SSE channel.
     sampling_create_message/3,
     elicit_create/3,
+    roots_list/2,
     deliver_response/2,
     %% Server -> client notifications.
     broadcast_list_changed/1,
@@ -219,6 +222,27 @@ list_elicitation_capable() ->
         end
     end, [], ?SESSION_TABLE).
 
+%% @doc Whether a session declared roots capability in its initialize
+%% request.
+-spec has_roots(binary()) -> boolean().
+has_roots(SessionId) ->
+    case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, #mcp_session{client_capabilities = Caps}}] ->
+            maps:is_key(<<"roots">>, Caps);
+        [] ->
+            false
+    end.
+
+%% @doc List session ids whose client declared roots capability.
+-spec list_roots_capable() -> [binary()].
+list_roots_capable() ->
+    ets:foldl(fun({Id, #mcp_session{client_capabilities = Caps}}, Acc) ->
+        case maps:is_key(<<"roots">>, Caps) of
+            true -> [Id | Acc];
+            false -> Acc
+        end
+    end, [], ?SESSION_TABLE).
+
 %% @doc Set the SSE process pid for a session.
 -spec set_sse_pid(binary(), pid() | undefined) -> ok | {error, not_found}.
 set_sse_pid(SessionId, Pid) ->
@@ -280,6 +304,22 @@ elicit_create(SessionId, Params, Opts) ->
             case get_sse_pid(SessionId) of
                 {error, _} = E -> E;
                 {ok, Pid} -> do_elicit(SessionId, Pid, Params, Opts)
+            end
+    end.
+
+%% @doc Send `roots/list' to the client behind a session and wait for
+%% the response. The session must (a) exist, (b) have an active sse_pid,
+%% and (c) have declared roots capability in initialize.
+-spec roots_list(binary(), map()) ->
+    {ok, [map()]}
+  | {error, timeout | not_supported | no_sse | not_found | term()}.
+roots_list(SessionId, Opts) ->
+    case has_roots(SessionId) of
+        false -> {error, not_supported};
+        true ->
+            case get_sse_pid(SessionId) of
+                {error, _} = E -> E;
+                {ok, Pid} -> do_roots_list(SessionId, Pid, Opts)
             end
     end.
 
@@ -744,6 +784,37 @@ do_elicit(SessionId, SsePid, Params, Opts) ->
         {elicitation_response, Ref, #{<<"result">> := Result}} ->
             {ok, Result};
         {elicitation_response, Ref, #{<<"error">> := Err}} ->
+            {error, {client_error, Err}}
+    after Timeout ->
+        _ = gen_server:call(?MODULE, {discard_pending, RequestId}),
+        {error, timeout}
+    end.
+
+do_roots_list(SessionId, SsePid, Opts) ->
+    Timeout = maps:get(timeout_ms, Opts, ?DEFAULT_SAMPLING_TIMEOUT),
+    RequestId = generate_request_id(<<"roots-">>),
+    Ref = make_ref(),
+    ok = gen_server:call(?MODULE,
+        {register_pending, RequestId, #pending{
+            id = RequestId,
+            session_id = SessionId,
+            caller = self(),
+            caller_ref = Ref,
+            expires_at = erlang:system_time(millisecond) + Timeout,
+            tag = roots_response
+        }}),
+    Request = #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => RequestId,
+        <<"method">> => <<"roots/list">>,
+        <<"params">> => #{}
+    },
+    SsePid ! {sse_send_message, Request},
+    receive
+        {roots_response, Ref, #{<<"result">> := Result}} ->
+            Roots = maps:get(<<"roots">>, Result, []),
+            {ok, Roots};
+        {roots_response, Ref, #{<<"error">> := Err}} ->
             {error, {client_error, Err}}
     after Timeout ->
         _ = gen_server:call(?MODULE, {discard_pending, RequestId}),

--- a/test/barrel_mcp_sampling_tests.erl
+++ b/test/barrel_mcp_sampling_tests.erl
@@ -233,6 +233,69 @@ test_elicit_timeout() ->
     exit(Pid, kill).
 
 %% ============================================================================
+%% roots_list round-trip
+%% ============================================================================
+
+roots_list_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"declines without roots capability",
+             fun test_roots_not_supported/0},
+            {"happy path: response routed to caller",
+             fun test_roots_round_trip/0},
+            {"timeout when no response arrives",
+             fun test_roots_timeout/0}
+        ]
+    end}.
+
+test_roots_not_supported() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ?assertEqual({error, not_supported},
+                 barrel_mcp:roots_list(S1)).
+
+test_roots_round_trip() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ok = barrel_mcp_session:set_client_capabilities(
+        S1, #{<<"roots">> => #{}}),
+    Self = self(),
+    Pid = spawn(fun() -> sampling_responder(Self) end),
+    ok = barrel_mcp_session:set_sse_pid(S1, Pid),
+    spawn(fun() ->
+        Self ! {result,
+                barrel_mcp:roots_list(S1, #{timeout_ms => 2000})}
+    end),
+    Request = receive
+        {got_message, Msg} -> Msg
+    after 1000 -> ?assert(false), undefined
+    end,
+    Id = maps:get(<<"id">>, Request),
+    ?assertEqual(<<"roots/list">>, maps:get(<<"method">>, Request)),
+    ok = barrel_mcp_session:deliver_response(Id, #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => Id,
+        <<"result">> => #{<<"roots">> =>
+            [#{<<"uri">> => <<"file:///workspace">>,
+               <<"name">> => <<"Workspace">>}]}
+    }),
+    receive
+        {result, {ok, Roots}} ->
+            ?assertMatch([#{<<"uri">> := <<"file:///workspace">>}], Roots)
+    after 2000 ->
+        ?assert(false)
+    end,
+    exit(Pid, kill).
+
+test_roots_timeout() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ok = barrel_mcp_session:set_client_capabilities(
+        S1, #{<<"roots">> => #{}}),
+    Pid = spawn(fun() -> idle_loop() end),
+    ok = barrel_mcp_session:set_sse_pid(S1, Pid),
+    ?assertEqual({error, timeout},
+                 barrel_mcp:roots_list(S1, #{timeout_ms => 100})),
+    exit(Pid, kill).
+
+%% ============================================================================
 %% Helpers
 %% ============================================================================
 


### PR DESCRIPTION
## Summary

Adds the third server-to-client primitive in the spec: `roots/list`, which lets a server enumerate the host's available roots.

- New `barrel_mcp:roots_list/1,2` façade. Blocks until the client responds or `timeout_ms` (default 30s) elapses.
- New helpers `barrel_mcp:list_sessions_with_roots/0`, `barrel_mcp_session:has_roots/1`, `barrel_mcp_session:list_roots_capable/0`.
- Round-trip, timeout, and not-supported eunit coverage. All existing tests + dialyzer green.

Requires the client to have declared `roots` capability in its `initialize` request and an active SSE stream. The client routes inbound `roots/list` through the existing `barrel_mcp_client_handler` callback module — no client change needed.