### PR TITLE
Interop: cover elicitation/create + roots/list round-trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Interop coverage: elicitation/create + roots/list
+
+- Direction A now exercises the remaining two server-to-client primitives end-to-end against the reference SDK: a server-side tool calls `barrel_mcp:elicit_create/3` (form-mode payload), the Python `elicitation_callback` returns an `accept` action with a fixed colour, and the tool surfaces that colour as text. Same shape for `roots/list`: a tool calls `barrel_mcp:roots_list/1`, the Python `list_roots_callback` returns one fixed root, and the tool surfaces its name. With sampling already covered, every server-to-client primitive is now wire-validated against the reference implementation on every CI run.
+
 ### Interop coverage: server-to-client sampling/createMessage
 
 - Direction A of the Python interop suite now exercises the full sampling round-trip against the reference SDK: a server-side tool calls `barrel_mcp:sampling_create_message/3`, the Python `sampling_callback` returns a canned reply, the tool surfaces that text as its result. Verifies that the pending-request map, SSE delivery, response correlation, and capability gating all interoperate with the reference implementation.

--- a/test/barrel_mcp_python_interop_SUITE.erl
+++ b/test/barrel_mcp_python_interop_SUITE.erl
@@ -28,7 +28,8 @@
 
 %% Tool / resource / prompt handlers exported for the registry.
 -export([echo_tool/1, slow_tool/2, trigger_update_tool/1,
-         ask_llm_tool/1, greeting_resource/1, hello_prompt/1]).
+         ask_llm_tool/1, ask_user_tool/1, list_roots_tool/1,
+         greeting_resource/1, hello_prompt/1]).
 
 -define(PORT, 22451).
 
@@ -132,6 +133,16 @@ ensure_fixture() ->
         description => <<"Ask the connected client to sample a message">>,
         input_schema => #{<<"type">> => <<"object">>}
     }),
