### PR TITLE
Interop: cover server-to-client sampling/createMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Interop coverage: server-to-client sampling/createMessage
+
+- Direction A of the Python interop suite now exercises the full sampling round-trip against the reference SDK: a server-side tool calls `barrel_mcp:sampling_create_message/3`, the Python `sampling_callback` returns a canned reply, the tool surfaces that text as its result. Verifies that the pending-request map, SSE delivery, response correlation, and capability gating all interoperate with the reference implementation.
+
 ### Interop coverage: resources/subscribe + notifications/resources/updated
 
 - Direction A of the Python interop suite now exercises the full subscribe round-trip: subscribe to a URI, trigger a server-side `notify_resource_updated/1`, wait for the inbound `notifications/resources/updated` to arrive on the client SSE stream, unsubscribe. Verifies that `barrel_mcp_session:subscribe_resource/2`, `notify_resource_updated/1`, and the SSE delivery path all interoperate correctly with the reference implementation's notification handling.

--- a/test/barrel_mcp_python_interop_SUITE.erl
+++ b/test/barrel_mcp_python_interop_SUITE.erl
@@ -28,7 +28,7 @@
 
 %% Tool / resource / prompt handlers exported for the registry.
 -export([echo_tool/1, slow_tool/2, trigger_update_tool/1,
-         greeting_resource/1, hello_prompt/1]).
+         ask_llm_tool/1, greeting_resource/1, hello_prompt/1]).
 
 -define(PORT, 22451).
 
@@ -127,6 +127,11 @@ ensure_fixture() ->
         description => <<"Push notifications/resources/updated for the greeting URI">>,
         input_schema => #{<<"type">> => <<"object">>}
     }),
+    ok = barrel_mcp_registry:reg(tool, <<"ask_llm">>, ?MODULE,
+                                  ask_llm_tool, #{
+        description => <<"Ask the connected client to sample a message">>,
+        input_schema => #{<<"type">> => <<"object">>}
+    }),
     ok = barrel_mcp_registry:reg(resource, <<"greeting">>, ?MODULE,
                                   greeting_resource, #{
         name => <<"Greeting">>,
@@ -145,6 +150,7 @@ cleanup_fixture() ->
     catch barrel_mcp_registry:unreg(tool, <<"echo">>),
     catch barrel_mcp_registry:unreg(tool, <<"slow_echo">>),
     catch barrel_mcp_registry:unreg(tool, <<"trigger_update">>),
+    catch barrel_mcp_registry:unreg(tool, <<"ask_llm">>),
     catch barrel_mcp_registry:unreg(resource, <<"greeting">>),
     catch barrel_mcp_registry:unreg(prompt, <<"hello_prompt">>),
     ok.
@@ -154,6 +160,22 @@ echo_tool(#{<<"text">> := T}) -> T.
 trigger_update_tool(_) ->
     ok = barrel_mcp:notify_resource_updated(<<"mem://greeting">>),
     <<"triggered">>.
+
+%% Ask the only sampling-capable session for a message and return
+%% the text. Mirrors examples/sampling_host's ask_sampler/1.
+ask_llm_tool(_) ->
+    [SessionId | _] = barrel_mcp:list_sessions_with_sampling(),
+    Params = #{
+        <<"messages">> =>
+            [#{<<"role">> => <<"user">>,
+               <<"content">> => #{<<"type">> => <<"text">>,
+                                   <<"text">> => <<"hi">>}}],
+        <<"maxTokens">> => 32
+    },
+    {ok, Result, _Usage} =
+        barrel_mcp:sampling_create_message(SessionId, Params,
+                                           #{timeout_ms => 5000}),
+    maps:get(<<"text">>, maps:get(<<"content">>, Result)).
 
 %% Long-running arity-2 handler. Sleeps briefly then echoes back so
 %% the Python client can see the task transition through `working' →

--- a/test/interop/client.py
+++ b/test/interop/client.py
@@ -15,6 +15,7 @@ import traceback
 
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
+from mcp.types import CreateMessageResult, TextContent
 
 
 EXPECTED_TOOL = "echo"
@@ -25,6 +26,19 @@ EXPECTED_PROMPT = "hello_prompt"
 def fail(msg: str) -> None:
     print(f"FAIL: {msg}")
     sys.exit(1)
+
+
+SAMPLED_REPLY = "the canned answer"
+
+
+async def sampling_callback(_context, _params):
+    """Server-to-client sampling/createMessage handler. Returns a
+    canned reply so the round-trip is deterministic in CI."""
+    return CreateMessageResult(
+        role="assistant",
+        content=TextContent(type="text", text=SAMPLED_REPLY),
+        model="canned-test-model",
+    )
 
 
 async def run(url: str) -> None:
@@ -46,7 +60,9 @@ async def run(url: str) -> None:
 
     async with streamable_http_client(url) as (read, write, _):
         async with ClientSession(
-            read, write, message_handler=on_message
+            read, write,
+            message_handler=on_message,
+            sampling_callback=sampling_callback,
         ) as session:
             await session.initialize()
 
@@ -97,6 +113,20 @@ async def run(url: str) -> None:
             except asyncio.TimeoutError:
                 fail("did not receive notifications/resources/updated")
             await session.unsubscribe_resource(EXPECTED_RESOURCE_URI)
+
+            # Server-to-client sampling round-trip. The server's
+            # ask_llm tool sends sampling/createMessage to us; our
+            # sampling_callback returns SAMPLED_REPLY; the tool
+            # surfaces that text as its result.
+            sampling_result = await session.call_tool(
+                "ask_llm", arguments={}
+            )
+            text_blocks = [
+                b for b in sampling_result.content
+                if getattr(b, "text", None)
+            ]
+            if not text_blocks or text_blocks[0].text != SAMPLED_REPLY:
+                fail(f"sampling round-trip failed: {sampling_result}")
 
     print("OK")
 


### PR DESCRIPTION
## Summary

Direction A of the Python interop suite now exercises the full server-to-client sampling round-trip against the reference SDK:

1. Python client provides a `sampling_callback` (auto-declares the `sampling` capability on initialize).
2. Python client calls a server-side `ask_llm` tool.
3. The tool calls `barrel_mcp:sampling_create_message/3`, which pushes `sampling/createMessage` over SSE to the client.
4. The Python callback returns a canned reply.
5. The tool surfaces that text as its result; the test asserts the round-tripped string.

Verifies that the pending-request map, SSE delivery of server-initiated requests, response correlation by id, and the `has_sampling` capability gate all interoperate with the reference implementation.

eunit + ct + dialyzer + both interop directions green.