### PR TITLE
barrel_mcp_agent: federation aggregator for agent hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `barrel_mcp_agent` — multi-server tool aggregator
+
+- New module sitting on top of `barrel_mcp_clients`. Aggregates `tools/list` across every connected MCP client, rewrites each tool name to `<<"ServerId<sep>ToolName">>` (default separator `:`), and routes a namespaced `call_tool/2,3` back to the correct client.
+- `to_anthropic/0,1` and `to_openai/0,1` return the aggregated catalog directly in provider format, ready to hand to a model.
+- Closes the orchestration gap for hosts running an agent loop against multiple MCP servers.
+
 ### `barrel_mcp_tool_format` — LLM provider tool-shape translator
 
 - New module bridging MCP tool definitions and the tool shapes the LLM provider APIs expect.

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -173,7 +173,7 @@ models and routes the model's tool calls back through the MCP
 client.
 
 ```erlang
-agent_tool_loop(McpPid) ->
+single_server_loop(McpPid) ->
     {ok, McpTools} = barrel_mcp_client:list_tools_all(McpPid),
     AnthropicTools = barrel_mcp_tool_format:to_anthropic(McpTools),
     %% ... call Anthropic with AnthropicTools, get tool_use blocks ...
@@ -188,6 +188,26 @@ receive_tool_use_block() ->
 
 `to_openai/1` and `from_openai_call/1` follow the same pattern for
 the OpenAI Chat Completions tool-call envelope.
+
+### Federate across servers with the agent aggregator
+
+When the host connects to several MCP servers at once (via
+`barrel_mcp:start_client/2`), `barrel_mcp_agent` collapses every
+catalog into one namespaced list and routes a model's call back to
+the right server.
+
+```erlang
+multi_server_loop() ->
+    Tools = barrel_mcp_agent:to_anthropic(),
+    %% ... call Anthropic with Tools ...
+    Block = receive_tool_use_block(),
+    {Name, Args} = barrel_mcp_tool_format:from_anthropic_call(Block),
+    barrel_mcp_agent:call_tool(Name, Args).
+```
+
+Tool names round-trip through `<<"ServerId:ToolName">>`. Pick a
+different separator with `#{separator => <<"::">>}` if `:` clashes
+with one of your tool names.
 
 ---
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -193,6 +193,22 @@ by the spec.
     `refresh_token` was supplied. The interactive authorization-code
     redirect stays a host concern.
 
+### Multi-server agent aggregator (`barrel_mcp_agent`)
+
+Sits on top of `barrel_mcp_clients` and turns the federation
+registry into a single namespaced tool catalog the host can hand
+to an LLM, plus a router that dispatches a model's tool call back
+to the right MCP server.
+
+- `list_tools/0,1` — aggregated `tools/list` across every
+  registered client; tool names rewritten to
+  `<<"ServerId<sep>ToolName">>` (default separator `:`).
+- `to_anthropic/0,1`, `to_openai/0,1` — the same catalog in the
+  matching provider shape.
+- `call_tool/2,3` — parses the namespaced name, routes to the
+  right client. Errors `{error, no_separator | unknown_server}`
+  cover the parse / lookup paths.
+
 ### LLM provider bridge (`barrel_mcp_tool_format`)
 
 Translates MCP tool maps to the shapes the major LLM provider

