### PR TITLE
Interop: cover resources/subscribe + notifications/resources/updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Interop coverage: resources/subscribe + notifications/resources/updated
+
+- Direction A of the Python interop suite now exercises the full subscribe round-trip: subscribe to a URI, trigger a server-side `notify_resource_updated/1`, wait for the inbound `notifications/resources/updated` to arrive on the client SSE stream, unsubscribe. Verifies that `barrel_mcp_session:subscribe_resource/2`, `notify_resource_updated/1`, and the SSE delivery path all interoperate correctly with the reference implementation's notification handling.
+
 ### Tasks Task-shape wire alignment
 
 - Renamed the wire field `updatedAt` → `lastUpdatedAt` on every Task envelope (`tasks/get`, `tasks/list`, `notifications/tasks/changed`). The reference Python SDK models the field as `lastUpdatedAt`, and accepts no other name.

--- a/test/barrel_mcp_python_interop_SUITE.erl
+++ b/test/barrel_mcp_python_interop_SUITE.erl
@@ -27,7 +27,8 @@
          erlang_client_against_python_server/1]).
 
 %% Tool / resource / prompt handlers exported for the registry.
--export([echo_tool/1, slow_tool/2, greeting_resource/1, hello_prompt/1]).
+-export([echo_tool/1, slow_tool/2, trigger_update_tool/1,
+         greeting_resource/1, hello_prompt/1]).
 
 -define(PORT, 22451).
 
@@ -121,6 +122,11 @@ ensure_fixture() ->
                            <<"properties">> =>
                                #{<<"text">> => #{<<"type">> => <<"string">>}}}
     }),
+    ok = barrel_mcp_registry:reg(tool, <<"trigger_update">>, ?MODULE,
+                                  trigger_update_tool, #{
+        description => <<"Push notifications/resources/updated for the greeting URI">>,
+        input_schema => #{<<"type">> => <<"object">>}
+    }),
     ok = barrel_mcp_registry:reg(resource, <<"greeting">>, ?MODULE,
                                   greeting_resource, #{
         name => <<"Greeting">>,
@@ -138,11 +144,16 @@ ensure_fixture() ->
 cleanup_fixture() ->
     catch barrel_mcp_registry:unreg(tool, <<"echo">>),
     catch barrel_mcp_registry:unreg(tool, <<"slow_echo">>),
+    catch barrel_mcp_registry:unreg(tool, <<"trigger_update">>),
     catch barrel_mcp_registry:unreg(resource, <<"greeting">>),
     catch barrel_mcp_registry:unreg(prompt, <<"hello_prompt">>),
     ok.
 
 echo_tool(#{<<"text">> := T}) -> T.
+
+trigger_update_tool(_) ->
+    ok = barrel_mcp:notify_resource_updated(<<"mem://greeting">>),
+    <<"triggered">>.
 
 %% Long-running arity-2 handler. Sleeps briefly then echoes back so
 %% the Python client can see the task transition through `working' →

--- a/test/interop/client.py
+++ b/test/interop/client.py
@@ -28,8 +28,26 @@ def fail(msg: str) -> None:
 
 
 async def run(url: str) -> None:
+    update_event = asyncio.Event()
+
+    async def on_message(message):
+        # ClientSession dispatches inbound notifications to this
+        # handler. We only care about the resources/updated stream
+        # for the subscribe round-trip.
+        from mcp.types import (
+            ServerNotification,
+            ResourceUpdatedNotification,
+        )
+        if isinstance(message, ServerNotification):
+            inner = message.root
+            if isinstance(inner, ResourceUpdatedNotification):
+                if str(inner.params.uri) == EXPECTED_RESOURCE_URI:
+                    update_event.set()
+
     async with streamable_http_client(url) as (read, write, _):
-        async with ClientSession(read, write) as session:
+        async with ClientSession(
+            read, write, message_handler=on_message
+        ) as session:
             await session.initialize()
 
             tools = await session.list_tools()
@@ -69,6 +87,16 @@ async def run(url: str) -> None:
             tasks_list = await session.experimental.list_tasks()
             if not isinstance(tasks_list.tasks, list):
                 fail(f"list_tasks did not return a list: {tasks_list}")
+
+            # Subscribe / notifications/resources/updated round-trip.
+            # subscribe -> trigger -> wait for the notification.
+            await session.subscribe_resource(EXPECTED_RESOURCE_URI)
+            await session.call_tool("trigger_update", arguments={})
+            try:
+                await asyncio.wait_for(update_event.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                fail("did not receive notifications/resources/updated")
+            await session.unsubscribe_resource(EXPECTED_RESOURCE_URI)
 
     print("OK")
 


### PR DESCRIPTION
## Summary

Extends Direction A of the Python interop suite to verify the full subscribe / notify round-trip end to end against the reference SDK:

1. Subscribe to a URI (`session.subscribe_resource`).
2. Call a server-side `trigger_update` tool that invokes `barrel_mcp:notify_resource_updated/1` for that URI.
3. Wait up to 5s for the inbound `notifications/resources/updated` to arrive on the client SSE stream (handled via a `message_handler` that signals an `asyncio.Event`).
4. Unsubscribe.

Catches drift in: subscription registration, notification dispatch, SSE event framing, and the Python SDK's notification routing through `ResourceUpdatedNotification`. Both directions still green; eunit + ct + dialyzer clean.