### PR TITLE
logging/setLevel actually filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `logging/setLevel` actually filters the log stream
+
+- The previous `logging/setLevel` handler was a no-op stub that accepted any payload and returned `{}`. It now validates the requested level against the eight RFC 5424 levels (debug, info, notice, warning, error, critical, alert, emergency), persists the chosen level on the session, and rejects unknown levels with `-32602`.
+- New `barrel_mcp:notify_log/3,4` façade. Emits `notifications/message` to a session and is silently dropped when the event level is below the session's configured level. Default session level is `info`, matching the spec.
+- New helpers `barrel_mcp_session:set_log_level/2`, `get_log_level/1`, `log_level_priority/1`.
+
 ### Server-to-client `roots/list`
 
 - New `barrel_mcp:roots_list/1,2` façade. Sends `roots/list` to the connected client behind a session id and returns the host's roots. Requires the client to have declared `roots` capability in its `initialize' request and an active SSE stream.

--- a/guides/features.md
+++ b/guides/features.md
@@ -98,6 +98,7 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
 | --- | --- |
 | `barrel_mcp:notify_resource_updated/1,2` | `notifications/resources/updated` to every subscriber. |
 | `barrel_mcp:notify_progress/3,4` | `notifications/progress` to a session. |
+| `barrel_mcp:notify_log/3,4` | `notifications/message` (server log stream) to a session, filtered against the session's `logging/setLevel`. |
 | `barrel_mcp:notify_list_changed/1` | `notifications/tools/list_changed`, `.../resources/list_changed`, or `.../prompts/list_changed` to every active SSE session. Auto-emitted on `reg_*`/`unreg_*`. |
 | `barrel_mcp:sampling_create_message/3` | Server→client `sampling/createMessage` (requires the client to declare `sampling` capability). |
 | `barrel_mcp:elicit_create/3` | Server→client `elicitation/create` to ask the host for structured user input (requires the client to declare `elicitation` capability). |

--- a/src/barrel_mcp.erl
+++ b/src/barrel_mcp.erl
@@ -115,6 +115,8 @@
     notify_resource_updated/2,
     notify_progress/3,
     notify_progress/4,
+    notify_log/3,
+    notify_log/4,
     notify_list_changed/1
 ]).
 
@@ -796,6 +798,51 @@ notify_progress(SessionId, Token, Progress) ->
 -spec notify_progress(binary(), term(), number(), number() | undefined) -> ok.
 notify_progress(SessionId, Token, Progress, Total) ->
     barrel_mcp_session:notify_progress(SessionId, Token, Progress, Total).
+
+%% @doc Emit `notifications/message' (the MCP server log stream) to a
+%% session. The notification is dropped silently when `Level' is below
+%% the session's configured level (`logging/setLevel'). `Logger' is an
+%% optional component name; pass `undefined' to omit it. `Data' is the
+%% structured payload — typically a string or a map.
+-spec notify_log(binary(), atom() | binary(), term()) -> ok.
+notify_log(SessionId, Level, Data) ->
+    notify_log(SessionId, Level, undefined, Data).
+
+-spec notify_log(binary(), atom() | binary(), binary() | undefined,
+                 term()) -> ok.
+notify_log(SessionId, Level, Logger, Data) ->
+    case barrel_mcp_session:log_level_priority(Level) of
+        error -> ok;  %% invalid level — drop
+        EventPrio ->
+            ConfigPrio = case barrel_mcp_session:get_log_level(SessionId) of
+                {ok, L} -> barrel_mcp_session:log_level_priority(L);
+                _ -> 1  %% default `info'
+            end,
+            case EventPrio >= ConfigPrio of
+                false -> ok;
+                true ->
+                    case barrel_mcp_session:get_sse_pid(SessionId) of
+                        {ok, Pid} when is_pid(Pid) ->
+                            Pid ! {sse_send_message, log_envelope(Level, Logger, Data)},
+                            ok;
+                        _ -> ok
+                    end
+            end
+    end.
+
+log_envelope(Level, Logger, Data) ->
+    LevelBin = level_to_binary(Level),
+    Params0 = #{<<"level">> => LevelBin, <<"data">> => Data},
+    Params = case Logger of
+                 undefined -> Params0;
+                 _ -> Params0#{<<"logger">> => Logger}
+             end,
+    #{<<"jsonrpc">> => <<"2.0">>,
+      <<"method">> => <<"notifications/message">>,
+      <<"params">> => Params}.
+
+level_to_binary(L) when is_atom(L) -> atom_to_binary(L, utf8);
+level_to_binary(L) when is_binary(L) -> L.
 
 %% @doc Push a `notifications/<kind>/list_changed' envelope to every
 %% currently-connected SSE session. Hosts call this when they mutate

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -380,8 +380,40 @@ handle_request(<<"completion/complete">>, Params, Id, _State) ->
     end;
 
 %% Logging