--- a/src/barrel_mcp_agent.erl
+++ b/src/barrel_mcp_agent.erl
@@ -1,0 +1,147 @@
+%%%-------------------------------------------------------------------
+%%% @doc Multi-server tool aggregator for agent hosts.
+%%%
+%%% Sits on top of {@link barrel_mcp_clients} and turns the set of
+%%% connected MCP clients into a single namespaced tool catalog the
+%%% host can hand to an LLM, plus a router that dispatches a model's
+%%% tool call back to the right MCP server.
+%%%
+%%% Tool names are namespaced as `<<"ServerId<Sep>ToolName">>'. The
+%%% default separator is `<<":">>'; override with the `separator'
+%%% option on every call. Hosts that allow `:' in tool names should
+%%% pick a separator that does not appear in any registered tool.
+%%%
+%%% Typical agent loop:
+%%% ```
+%%% Tools = barrel_mcp_agent:to_anthropic(),
+%%% %% ... ask the model with Tools, receive a tool_use block ...
+%%% {Name, Args} = barrel_mcp_tool_format:from_anthropic_call(Block),
+%%% {ok, Result} = barrel_mcp_agent:call_tool(Name, Args).
+%%% '''
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_agent).
+
+-export([
+    list_tools/0,
+    list_tools/1,
+    to_anthropic/0,
+    to_anthropic/1,
+    to_openai/0,
+    to_openai/1,
+    call_tool/2,
+    call_tool/3
+]).
+
+-type opts() :: #{separator => binary(), timeout => timeout()}.
+
+-export_type([opts/0]).
+
+-define(DEFAULT_SEP, <<":">>).
+
+%%====================================================================
+%% Listing
+%%====================================================================
+
+%% @doc Return every tool from every registered client, with each
+%% tool's `<<"name">>' rewritten to `<<"ServerId<Sep>ToolName">>'.
+%% Servers that error out are skipped (with a `logger:warning').
+-spec list_tools() -> [map()].
+list_tools() -> list_tools(#{}).
+
+-spec list_tools(opts()) -> [map()].
+list_tools(Opts) ->
+    Sep = sep(Opts),
+    Servers = barrel_mcp_clients:list_clients(),
+    lists:flatmap(fun({ServerId, Pid}) ->
+        case fetch_tools(Pid) of
+            {ok, Tools} ->
+                [namespace_tool(ServerId, Sep, T) || T <- Tools];
+            {error, Reason} ->
+                logger:warning("barrel_mcp_agent: list_tools ~p failed: ~p",
+                               [ServerId, Reason]),
+                []
+        end
+    end, Servers).
+
+fetch_tools(Pid) ->
+    barrel_mcp_client:list_tools_all(Pid).
+
+namespace_tool(ServerId, Sep, Tool) ->
+    Original = maps:get(<<"name">>, Tool),
+    Tool#{<<"name">> => <<(to_bin(ServerId))/binary, Sep/binary,
+                          Original/binary>>}.
+
+%%====================================================================
+%% Provider formats
+%%====================================================================
+
+%% @doc Aggregated tools in Anthropic Messages API format.
+-spec to_anthropic() -> [map()].
+to_anthropic() -> to_anthropic(#{}).
+
+-spec to_anthropic(opts()) -> [map()].
+to_anthropic(Opts) ->
+    barrel_mcp_tool_format:to_anthropic(list_tools(Opts)).
+
+%% @doc Aggregated tools in OpenAI Chat Completions tool format.
+-spec to_openai() -> [map()].
+to_openai() -> to_openai(#{}).
+
+-spec to_openai(opts()) -> [map()].
+to_openai(Opts) ->
+    barrel_mcp_tool_format:to_openai(list_tools(Opts)).
+
+%%====================================================================
+%% Routing
+%%====================================================================
+
+%% @doc Route a model's tool call back to the right MCP server.
+%% `NamespacedName' is `<<"ServerId<Sep>ToolName">>'; the `ServerId'
+%% prefix selects the client and the `ToolName' suffix is forwarded.
+%% Errors:
+%% <ul>
+%%   <li>`{error, no_separator}' — the name does not contain the
+%%       configured separator.</li>
+%%   <li>`{error, unknown_server}' — no client is registered under
+%%       the parsed `ServerId'.</li>
+%%   <li>Any error returned by
+%%       {@link barrel_mcp_client:call_tool/4}.</li>
+%% </ul>
+-spec call_tool(binary(), map()) ->
+    {ok, map()} | {error, term()}.
+call_tool(NsName, Args) ->
+    call_tool(NsName, Args, #{}).
+
+-spec call_tool(binary(), map(), opts()) ->
+    {ok, map()} | {error, term()}.
+call_tool(NsName, Args, Opts) ->
+    Sep = sep(Opts),
+    case split_ns(NsName, Sep) of
+        {error, _} = E -> E;
+        {ServerId, ToolName} ->
+            case barrel_mcp_clients:whereis_client(ServerId) of
+                undefined -> {error, unknown_server};
+                Pid ->
+                    Timeout = maps:get(timeout, Opts, 30000),
+                    barrel_mcp_client:call_tool(
+                      Pid, ToolName, Args, #{timeout => Timeout})
+            end
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+sep(Opts) -> maps:get(separator, Opts, ?DEFAULT_SEP).
+
+to_bin(B) when is_binary(B) -> B;
+to_bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
+to_bin(L) when is_list(L) -> list_to_binary(L);
+to_bin(I) when is_integer(I) -> integer_to_binary(I).
+
+split_ns(Bin, Sep) when is_binary(Bin), is_binary(Sep) ->
+    case binary:split(Bin, Sep) of
+        [_] -> {error, no_separator};
+        [Server, Tool] -> {Server, Tool}
+    end.

--- a/test/barrel_mcp_agent_tests.erl
+++ b/test/barrel_mcp_agent_tests.erl
@@ -1,0 +1,55 @@
+-module(barrel_mcp_agent_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% These tests exercise the parts of barrel_mcp_agent that don't need
+%% live MCP transports: namespace splitting, error reporting, and
+%% empty-registry behaviour.
+
+agent_test_() ->
+    {setup, fun setup/0, fun teardown/1, fun(_) ->
+        [
+            {"call_tool with no separator returns no_separator",
+             fun test_call_no_separator/0},
+            {"call_tool with unknown server returns unknown_server",
+             fun test_call_unknown_server/0},
+            {"custom separator is honoured",
+             fun test_custom_separator/0},
+            {"empty registry yields empty tool list",
+             fun test_empty_list_tools/0},
+            {"empty registry produces empty Anthropic / OpenAI lists",
+             fun test_empty_provider_lists/0}
+        ]
+    end}.
+
+setup() ->
+    catch application:stop(barrel_mcp),
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    ok.
+
+teardown(_) ->
+    application:stop(barrel_mcp),
+    ok.
+
+test_call_no_separator() ->
+    ?assertEqual({error, no_separator},
+                 barrel_mcp_agent:call_tool(<<"plain_name">>, #{})).
+
+test_call_unknown_server() ->
+    ?assertEqual({error, unknown_server},
+                 barrel_mcp_agent:call_tool(<<"ghost:tool">>, #{})).
+
+test_custom_separator() ->
+    ?assertEqual({error, no_separator},
+                 barrel_mcp_agent:call_tool(<<"ghost:tool">>, #{},
+                                            #{separator => <<"::">>})),
+    ?assertEqual({error, unknown_server},
+                 barrel_mcp_agent:call_tool(<<"ghost::tool">>, #{},
+                                            #{separator => <<"::">>})).
+
+test_empty_list_tools() ->
+    ?assertEqual([], barrel_mcp_agent:list_tools()).
+
+test_empty_provider_lists() ->
+    ?assertEqual([], barrel_mcp_agent:to_anthropic()),
+    ?assertEqual([], barrel_mcp_agent:to_openai()).


### PR DESCRIPTION
## Summary

New module `barrel_mcp_agent` — sits on top of `barrel_mcp_clients` and turns the federation registry into a single namespaced tool catalog plus a router that dispatches the model's tool call back to the right server.

- `list_tools/0,1` — every tool from every registered client, names rewritten to `<<"ServerId<sep>ToolName">>` (default separator `:`).
- `to_anthropic/0,1`, `to_openai/0,1` — same catalog, in provider format. Composes with `barrel_mcp_tool_format` (#20).
- `call_tool/2,3` — parses the namespaced name and forwards. Errors `{error, no_separator}` and `{error, unknown_server}` cover the parse / lookup paths.

5 unit tests (parse / lookup paths, empty registry, custom separator). Live federation is exercised by the existing example apps. 225 eunit + 30 ct + dialyzer green.

This is the orchestration glue an agent host needs when it runs against multiple MCP servers at once.