### PR TITLE
barrel_mcp_tool_format: Anthropic / OpenAI bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `barrel_mcp_tool_format` — LLM provider tool-shape translator
+
+- New module bridging MCP tool definitions and the tool shapes the LLM provider APIs expect.
+- `to_anthropic/1`, `to_openai/1` translate MCP `tools/list` entries (single map or list) to the Anthropic Messages API and OpenAI Chat Completions tool shapes.
+- `from_anthropic_call/1`, `from_openai_call/1` translate a model's tool-call back to the `(Name, Arguments)` pair `barrel_mcp_client:call_tool/4` expects. Accepts both parsed arguments (already a map) and the wire form (JSON string).
+- Closes the bridge an agent host needs when it hands MCP tools to a model and routes the model's tool calls back through an MCP client.
+
 ### `resources/read` content-block flexibility
 
 - Resource handlers may now return a list of pre-built content blocks; each block is passed through verbatim, with `uri` auto-injected when the handler omits it.

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -164,6 +164,31 @@ list_every_tool(Pid) ->
 The same shape applies to `list_resources/1,2`,
 `list_resource_templates/1,2`, and `list_prompts/1,2`.
 
+### Translate to provider tool shapes
+
+`barrel_mcp_tool_format` converts MCP tool maps to the shapes the
+LLM provider APIs expect, and vice versa. Use it when you're
+building an agent host that hands MCP tools to Anthropic / OpenAI
+models and routes the model's tool calls back through the MCP
+client.
+
+```erlang
+agent_tool_loop(McpPid) ->
+    {ok, McpTools} = barrel_mcp_client:list_tools_all(McpPid),
+    AnthropicTools = barrel_mcp_tool_format:to_anthropic(McpTools),
+    %% ... call Anthropic with AnthropicTools, get tool_use blocks ...
+    Block = receive_tool_use_block(),
+    {Name, Args} = barrel_mcp_tool_format:from_anthropic_call(Block),
+    barrel_mcp_client:call_tool(McpPid, Name, Args).
+receive_tool_use_block() ->
+    %% Replace with your real LLM client.
+    #{<<"name">> => <<"echo">>,
+      <<"input">> => #{<<"text">> => <<"hi">>}}.
+```
+
+`to_openai/1` and `from_openai_call/1` follow the same pattern for
+the OpenAI Chat Completions tool-call envelope.
+
 ---
 
 ## 7. Call a tool

--- a/guides/features.md
+++ b/guides/features.md
@@ -193,6 +193,17 @@ by the spec.
     `refresh_token` was supplied. The interactive authorization-code
     redirect stays a host concern.
 
+### LLM provider bridge (`barrel_mcp_tool_format`)
+
+Translates MCP tool maps to the shapes the major LLM provider
+APIs expect, and translates a model's tool-call back into the
+`(Name, Arguments)` pair `barrel_mcp_client:call_tool/4` consumes.
+
+- `to_anthropic/1`, `to_openai/1` — MCP tool → provider tool.
+- `from_anthropic_call/1`, `from_openai_call/1` — provider call →
+  `{Name, Args}`. Accepts both parsed maps and JSON-string
+  arguments (the OpenAI wire shape).
+
 ### Schema validation (`barrel_mcp_schema`)
 
 Pure-Erlang JSON Schema subset validator hosts can use to pre-flight