-handle_request(<<"logging/setLevel">>, _Params, Id, _State) ->
-    success_response(Id, #{});
+handle_request(<<"logging/setLevel">>, Params, Id, State) ->
+    Level = maps:get(<<"level">>, Params, undefined),
+    case {Level, maps:find(session_id, State)} of
+        {undefined, _} ->
+            error_response(Id, ?JSONRPC_INVALID_PARAMS,
+                           <<"Missing required parameter: level">>);
+        {_, error} ->
+            %% Stdio / no session — accept but no per-session storage.
+            case barrel_mcp_session:log_level_priority(Level) of
+                error ->
+                    error_response(Id, ?JSONRPC_INVALID_PARAMS,
+                                   <<"Invalid log level">>);
+                _ ->
+                    success_response(Id, #{})
+            end;
+        {_, {ok, undefined}} ->
+            case barrel_mcp_session:log_level_priority(Level) of
+                error ->
+                    error_response(Id, ?JSONRPC_INVALID_PARAMS,
+                                   <<"Invalid log level">>);
+                _ ->
+                    success_response(Id, #{})
+            end;
+        {_, {ok, SessionId}} ->
+            case barrel_mcp_session:set_log_level(SessionId, Level) of
+                ok ->
+                    success_response(Id, #{});
+                {error, invalid_level} ->
+                    error_response(Id, ?JSONRPC_INVALID_PARAMS,
+                                   <<"Invalid log level">>);
+                {error, not_found} ->
+                    success_response(Id, #{})
+            end
+    end;
 
 %% Unknown method
 handle_request(Method, _Params, Id, _State) ->

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -30,6 +30,10 @@
     list_elicitation_capable/0,
     has_roots/1,
     list_roots_capable/0,
+    %% Per-session log level (`logging/setLevel').
+    set_log_level/2,
+    get_log_level/1,
+    log_level_priority/1,
     %% Negotiated protocol version (after `initialize').
     set_protocol_version/2,
     get_protocol_version/1,
@@ -82,8 +86,15 @@
     sse_pid :: pid() | undefined,  %% Process handling SSE stream
     %% Recent SSE events (newest first) for `Last-Event-ID' replay.
     sse_buffer = [] :: [{binary(), map()}],
-    sse_buffer_max = 256 :: pos_integer()
+    sse_buffer_max = 256 :: pos_integer(),
+    %% Per-session log level set by `logging/setLevel'. Default
+    %% `info' per the MCP spec. Filters `notifications/message' on
+    %% emit.
+    log_level = info :: log_level()
 }).
+
+-type log_level() :: debug | info | notice | warning | error
+                   | critical | alert | emergency.
 
 %% Async tool call in-flight tracking.
 -record(in_flight, {
@@ -242,6 +253,63 @@ list_roots_capable() ->
             false -> Acc
         end
     end, [], ?SESSION_TABLE).
+
+%% @doc Set the per-session log level (driven by `logging/setLevel').
+%% `Level' is one of the eight RFC 5424 levels accepted by the MCP
+%% spec; rejects anything else with `{error, invalid_level}'.
+-spec set_log_level(binary(), log_level() | binary()) ->
+    ok | {error, not_found | invalid_level}.
+set_log_level(SessionId, Level) ->
+    case parse_level(Level) of
+        {ok, L} ->
+            gen_server:call(?MODULE, {set_log_level, SessionId, L});
+        error ->
+            {error, invalid_level}
+    end.
+
+%% @doc Read the current log level for a session. Defaults to `info'
+%% before any `logging/setLevel' is received.
+-spec get_log_level(binary()) -> {ok, log_level()} | {error, not_found}.
+get_log_level(SessionId) ->
+    case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, #mcp_session{log_level = L}}] -> {ok, L};
+        [] -> {error, not_found}
+    end.
+
+%% @doc Numeric priority for the eight RFC 5424 levels (debug=0,
+%% emergency=7). Higher = more severe. Used for filtering: a
+%% notification at priority N is delivered iff N >= configured level.
+-spec log_level_priority(log_level() | binary()) -> 0..7 | error.
+log_level_priority(Level) ->
+    case parse_level(Level) of
+        {ok, L} -> level_priority(L);
+        error -> error
+    end.
+
+level_priority(debug)     -> 0;
+level_priority(info)      -> 1;
+level_priority(notice)    -> 2;
+level_priority(warning)   -> 3;
+level_priority(error)     -> 4;
+level_priority(critical)  -> 5;
+level_priority(alert)     -> 6;
+level_priority(emergency) -> 7.
+
+parse_level(L) when is_atom(L) ->
+    case lists:member(L, [debug, info, notice, warning, error,
+                          critical, alert, emergency]) of
+        true -> {ok, L};
+        false -> error
+    end;
+parse_level(<<"debug">>)     -> {ok, debug};
+parse_level(<<"info">>)      -> {ok, info};
+parse_level(<<"notice">>)    -> {ok, notice};
+parse_level(<<"warning">>)   -> {ok, warning};
+parse_level(<<"error">>)     -> {ok, error};
+parse_level(<<"critical">>)  -> {ok, critical};
+parse_level(<<"alert">>)     -> {ok, alert};
+parse_level(<<"emergency">>) -> {ok, emergency};
+parse_level(_)               -> error.
 
 %% @doc Set the SSE process pid for a session.
 -spec set_sse_pid(binary(), pid() | undefined) -> ok | {error, not_found}.
@@ -519,6 +587,16 @@ handle_call({set_client_capabilities, SessionId, Caps}, _From, State) ->
     Reply = case ets:lookup(?SESSION_TABLE, SessionId) of
         [{_, Session}] ->
             Updated = Session#mcp_session{client_capabilities = Caps},
+            true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
+            ok;
+        [] -> {error, not_found}
+    end,
+    {reply, Reply, State};
+
+handle_call({set_log_level, SessionId, Level}, _From, State) ->
+    Reply = case ets:lookup(?SESSION_TABLE, SessionId) of
+        [{_, Session}] ->
+            Updated = Session#mcp_session{log_level = Level},
             true = ets:insert(?SESSION_TABLE, {SessionId, Updated}),
             ok;
         [] -> {error, not_found}

--- a/test/barrel_mcp_sampling_tests.erl
+++ b/test/barrel_mcp_sampling_tests.erl
@@ -296,6 +296,83 @@ test_roots_timeout() ->
     exit(Pid, kill).
 
 %% ============================================================================
+%% logging/setLevel + notify_log filtering
+%% ============================================================================
+
+logging_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"default level is info",
+             fun test_default_log_level/0},
+            {"set_log_level rejects invalid level",
+             fun test_set_log_level_invalid/0},
+            {"notify_log delivers >= configured level",
+             fun test_notify_log_at_or_above/0},
+            {"notify_log drops below configured level",
+             fun test_notify_log_below/0},
+            {"unknown level passed to notify_log is dropped",
+             fun test_notify_log_invalid_dropped/0}
+        ]
+    end}.
+
+test_default_log_level() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ?assertEqual({ok, info}, barrel_mcp_session:get_log_level(S1)).
+
+test_set_log_level_invalid() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    ?assertEqual({error, invalid_level},
+                 barrel_mcp_session:set_log_level(S1, <<"verbose">>)),
+    ?assertEqual({ok, info}, barrel_mcp_session:get_log_level(S1)),
+    ok = barrel_mcp_session:set_log_level(S1, <<"warning">>),
+    ?assertEqual({ok, warning},
+                 barrel_mcp_session:get_log_level(S1)).
+
+test_notify_log_at_or_above() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    Self = self(),
+    Pid = spawn(fun() -> capture_loop(Self) end),
+    ok = barrel_mcp_session:set_sse_pid(S1, Pid),
+    ok = barrel_mcp_session:set_log_level(S1, <<"warning">>),
+    ok = barrel_mcp:notify_log(S1, error, <<"boom">>),
+    receive
+        {captured, {sse_send_message, Msg}} ->
+            ?assertEqual(<<"notifications/message">>,
+                         maps:get(<<"method">>, Msg)),
+            Params = maps:get(<<"params">>, Msg),
+            ?assertEqual(<<"error">>, maps:get(<<"level">>, Params)),
+            ?assertEqual(<<"boom">>, maps:get(<<"data">>, Params))
+    after 1000 -> ?assert(false)
+    end,
+    exit(Pid, kill).
+
+test_notify_log_below() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    Self = self(),
+    Pid = spawn(fun() -> capture_loop(Self) end),
+    ok = barrel_mcp_session:set_sse_pid(S1, Pid),
+    ok = barrel_mcp_session:set_log_level(S1, <<"warning">>),
+    ok = barrel_mcp:notify_log(S1, debug, <<"chatter">>),
+    receive
+        {captured, _} -> ?assert(false)
+    after 200 -> ok
+    end,
+    exit(Pid, kill).
+
+test_notify_log_invalid_dropped() ->
+    {ok, S1} = barrel_mcp_session:create(#{}),
+    Self = self(),
+    Pid = spawn(fun() -> capture_loop(Self) end),
+    ok = barrel_mcp_session:set_sse_pid(S1, Pid),
+    ?assertEqual(ok,
+                 barrel_mcp:notify_log(S1, <<"verbose">>, <<"x">>)),
+    receive
+        {captured, _} -> ?assert(false)
+    after 200 -> ok
+    end,
+    exit(Pid, kill).
+
+%% ============================================================================
 %% Helpers
 %% ============================================================================
 


### PR DESCRIPTION
## Summary

Turns the `logging/setLevel` no-op stub into a working spec-conformant handler with a matching emit façade.

- Validates the level against the eight RFC 5424 levels (`debug`, `info`, `notice`, `warning`, `error`, `critical`, `alert`, `emergency`), persists it on the session, and rejects unknown levels with `-32602`.
- New `barrel_mcp:notify_log/3,4` emits `notifications/message` to a session and is silently dropped when the event level is below the session's configured level.
- New helpers `barrel_mcp_session:set_log_level/2`, `get_log_level/1`, `log_level_priority/1`. Default session level is `info`.
- Eunit covers default level, invalid-level rejection, delivery at/above configured level, drop below, and unknown-level no-op. All existing tests + dialyzer + ct + examples green.