### PR TITLE
Tool annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tool annotations
+
+- `reg_tool/4` accepts a new `annotations` option — a free-form map of behavioural hints (the spec defines `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` as booleans). The map is surfaced verbatim under `annotations` in the `tools/list` payload. Tools without annotations omit the field.
+
 ### `logging/setLevel` actually filters the log stream
 
 - The previous `logging/setLevel` handler was a no-op stub that accepted any payload and returned `{}`. It now validates the requested level against the eight RFC 5424 levels (debug, info, notice, warning, error, critical, alert, emergency), persists the chosen level on the session, and rejects unknown levels with `-32602`.

--- a/guides/features.md
+++ b/guides/features.md
@@ -53,6 +53,10 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
   `{resource_template, Uri, Arg}`; advertised via the
   `completions` capability when at least one is registered.
 - All registrations accept optional `title` and `icons`.
+- Tool registrations additionally accept `annotations` —
+  spec-shaped behavioural hints (`readOnlyHint`, `destructiveHint`,
+  `idempotentHint`, `openWorldHint`) surfaced verbatim under
+  `annotations` in `tools/list`.
 
 ### Tool features
 

--- a/src/barrel_mcp.erl
+++ b/src/barrel_mcp.erl
@@ -143,6 +143,10 @@
 %% <ul>
 %%   <li>`description' - Human-readable description of the tool</li>
 %%   <li>`input_schema' - JSON Schema defining expected input format</li>
+%%   <li>`annotations' - Map of MCP behavioural hints surfaced under
+%%       `annotations' on `tools/list'. Spec keys are
+%%       `readOnlyHint', `destructiveHint', `idempotentHint',
+%%       `openWorldHint' (all booleans). Values pass through verbatim.</li>
 %% </ul>
 %%
 %% == Handler Return Values ==
@@ -180,7 +184,9 @@
     Function :: atom(),
     Opts :: #{
         description => binary(),
-        input_schema => map()
+        input_schema => map(),
+        annotations => map(),
+        _ => _
     }.
 reg_tool(Name, Module, Function, Opts) ->
     barrel_mcp_registry:reg(tool, Name, Module, Function, Opts).

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -170,7 +170,8 @@ handle_request(<<"tools/list">>, _Params, Id, _State) ->
         with_optional_fields(Base, Handler, [
             {<<"outputSchema">>, output_schema},
             {<<"title">>, title},
-            {<<"icons">>, icons}
+            {<<"icons">>, icons},
+            {<<"annotations">>, annotations}
         ])
     end, barrel_mcp_registry:all(tool)),
     success_response(Id, #{<<"tools">> => Tools});

--- a/src/barrel_mcp_registry.erl
+++ b/src/barrel_mcp_registry.erl
@@ -544,7 +544,9 @@ build_handler(tool, Module, Function, Opts) ->
         long_running => maps:get(long_running, Opts, false),
         validate_output => maps:get(validate_output, Opts, false)
     },
-    add_metadata(maps:merge(Base, opt_field(output_schema, Opts)), Opts);
+    Merged = maps:merge(Base, opt_field(output_schema, Opts)),
+    Merged1 = maps:merge(Merged, opt_field(annotations, Opts)),
+    add_metadata(Merged1, Opts);
 build_handler(resource, Module, Function, Opts) ->
     Base = #{
         module => Module,

--- a/test/barrel_mcp_tools_tests.erl
+++ b/test/barrel_mcp_tools_tests.erl
@@ -31,7 +31,9 @@ tools_test_() ->
         {"Call tool returns list of content blocks", fun test_call_tool_list/0},
         {"Call non-existent tool returns error", fun test_call_tool_not_found/0},
         {"Call tool with error returns error response", fun test_call_tool_error/0},
-        {"Tool with input schema is listed correctly", fun test_tool_input_schema/0}
+        {"Tool with input schema is listed correctly", fun test_tool_input_schema/0},
+        {"Tool annotations are surfaced in tools/list",
+         fun test_tool_annotations/0}
      ]
     }.
 
@@ -201,3 +203,36 @@ test_tool_input_schema() ->
     ?assert(maps:is_key(<<"properties">>, InputSchema)),
 
     barrel_mcp_registry:unreg(tool, <<"search">>).
+
+test_tool_annotations() ->
+    Annotations = #{
+        <<"readOnlyHint">> => true,
+        <<"destructiveHint">> => false,
+        <<"idempotentHint">> => true,
+        <<"openWorldHint">> => false
+    },
+    ok = barrel_mcp_registry:reg(tool, <<"reader">>, ?MODULE, echo_tool, #{
+        description => <<"Read-only inspector">>,
+        annotations => Annotations
+    }),
+    Request = #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => 1,
+        <<"method">> => <<"tools/list">>
+    },
+    Response = barrel_mcp_protocol:handle(Request),
+    Result = maps:get(<<"result">>, Response),
+    [Tool] = maps:get(<<"tools">>, Result),
+    ?assertEqual(Annotations, maps:get(<<"annotations">>, Tool)),
+    %% Tools without annotations omit the field.
+    ok = barrel_mcp_registry:reg(tool, <<"plain">>, ?MODULE, echo_tool, #{}),
+    Response2 = barrel_mcp_protocol:handle(Request),
+    [_, _] = maps:get(<<"tools">>, maps:get(<<"result">>, Response2)),
+    Tools = maps:get(<<"tools">>, maps:get(<<"result">>, Response2)),
+    Plain = lists:filter(fun(T) ->
+                              maps:get(<<"name">>, T) =:= <<"plain">>
+                          end, Tools),
+    [PlainTool] = Plain,
+    ?assertNot(maps:is_key(<<"annotations">>, PlainTool)),
+    barrel_mcp_registry:unreg(tool, <<"reader">>),
+    barrel_mcp_registry:unreg(tool, <<"plain">>).


### PR DESCRIPTION
## Summary

`reg_tool/4` now accepts an `annotations` option — the MCP spec's behavioural hints surfaced under `annotations` on `tools/list`.

- Spec keys: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` (all booleans).
- Values pass through verbatim, so any future spec additions work without library changes.
- Tools without `annotations` omit the field.

Eunit + ct + dialyzer + examples all green.