### PR TITLE
resources/read: per-block annotations and multi-block returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `resources/read` content-block flexibility
+
+- Resource handlers may now return a list of pre-built content blocks; each block is passed through verbatim, with `uri` auto-injected when the handler omits it.
+- The `#{text := _}` and `#{blob := _, mimeType := _}` map shapes accept optional `mimeType` (text only — blob already requires it) and `annotations` keys, matching the spec's per-content metadata. Both flow through to the wire under `mimeType` / `annotations`.
+
 ### Tool, resource, prompt, and resource-template annotations
 
 - `reg_tool/4`, `reg_resource/4`, `reg_prompt/4`, and `reg_resource_template/4` accept a new `annotations` option — a free-form map surfaced verbatim under `annotations` in the matching `*/list` payload. The MCP spec defines `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` for tools, and `audience` / `priority` for resources, prompts, and templates. Registrations without annotations omit the field on the wire.

--- a/guides/features.md
+++ b/guides/features.md
@@ -44,7 +44,11 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
   handlers receive a `Ctx` map with `session_id`, `request_id`,
   `progress_token`, and an `emit_progress` function.
 - **Resources** — text/binary content, MIME types,
-  `notifications/resources/updated` for live updates.
+  `notifications/resources/updated` for live updates. Handlers
+  may return a single block (`#{text := _}` /
+  `#{blob := _, mimeType := _}`, with optional `mimeType` and
+  `annotations`) or a list of pre-built content blocks for
+  multi-part responses.
 - **Resource templates** — RFC 6570 URI templates, surfaced via
   `resources/templates/list`.
 - **Prompts** — multi-message conversation templates with

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -540,16 +540,40 @@ format_tool_result(Result) when is_list(Result) ->
 format_tool_result(Result) ->
     [#{<<"type">> => <<"text">>, <<"text">> => io_lib:format("~p", [Result])}].
 
+format_resource_result(Uri, Result) when is_list(Result) ->
+    [add_resource_uri(Uri, B) || B <- Result];
 format_resource_result(Uri, Result) when is_binary(Result) ->
     [#{<<"uri">> => Uri, <<"text">> => Result}];
-format_resource_result(Uri, #{text := Text}) ->
-    [#{<<"uri">> => Uri, <<"text">> => Text}];
-format_resource_result(Uri, #{blob := Blob, mimeType := MimeType}) ->
-    [#{<<"uri">> => Uri, <<"blob">> => base64:encode(Blob), <<"mimeType">> => MimeType}];
+format_resource_result(Uri, #{text := Text} = M) ->
+    Block = #{<<"uri">> => Uri, <<"text">> => Text},
+    [decorate_block(Block, M)];
+format_resource_result(Uri, #{blob := Blob, mimeType := MimeType} = M) ->
+    Block = #{<<"uri">> => Uri,
+              <<"blob">> => base64:encode(Blob),
+              <<"mimeType">> => MimeType},
+    [decorate_block(Block, M)];
 format_resource_result(Uri, Result) when is_map(Result) ->
     [#{<<"uri">> => Uri, <<"text">> => iolist_to_binary(json:encode(Result))}];
 format_resource_result(Uri, Result) ->
     [#{<<"uri">> => Uri, <<"text">> => io_lib:format("~p", [Result])}].
+
+%% Pass `annotations' / `mimeType' through onto an already-built block.
+decorate_block(Block, M) ->
+    Block1 = case maps:find(mimeType, M) of
+                 {ok, Mime} -> Block#{<<"mimeType">> => Mime};
+                 error -> Block
+             end,
+    case maps:find(annotations, M) of
+        {ok, Ann} -> Block1#{<<"annotations">> => Ann};
+        error -> Block1
+    end.
+
+%% Inject `uri' into a pre-built content block (binary-keyed map).
+add_resource_uri(Uri, Block) when is_map(Block) ->
+    case maps:is_key(<<"uri">>, Block) of
+        true -> Block;
+        false -> Block#{<<"uri">> => Uri}
+    end.
 
 format_error({Class, Reason, _Stack}) ->
     iolist_to_binary(io_lib:format("~p:~p", [Class, Reason])).

--- a/test/barrel_mcp_resources_tests.erl
+++ b/test/barrel_mcp_resources_tests.erl
@@ -11,7 +11,9 @@
 -export([
     text_resource/1,
     binary_resource/1,
-    json_resource/1
+    json_resource/1,
+    annotated_resource/1,
+    multi_block_resource/1
 ]).
 
 %%====================================================================
@@ -32,7 +34,11 @@ resources_test_() ->
         {"Resource with mime type is listed correctly", fun test_resource_mime_type/0},
         {"List resource templates returns empty", fun test_list_resource_templates/0},
         {"Resource annotations are surfaced in resources/list",
-         fun test_resource_annotations/0}
+         fun test_resource_annotations/0},
+        {"Resource read carries annotations on the content block",
+         fun test_resource_read_block_annotations/0},
+        {"Resource read accepts a list of pre-built content blocks",
+         fun test_resource_read_multi_block/0}
      ]
     }.
 
@@ -59,6 +65,17 @@ binary_resource(_Args) ->
 
 json_resource(_Args) ->
     #{<<"name">> => <<"test">>, <<"value">> => 42}.
+
+annotated_resource(_Args) ->
+    #{text => <<"hello">>,
+      mimeType => <<"text/markdown">>,
+      annotations => #{<<"audience">> => [<<"assistant">>],
+                       <<"priority">> => 0.5}}.
+
+multi_block_resource(_Args) ->
+    [#{<<"text">> => <<"summary">>},
+     #{<<"uri">> => <<"mem://multi/details">>,
+       <<"text">> => <<"details">>}].
 
 %%====================================================================
 %% Tests
@@ -251,3 +268,44 @@ test_resource_annotations() ->
     [Resource] = maps:get(<<"resources">>, Result),
     ?assertEqual(Annotations, maps:get(<<"annotations">>, Resource)),
     barrel_mcp_registry:unreg(resource, <<"ann_res">>).
+
+test_resource_read_block_annotations() ->
+    ok = barrel_mcp_registry:reg(resource, <<"ann_block">>, ?MODULE,
+                                  annotated_resource, #{
+        name => <<"AnnBlock">>,
+        uri => <<"mem://ann-block">>
+    }),
+    Request = #{<<"jsonrpc">> => <<"2.0">>,
+                <<"id">> => 1,
+                <<"method">> => <<"resources/read">>,
+                <<"params">> => #{<<"uri">> => <<"mem://ann-block">>}},
+    Response = barrel_mcp_protocol:handle(Request),
+    [Block] = maps:get(<<"contents">>,
+                       maps:get(<<"result">>, Response)),
+    ?assertEqual(<<"hello">>, maps:get(<<"text">>, Block)),
+    ?assertEqual(<<"text/markdown">>, maps:get(<<"mimeType">>, Block)),
+    ?assertEqual(#{<<"audience">> => [<<"assistant">>],
+                   <<"priority">> => 0.5},
+                 maps:get(<<"annotations">>, Block)),
+    barrel_mcp_registry:unreg(resource, <<"ann_block">>).
+
+test_resource_read_multi_block() ->
+    ok = barrel_mcp_registry:reg(resource, <<"multi">>, ?MODULE,
+                                  multi_block_resource, #{
+        name => <<"Multi">>,
+        uri => <<"mem://multi">>
+    }),
+    Request = #{<<"jsonrpc">> => <<"2.0">>,
+                <<"id">> => 1,
+                <<"method">> => <<"resources/read">>,
+                <<"params">> => #{<<"uri">> => <<"mem://multi">>}},
+    Response = barrel_mcp_protocol:handle(Request),
+    Blocks = maps:get(<<"contents">>,
+                      maps:get(<<"result">>, Response)),
+    ?assertEqual(2, length(Blocks)),
+    [B1, B2] = Blocks,
+    %% URI is auto-injected when the handler omits it.
+    ?assertEqual(<<"mem://multi">>, maps:get(<<"uri">>, B1)),
+    %% Pre-set URI on the second block is preserved.
+    ?assertEqual(<<"mem://multi/details">>, maps:get(<<"uri">>, B2)),
+    barrel_mcp_registry:unreg(resource, <<"multi">>).


### PR DESCRIPTION
## Summary

Closes the per-content-block metadata gap on `resources/read`.

- Resource handlers may return a list of pre-built content blocks; each block is passed through verbatim, and `uri` is auto-injected when the handler omits it.
- The `#{text := _}` and `#{blob := _, mimeType := _}` map shapes accept optional `mimeType` and `annotations` keys, both flowing through to the wire under `mimeType` / `annotations`.
- Matches the spec's per-content metadata model and lets resources expose audience / priority hints on individual content blocks.

209 eunit + 30 ct + dialyzer green.