### PR TITLE
chore: release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-03
+
+This release lands the agent-host story (server federation +
+provider-shape bridge + multi-server aggregator) on top of a major
+spec-conformance pass for MCP `2025-11-25`. The server's
+`protocol_version` env default is now `<<"2025-11-25">>` (was
+`<<"2025-03-26">>`).
+
+
 ### `barrel_mcp_agent` — multi-server tool aggregator
 
 - New module sitting on top of `barrel_mcp_clients`. Aggregates `tools/list` across every connected MCP client, rewrites each tool name to `<<"ServerId<sep>ToolName">>` (default separator `:`), and routes a namespaced `call_tool/2,3` back to the correct client.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,96 @@ To make the registry wait for an external process before becoming ready:
 
 If `wait_for_proc` is not set, the registry becomes ready immediately after init.
 
+## Usage by role
+
+barrel_mcp covers the three MCP roles in one library:
+
+- **server** — exposes tools, resources, prompts to MCP clients.
+- **client** — connects to one MCP server, calls tools, reads
+  resources, handles server-initiated requests.
+- **host (agent)** — drives one or more clients on behalf of an
+  LLM; collects each server's tool catalog, hands it to the
+  model, routes the model's tool call back through the right
+  client.
+
+The three short examples below cover the typical wiring; deeper
+guides live under `guides/` (`getting-started.md`,
+`tools-resources-prompts.md`, `building-a-client.md`).
+
+### Server — expose a tool over Streamable HTTP
+
+```erlang
+-module(my_server).
+-export([start/0, search/1]).
+
+start() ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    ok = barrel_mcp:reg_tool(<<"search">>, ?MODULE, search, #{
+        description => <<"Search the index">>,
+        input_schema => #{<<"type">> => <<"object">>,
+                           <<"required">> => [<<"q">>]}
+    }),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => 8080,
+                                              session_enabled => true}),
+    ok.
+
+search(#{<<"q">> := Q}) ->
+    iolist_to_binary([<<"results for ">>, Q]).
+```
+
+That's a complete MCP server. Point any MCP client (Claude Code,
+Claude Desktop via stdio, the `barrel_mcp_client` below, …) at
+`http://127.0.0.1:8080/mcp`.
+
+### Client — connect and call a tool
+
+```erlang
+client_demo() ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    {ok, Pid} = barrel_mcp_client:start(#{
+        transport => {http, <<"http://127.0.0.1:8080/mcp">>}
+    }),
+    {ok, Result} = barrel_mcp_client:call_tool(
+                     Pid, <<"search">>, #{<<"q">> => <<"hello">>}),
+    barrel_mcp_client:close(Pid),
+    Result.
+```
+
+The transport tuple selects the wire (`{http, Url}`,
+`{stdio, [Cmd | Args]}`). Auth and OAuth options live on the same
+spec — see `guides/building-a-client.md`.
+
+### Host (agent) — hand many MCP servers to an LLM
+
+```erlang
+agent_loop() ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    {ok, _} = barrel_mcp:start_client(<<"github">>, #{
+        transport => {http, <<"https://mcp.github.example/mcp">>},
+        auth => {bearer, GhToken}
+    }),
+    {ok, _} = barrel_mcp:start_client(<<"shell">>, #{
+        transport => {stdio, ["mcp-shell-server"]}
+    }),
+    %% Hand every connected server's tools to the model:
+    AnthropicTools = barrel_mcp_agent:to_anthropic(),
+    %% ... call the LLM with AnthropicTools and capture the
+    %%     tool_use block it returned ...
+    Block = ask_llm(AnthropicTools),
+    {NsName, Args} = barrel_mcp_tool_format:from_anthropic_call(Block),
+    %% Routes "github:..." to the github client, "shell:..." to
+    %% the shell client.
+    barrel_mcp_agent:call_tool(NsName, Args).
+```
+
+`barrel_mcp_agent` namespaces tool names as
+`<<"ServerId:ToolName">>` across the federation.
+`barrel_mcp_tool_format` translates between MCP tool maps and the
+provider shapes (Anthropic Messages API, OpenAI Chat Completions);
+swap `to_anthropic/0` and `from_anthropic_call/1` for the OpenAI
+counterparts to use a different model. `ask_llm/1` is your own
+LLM HTTP call — barrel_mcp does not bundle an LLM SDK.
+
 ## Quick Start
 
 ### Starting the Application

--- a/src/barrel_mcp.app.src
+++ b/src/barrel_mcp.app.src
@@ -1,14 +1,14 @@
 {application, barrel_mcp, [
     {description, "MCP Protocol Library for Erlang"},
-    {vsn, "1.1.1"},
+    {vsn, "1.2.0"},
     {registered, [barrel_mcp_registry, barrel_mcp_sup, barrel_mcp_session,
                   barrel_mcp_tasks, barrel_mcp_client_sup]},
     {mod, {barrel_mcp_app, []}},
     {applications, [kernel, stdlib, crypto, cowboy, hackney]},
     {env, [
         {server_name, <<"barrel">>},
-        {server_version, <<"1.1.1">>},
-        {protocol_version, <<"2025-03-26">>},
+        {server_version, <<"1.2.0">>},
+        {protocol_version, <<"2025-11-25">>},
         {session_ttl, 1800000}  %% 30 minutes default
     ]},
     {modules, []},


### PR DESCRIPTION
## Summary

Bumps `vsn` / `server_version` to `1.2.0` and corrects the `protocol_version` env default to `<<"2025-11-25">>` (the server has been negotiating that version internally since the 2025-11-25 spec parity work).

The 1.2.0 heading in CHANGELOG captures everything since 1.1.1:
- Tasks spec parity (PR #13)
- Server→client elicitation/create (PR #14)
- Server→client roots/list (PR #15)
- logging/setLevel actually filters (PR #16)
- Tool / resource / prompt / template annotations (PRs #17, #18)
- resources/read content-block flexibility (PR #19)
- `barrel_mcp_tool_format` Anthropic / OpenAI bridge (PR #20)
- `barrel_mcp_agent` multi-server aggregator (PR #21, #22)
- Critical correctness + security fixes (PR #12)