### PR TITLE
Resource, prompt, and resource-template annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Tool annotations
+### Tool, resource, prompt, and resource-template annotations
 
-- `reg_tool/4` accepts a new `annotations` option — a free-form map of behavioural hints (the spec defines `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint` as booleans). The map is surfaced verbatim under `annotations` in the `tools/list` payload. Tools without annotations omit the field.
+- `reg_tool/4`, `reg_resource/4`, `reg_prompt/4`, and `reg_resource_template/4` accept a new `annotations` option — a free-form map surfaced verbatim under `annotations` in the matching `*/list` payload. The MCP spec defines `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` for tools, and `audience` / `priority` for resources, prompts, and templates. Registrations without annotations omit the field on the wire.
 
 ### `logging/setLevel` actually filters the log stream
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -53,10 +53,12 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
   `{resource_template, Uri, Arg}`; advertised via the
   `completions` capability when at least one is registered.
 - All registrations accept optional `title` and `icons`.
-- Tool registrations additionally accept `annotations` —
-  spec-shaped behavioural hints (`readOnlyHint`, `destructiveHint`,
-  `idempotentHint`, `openWorldHint`) surfaced verbatim under
-  `annotations` in `tools/list`.
+- Tool, resource, prompt, and resource-template registrations
+  also accept `annotations` — a free-form map surfaced verbatim
+  under `annotations` in the matching `*/list` payload. Tools use
+  `readOnlyHint`, `destructiveHint`, `idempotentHint`,
+  `openWorldHint`; resources/prompts/templates use `audience`
+  (`["user" | "assistant"]`) and `priority` (0..1).
 
 ### Tool features
 

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -215,7 +215,8 @@ handle_request(<<"resources/list">>, _Params, Id, _State) ->
         },
         with_optional_fields(Base, Handler, [
             {<<"title">>, title},
-            {<<"icons">>, icons}
+            {<<"icons">>, icons},
+            {<<"annotations">>, annotations}
         ])
     end, barrel_mcp_registry:all(resource)),
     success_response(Id, #{<<"resources">> => Resources});
@@ -248,7 +249,8 @@ handle_request(<<"resources/templates/list">>, _Params, Id, _State) ->
         Compact = maps:filter(fun(_K, V) -> V =/= <<>> end, Base),
         with_optional_fields(Compact, Handler, [
             {<<"title">>, title},
-            {<<"icons">>, icons}
+            {<<"icons">>, icons},
+            {<<"annotations">>, annotations}
         ])
     end, barrel_mcp_registry:all(resource_template)),
     success_response(Id, #{<<"resourceTemplates">> => Templates});
@@ -291,7 +293,8 @@ handle_request(<<"prompts/list">>, _Params, Id, _State) ->
         },
         with_optional_fields(Base, Handler, [
             {<<"title">>, title},
-            {<<"icons">>, icons}
+            {<<"icons">>, icons},
+            {<<"annotations">>, annotations}
         ])
     end, barrel_mcp_registry:all(prompt)),
     success_response(Id, #{<<"prompts">> => Prompts});

--- a/src/barrel_mcp_registry.erl
+++ b/src/barrel_mcp_registry.erl
@@ -556,7 +556,7 @@ build_handler(resource, Module, Function, Opts) ->
         description => maps:get(description, Opts, <<>>),
         mime_type => maps:get(mime_type, Opts, <<"text/plain">>)
     },
-    add_metadata(Base, Opts);
+    add_metadata(maps:merge(Base, opt_field(annotations, Opts)), Opts);
 build_handler(prompt, Module, Function, Opts) ->
     Base = #{
         module => Module,
@@ -565,7 +565,7 @@ build_handler(prompt, Module, Function, Opts) ->
         description => maps:get(description, Opts, <<>>),
         arguments => maps:get(arguments, Opts, [])
     },
-    add_metadata(Base, Opts);
+    add_metadata(maps:merge(Base, opt_field(annotations, Opts)), Opts);
 build_handler(resource_template, Module, Function, Opts) ->
     Base = #{
         module => Module,
@@ -575,7 +575,7 @@ build_handler(resource_template, Module, Function, Opts) ->
         description => maps:get(description, Opts, <<>>),
         mime_type => maps:get(mime_type, Opts, <<"text/plain">>)
     },
-    add_metadata(Base, Opts);
+    add_metadata(maps:merge(Base, opt_field(annotations, Opts)), Opts);
 build_handler(completion, Module, Function, _Opts) ->
     %% Completion handlers are arity 2: (PartialValue, Ctx) ->
     %%   {ok, [Suggestion]} | {ok, [Suggestion], #{has_more => true}}.

--- a/test/barrel_mcp_resources_tests.erl
+++ b/test/barrel_mcp_resources_tests.erl
@@ -30,7 +30,9 @@ resources_test_() ->
         {"Read resource returns JSON content", fun test_read_resource_json/0},
         {"Read non-existent resource returns error", fun test_read_resource_not_found/0},
         {"Resource with mime type is listed correctly", fun test_resource_mime_type/0},
-        {"List resource templates returns empty", fun test_list_resource_templates/0}
+        {"List resource templates returns empty", fun test_list_resource_templates/0},
+        {"Resource annotations are surfaced in resources/list",
+         fun test_resource_annotations/0}
      ]
     }.
 
@@ -230,3 +232,22 @@ test_list_resource_templates() ->
     Result = maps:get(<<"result">>, Response),
     Templates = maps:get(<<"resourceTemplates">>, Result),
     ?assertEqual([], Templates).
+
+test_resource_annotations() ->
+    Annotations = #{<<"audience">> => [<<"user">>],
+                    <<"priority">> => 0.8},
+    ok = barrel_mcp_registry:reg(resource, <<"ann_res">>, ?MODULE, text_resource, #{
+        name => <<"Annotated">>,
+        uri => <<"mem://annotated">>,
+        annotations => Annotations
+    }),
+    Request = #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => 1,
+        <<"method">> => <<"resources/list">>
+    },
+    Response = barrel_mcp_protocol:handle(Request),
+    Result = maps:get(<<"result">>, Response),
+    [Resource] = maps:get(<<"resources">>, Result),
+    ?assertEqual(Annotations, maps:get(<<"annotations">>, Resource)),
+    barrel_mcp_registry:unreg(resource, <<"ann_res">>).


### PR DESCRIPTION
## Summary

Extends the `annotations` registration option (shipped for tools in #17) to resources, prompts, and resource templates.

- `reg_resource/4`, `reg_prompt/4`, and `reg_resource_template/4` accept `annotations`.
- Surfaced verbatim under `annotations` in `resources/list`, `prompts/list`, and `resources/templates/list`.
- Spec uses `audience` (`["user" | "assistant"]`) and `priority` (0..1) on these surfaces, but the pass-through means any future keys work without library changes.

207 eunit + 30 ct + dialyzer + examples green.