--- a/src/barrel_mcp_tool_format.erl
+++ b/src/barrel_mcp_tool_format.erl
@@ -1,0 +1,127 @@
+%%%-------------------------------------------------------------------
+%%% @doc Translators between MCP tool shapes and LLM provider tool
+%%% shapes (Anthropic Messages API, OpenAI Chat Completions / Responses).
+%%%
+%%% Use this module to bridge an MCP server's `tools/list' response
+%%% into the tool definitions a provider expects, and to translate a
+%%% provider's tool-call back into the `(Name, Arguments)' pair you
+%%% feed to {@link barrel_mcp_client:call_tool/4}.
+%%%
+%%% The MCP shape (one entry from `tools/list') is:
+%%% ```
+%%% #{
+%%%   <<"name">>        := binary(),
+%%%   <<"description">> => binary(),
+%%%   <<"inputSchema">> => map(),
+%%%   <<"title">>       => binary(),     %% optional
+%%%   <<"annotations">> => map(),        %% optional
+%%%   ...                                 %% other MCP keys ignored
+%%% }
+%%% '''
+%%%
+%%% The Anthropic shape (Messages API `tools' array entry) is:
+%%% ```
+%%% #{
+%%%   <<"name">>         := binary(),
+%%%   <<"description">>  := binary(),
+%%%   <<"input_schema">> := map()
+%%% }
+%%% '''
+%%%
+%%% The OpenAI shape (Chat Completions `tools' array entry) is:
+%%% ```
+%%% #{
+%%%   <<"type">>     := <<"function">>,
+%%%   <<"function">> := #{
+%%%     <<"name">>        := binary(),
+%%%     <<"description">> := binary(),
+%%%     <<"parameters">>  := map()
+%%%   }
+%%% }
+%%% '''
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_tool_format).
+
+-export([
+    to_anthropic/1,
+    to_openai/1,
+    from_anthropic_call/1,
+    from_openai_call/1
+]).
+
+-type mcp_tool() :: map().
+-type provider_tool() :: map().
+-type tool_call() :: {Name :: binary(), Args :: map()}.
+
+-export_type([mcp_tool/0, provider_tool/0, tool_call/0]).
+
+%%====================================================================
+%% MCP -> provider
+%%====================================================================
+
+%% @doc Translate one MCP tool, or a list of MCP tools, into the
+%% Anthropic Messages API tool format. Unknown MCP keys are ignored;
+%% missing `description' becomes an empty binary.
+-spec to_anthropic(mcp_tool() | [mcp_tool()]) ->
+    provider_tool() | [provider_tool()].
+to_anthropic(Tools) when is_list(Tools) ->
+    [to_anthropic(T) || T <- Tools];
+to_anthropic(Tool) when is_map(Tool) ->
+    Schema = maps:get(<<"inputSchema">>, Tool,
+                      #{<<"type">> => <<"object">>}),
+    #{
+        <<"name">>         => maps:get(<<"name">>, Tool),
+        <<"description">>  => maps:get(<<"description">>, Tool, <<>>),
+        <<"input_schema">> => Schema
+    }.
+
+%% @doc Translate one MCP tool, or a list of MCP tools, into the OpenAI
+%% Chat Completions tool format. Wraps each tool in the
+%% `{type: "function", function: {...}}' envelope OpenAI requires.
+-spec to_openai(mcp_tool() | [mcp_tool()]) ->
+    provider_tool() | [provider_tool()].
+to_openai(Tools) when is_list(Tools) ->
+    [to_openai(T) || T <- Tools];
+to_openai(Tool) when is_map(Tool) ->
+    Schema = maps:get(<<"inputSchema">>, Tool,
+                      #{<<"type">> => <<"object">>}),
+    #{
+        <<"type">>     => <<"function">>,
+        <<"function">> => #{
+            <<"name">>        => maps:get(<<"name">>, Tool),
+            <<"description">> => maps:get(<<"description">>, Tool, <<>>),
+            <<"parameters">>  => Schema
+        }
+    }.
+
+%%====================================================================
+%% Provider -> MCP
+%%====================================================================
+
+%% @doc Translate a single Anthropic `tool_use' content block into the
+%% `(Name, Arguments)' pair you can feed to
+%% {@link barrel_mcp_client:call_tool/4}. Accepts both the canonical
+%% binary-keyed map and the camelCase variant some clients emit.
+-spec from_anthropic_call(map()) -> tool_call().
+from_anthropic_call(#{<<"name">> := Name, <<"input">> := Input}) ->
+    {Name, Input};
+from_anthropic_call(#{<<"toolName">> := Name, <<"input">> := Input}) ->
+    {Name, Input}.
+
+%% @doc Translate a single OpenAI `tool_call' object into the
+%% `(Name, Arguments)' pair. Accepts both the parsed-arguments shape
+%% (`arguments' is already a map) and the wire shape (`arguments' is a
+%% JSON string that needs decoding).
+-spec from_openai_call(map()) -> tool_call().
+from_openai_call(#{<<"function">> := Fn}) ->
+    Name = maps:get(<<"name">>, Fn),
+    Args = decode_args(maps:get(<<"arguments">>, Fn, <<"{}">>)),
+    {Name, Args}.
+
+decode_args(Args) when is_map(Args) -> Args;
+decode_args(Args) when is_binary(Args) ->
+    case json:decode(Args) of
+        Map when is_map(Map) -> Map;
+        _ -> #{}
+    end.

--- a/test/barrel_mcp_tool_format_tests.erl
+++ b/test/barrel_mcp_tool_format_tests.erl
@@ -1,0 +1,101 @@
+-module(barrel_mcp_tool_format_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% MCP -> Anthropic
+%%====================================================================
+
+to_anthropic_single_test() ->
+    Mcp = #{<<"name">> => <<"search">>,
+            <<"description">> => <<"Search the index">>,
+            <<"inputSchema">> => #{<<"type">> => <<"object">>,
+                                    <<"required">> => [<<"q">>]}},
+    ?assertEqual(#{<<"name">> => <<"search">>,
+                   <<"description">> => <<"Search the index">>,
+                   <<"input_schema">> => #{<<"type">> => <<"object">>,
+                                            <<"required">> => [<<"q">>]}},
+                 barrel_mcp_tool_format:to_anthropic(Mcp)).
+
+to_anthropic_list_test() ->
+    Mcp = [#{<<"name">> => <<"a">>}, #{<<"name">> => <<"b">>}],
+    Result = barrel_mcp_tool_format:to_anthropic(Mcp),
+    ?assertEqual(2, length(Result)),
+    ?assertEqual(<<"a">>, maps:get(<<"name">>, hd(Result))).
+
+to_anthropic_defaults_test() ->
+    %% Missing description and inputSchema: filled with empty defaults.
+    Result = barrel_mcp_tool_format:to_anthropic(#{<<"name">> => <<"x">>}),
+    ?assertEqual(<<>>, maps:get(<<"description">>, Result)),
+    ?assertEqual(#{<<"type">> => <<"object">>},
+                 maps:get(<<"input_schema">>, Result)).
+
+to_anthropic_drops_extras_test() ->
+    %% Extra MCP keys (title, annotations) are not surfaced.
+    Mcp = #{<<"name">> => <<"x">>,
+            <<"title">> => <<"X">>,
+            <<"annotations">> => #{<<"readOnlyHint">> => true}},
+    Result = barrel_mcp_tool_format:to_anthropic(Mcp),
+    ?assertNot(maps:is_key(<<"title">>, Result)),
+    ?assertNot(maps:is_key(<<"annotations">>, Result)).
+
+%%====================================================================
+%% MCP -> OpenAI
+%%====================================================================
+
+to_openai_single_test() ->
+    Mcp = #{<<"name">> => <<"search">>,
+            <<"description">> => <<"Search">>,
+            <<"inputSchema">> => #{<<"type">> => <<"object">>}},
+    Out = barrel_mcp_tool_format:to_openai(Mcp),
+    ?assertEqual(<<"function">>, maps:get(<<"type">>, Out)),
+    Fn = maps:get(<<"function">>, Out),
+    ?assertEqual(<<"search">>, maps:get(<<"name">>, Fn)),
+    ?assertEqual(<<"Search">>, maps:get(<<"description">>, Fn)),
+    ?assertEqual(#{<<"type">> => <<"object">>},
+                 maps:get(<<"parameters">>, Fn)).
+
+to_openai_list_test() ->
+    [Out] = barrel_mcp_tool_format:to_openai([#{<<"name">> => <<"x">>}]),
+    ?assertEqual(<<"function">>, maps:get(<<"type">>, Out)).
+
+%%====================================================================
+%% Anthropic -> MCP
+%%====================================================================
+
+from_anthropic_canonical_test() ->
+    Block = #{<<"type">> => <<"tool_use">>,
+              <<"id">> => <<"abc">>,
+              <<"name">> => <<"search">>,
+              <<"input">> => #{<<"q">> => <<"hello">>}},
+    ?assertEqual({<<"search">>, #{<<"q">> => <<"hello">>}},
+                 barrel_mcp_tool_format:from_anthropic_call(Block)).
+
+from_anthropic_camel_test() ->
+    Block = #{<<"toolName">> => <<"x">>, <<"input">> => #{}},
+    ?assertEqual({<<"x">>, #{}},
+                 barrel_mcp_tool_format:from_anthropic_call(Block)).
+
+%%====================================================================
+%% OpenAI -> MCP
+%%====================================================================
+
+from_openai_parsed_args_test() ->
+    Call = #{<<"id">> => <<"call_1">>,
+             <<"type">> => <<"function">>,
+             <<"function">> => #{<<"name">> => <<"search">>,
+                                 <<"arguments">> => #{<<"q">> => <<"hi">>}}},
+    ?assertEqual({<<"search">>, #{<<"q">> => <<"hi">>}},
+                 barrel_mcp_tool_format:from_openai_call(Call)).
+
+from_openai_string_args_test() ->
+    Call = #{<<"function">> =>
+                #{<<"name">> => <<"search">>,
+                  <<"arguments">> => <<"{\"q\": \"hi\"}">>}},
+    ?assertEqual({<<"search">>, #{<<"q">> => <<"hi">>}},
+                 barrel_mcp_tool_format:from_openai_call(Call)).
+
+from_openai_missing_args_defaults_to_empty_test() ->
+    Call = #{<<"function">> => #{<<"name">> => <<"x">>}},
+    ?assertEqual({<<"x">>, #{}},
+                 barrel_mcp_tool_format:from_openai_call(Call)).


### PR DESCRIPTION
## Summary

New module `barrel_mcp_tool_format` — the bridge an agent host needs when it hands MCP tools to a model and routes the model's tool calls back through `barrel_mcp_client:call_tool/4`.

- `to_anthropic/1`, `to_openai/1` — MCP tool definition (single map or list, as returned by `tools/list`) → provider tool shape.
- `from_anthropic_call/1`, `from_openai_call/1` — provider tool-call block → `{Name, Args}`. Accepts both parsed-arguments (already a map) and the wire shape where `arguments` is a JSON string (OpenAI).

11 unit tests covering both directions for both providers, including missing-field defaults and the JSON-string argument path. 220 eunit + 30 ct + dialyzer green.

The new building-a-client guide section shows the typical agent-host pattern: list MCP tools, translate to provider shape, send to the model, translate the response back, call the MCP tool.