+    ok = barrel_mcp_registry:reg(tool, <<"ask_user">>, ?MODULE,
+                                  ask_user_tool, #{
+        description => <<"Ask the connected client to elicit user input">>,
+        input_schema => #{<<"type">> => <<"object">>}
+    }),
+    ok = barrel_mcp_registry:reg(tool, <<"list_roots">>, ?MODULE,
+                                  list_roots_tool, #{
+        description => <<"Ask the connected client for its roots">>,
+        input_schema => #{<<"type">> => <<"object">>}
+    }),
     ok = barrel_mcp_registry:reg(resource, <<"greeting">>, ?MODULE,
                                   greeting_resource, #{
         name => <<"Greeting">>,
@@ -151,6 +162,8 @@ cleanup_fixture() ->
     catch barrel_mcp_registry:unreg(tool, <<"slow_echo">>),
     catch barrel_mcp_registry:unreg(tool, <<"trigger_update">>),
     catch barrel_mcp_registry:unreg(tool, <<"ask_llm">>),
+    catch barrel_mcp_registry:unreg(tool, <<"ask_user">>),
+    catch barrel_mcp_registry:unreg(tool, <<"list_roots">>),
     catch barrel_mcp_registry:unreg(resource, <<"greeting">>),
     catch barrel_mcp_registry:unreg(prompt, <<"hello_prompt">>),
     ok.
@@ -176,6 +189,36 @@ ask_llm_tool(_) ->
         barrel_mcp:sampling_create_message(SessionId, Params,
                                            #{timeout_ms => 5000}),
     maps:get(<<"text">>, maps:get(<<"content">>, Result)).
+
+%% Ask the only elicitation-capable session for a structured
+%% answer and return what the user picked. Form-mode payload
+%% per the spec.
+ask_user_tool(_) ->
+    [SessionId | _] = barrel_mcp:list_sessions_with_elicitation(),
+    Params = #{
+        <<"mode">> => <<"form">>,
+        <<"message">> => <<"Pick a colour">>,
+        <<"requestedSchema">> =>
+            #{<<"type">> => <<"object">>,
+              <<"properties">> =>
+                  #{<<"colour">> =>
+                        #{<<"type">> => <<"string">>}}}
+    },
+    {ok, Result} = barrel_mcp:elicit_create(SessionId, Params,
+                                             #{timeout_ms => 5000}),
+    %% The Python callback returns action=accept,
+    %% content={"colour": "blue"}. Surface the colour as text.
+    Content = maps:get(<<"content">>, Result, #{}),
+    maps:get(<<"colour">>, Content, <<"unset">>).
+
+%% Ask the only roots-capable session for its roots and return the
+%% first root's name (so we have a deterministic string to assert on).
+list_roots_tool(_) ->
+    [SessionId | _] = barrel_mcp:list_sessions_with_roots(),
+    {ok, Roots} = barrel_mcp:roots_list(SessionId,
+                                         #{timeout_ms => 5000}),
+    [#{<<"name">> := N} | _] = Roots,
+    N.
 
 %% Long-running arity-2 handler. Sleeps briefly then echoes back so
 %% the Python client can see the task transition through `working' →

--- a/test/interop/client.py
+++ b/test/interop/client.py
@@ -15,7 +15,14 @@ import traceback
 
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
-from mcp.types import CreateMessageResult, TextContent
+from mcp.types import (
+    CreateMessageResult,
+    ElicitResult,
+    ListRootsResult,
+    Root,
+    TextContent,
+)
+from pydantic import FileUrl
 
 
 EXPECTED_TOOL = "echo"
@@ -29,6 +36,9 @@ def fail(msg: str) -> None:
 
 
 SAMPLED_REPLY = "the canned answer"
+ELICITED_COLOUR = "blue"
+ROOT_NAME = "interop-root"
+ROOT_URI = "file:///tmp/interop"
 
 
 async def sampling_callback(_context, _params):
@@ -38,6 +48,19 @@ async def sampling_callback(_context, _params):
         role="assistant",
         content=TextContent(type="text", text=SAMPLED_REPLY),
         model="canned-test-model",
+    )
+
+
+async def elicitation_callback(_context, _params):
+    """Server-to-client elicitation/create handler. Always accepts
+    with a fixed colour so the round-trip is deterministic."""
+    return ElicitResult(action="accept", content={"colour": ELICITED_COLOUR})
+
+
+async def list_roots_callback(_context):
+    """Server-to-client roots/list handler. Returns one fixed root."""
+    return ListRootsResult(
+        roots=[Root(uri=FileUrl(ROOT_URI), name=ROOT_NAME)]
     )
 
 
@@ -63,6 +86,8 @@ async def run(url: str) -> None:
             read, write,
             message_handler=on_message,
             sampling_callback=sampling_callback,
+            elicitation_callback=elicitation_callback,
+            list_roots_callback=list_roots_callback,
         ) as session:
             await session.initialize()
 
@@ -127,6 +152,28 @@ async def run(url: str) -> None:
             ]
             if not text_blocks or text_blocks[0].text != SAMPLED_REPLY:
                 fail(f"sampling round-trip failed: {sampling_result}")
+
+            # Server-to-client elicitation/create round-trip.
+            elicit_result = await session.call_tool(
+                "ask_user", arguments={}
+            )
+            text_blocks = [
+                b for b in elicit_result.content
+                if getattr(b, "text", None)
+            ]
+            if not text_blocks or text_blocks[0].text != ELICITED_COLOUR:
+                fail(f"elicitation round-trip failed: {elicit_result}")
+
+            # Server-to-client roots/list round-trip.
+            roots_result = await session.call_tool(
+                "list_roots", arguments={}
+            )
+            text_blocks = [
+                b for b in roots_result.content
+                if getattr(b, "text", None)
+            ]
+            if not text_blocks or text_blocks[0].text != ROOT_NAME:
+                fail(f"roots round-trip failed: {roots_result}")
 
     print("OK")
 


### PR DESCRIPTION
## Summary

Direction A now exercises the remaining two server-to-client primitives end-to-end against the reference Python SDK:

- **`ask_user` tool** → `barrel_mcp:elicit_create/3` (form-mode payload) → Python `elicitation_callback` returns `accept` with a fixed colour → tool surfaces the colour.
- **`list_roots` tool** → `barrel_mcp:roots_list/1` → Python `list_roots_callback` returns one fixed root → tool surfaces its name.

Together with sampling (#27), every server-to-client primitive in the spec is now wire-validated against the reference implementation on every CI run. Verifies the pending-request map and capability gating for both surfaces, plus the spec-shaped form-mode elicitation params and the `Root` URI/name shape.

eunit + ct + dialyzer + both interop directions green.