### PR TITLE
Long-running tools: spec-shaped CreateTaskResult + CallToolResult on tasks/result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Long-running tools: spec-shaped CreateTaskResult + CallToolResult on tasks/result
+
+- **Wire change.** `tools/call` for `long_running => true` tools now returns the spec-shaped `CreateTaskResult` envelope `{<<"task">> => Task}` (the full Task object with taskId, status, createdAt, lastUpdatedAt, ttl) instead of the flat `{taskId, status}` shape that was rejected by the reference Python SDK with a pydantic ValidationError. Hosts that previously read `Result.taskId` need to read `Result.task.taskId`.
+- **Wire change.** The task collector now stores tool results as the spec-shaped `CallToolResult` (`{content, structuredContent?}`) instead of the raw value, so `tasks/result` returns a payload that decodes as `CallToolResult` against the reference SDK. Previously `tasks/result` could surface bare strings, which the JSON-RPC envelope validator rejected.
+- Direction A of the Python interop suite now exercises the full long-running flow end-to-end: `experimental.call_tool_as_task` → poll `experimental.get_task` until `completed` → fetch `experimental.get_task_result(..., CallToolResult)`. Both wire shapes above are now validated against `mcp 1.27.0`'s pydantic models on every CI run.
+
 ### Interop coverage: elicitation/create + roots/list
 
 - Direction A now exercises the remaining two server-to-client primitives end-to-end against the reference SDK: a server-side tool calls `barrel_mcp:elicit_create/3` (form-mode payload), the Python `elicitation_callback` returns an `accept` action with a fixed colour, and the tool surfaces that colour as text. Same shape for `roots/list`: a tool calls `barrel_mcp:roots_list/1`, the Python `list_roots_callback` returns one fixed root, and the tool surfaces its name. With sampling already covered, every server-to-client primitive is now wire-validated against the reference implementation on every CI run.

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -416,8 +416,15 @@ handle_long_running_call(Req0, State, SessionId, RequestId, ToolName,
     _ = barrel_mcp_tasks:set_worker(SessionId, TaskId,
                                      #{worker => Worker,
                                        request_id => RequestId}),
-    Result = #{<<"taskId">> => TaskId,
-               <<"status">> => <<"working">>},
+    %% Spec / reference SDK shape: CreateTaskResult wraps the full
+    %% Task envelope under `task'. A flat {taskId, status} map fails
+    %% pydantic validation in the reference Python client.
+    Task = case barrel_mcp_tasks:get(SessionId, TaskId) of
+               {ok, T} -> T;
+               _ -> #{<<"taskId">> => TaskId,
+                      <<"status">> => <<"working">>}
+           end,
+    Result = #{<<"task">> => Task},
     send_tool_envelope(Req0, State, SessionId, RequestId, Result).
 
 %% Tiny worker that funnels tool outcomes into the task registry.
@@ -427,9 +434,15 @@ spawn_task_collector(SessionId, TaskId) ->
 task_collector_loop(SessionId, TaskId) ->
     receive
         {tool_result, _ReqId, Result} ->
-            barrel_mcp_tasks:finish(SessionId, TaskId, Result);
-        {tool_structured, _ReqId, Data, _Content} ->
-            barrel_mcp_tasks:finish(SessionId, TaskId, Data);
+            %% Store the spec-shaped CallToolResult so `tasks/result'
+            %% returns a payload the reference Python SDK accepts.
+            Content = barrel_mcp_protocol:format_tool_result_external(Result),
+            barrel_mcp_tasks:finish(SessionId, TaskId,
+                                    #{<<"content">> => Content});
+        {tool_structured, _ReqId, Data, Content} ->
+            barrel_mcp_tasks:finish(SessionId, TaskId,
+                                    #{<<"content">> => Content,
+                                      <<"structuredContent">> => Data});
         {tool_error, _ReqId, Content} ->
             barrel_mcp_tasks:fail(SessionId, TaskId, {tool_error, Content});
         {tool_failed, _ReqId, Reason} ->

--- a/test/barrel_mcp_spec_additives_SUITE.erl
+++ b/test/barrel_mcp_spec_additives_SUITE.erl
@@ -197,8 +197,10 @@ long_running_returns_taskid(Config) ->
          {<<"mcp-session-id">>, SessionId}],
         Body, [with_body]),
     Result = maps:get(<<"result">>, json:decode(Resp)),
-    TaskId = maps:get(<<"taskId">>, Result),
-    ?assertEqual(<<"working">>, maps:get(<<"status">>, Result)),
+    %% Spec shape: {task: {taskId, status, ...}}.
+    Task = maps:get(<<"task">>, Result),
+    TaskId = maps:get(<<"taskId">>, Task),
+    ?assertEqual(<<"working">>, maps:get(<<"status">>, Task)),
     %% Wait for the worker to finish.
     timer:sleep(200),
     {ok, 200, _, GetResp} = hackney:request(post, url(Port),
@@ -255,7 +257,7 @@ long_running_cancel_signals_worker(Config) ->
          {<<"mcp-session-id">>, SessionId}],
         call_body(<<"cancellable">>, 31), [with_body]),
     Result = maps:get(<<"result">>, json:decode(RB)),
-    TaskId = maps:get(<<"taskId">>, Result),
+    TaskId = maps:get(<<"taskId">>, maps:get(<<"task">>, Result)),
     %% Cancel the task — the worker should receive a `{cancel, _}'
     %% signal in its mailbox (cooperatively observed by our tool).
     {ok, 200, _, _} = hackney:request(post, url(Port),

--- a/test/interop/client.py
+++ b/test/interop/client.py
@@ -16,6 +16,7 @@ import traceback
 from mcp import ClientSession
 from mcp.client.streamable_http import streamable_http_client
 from mcp.types import (
+    CallToolResult,
     CreateMessageResult,
     ElicitResult,
     ListRootsResult,
@@ -174,6 +175,34 @@ async def run(url: str) -> None:
             ]
             if not text_blocks or text_blocks[0].text != ROOT_NAME:
                 fail(f"roots round-trip failed: {roots_result}")
+
+            # Long-running tool round-trip via experimental.call_tool_as_task.
+            # Validates the CreateTaskResult immediate response shape,
+            # the Task model returned by tasks/get, and that
+            # tasks/result decodes as a CallToolResult.
+            create_result = await session.experimental.call_tool_as_task(
+                "slow_echo", arguments={"text": "from-task"}
+            )
+            task_id = create_result.task.taskId
+
+            # Poll until terminal — slow_echo sleeps 100ms server-side.
+            final = None
+            for _ in range(50):
+                final = await session.experimental.get_task(task_id)
+                if final.status in ("completed", "failed", "cancelled"):
+                    break
+                await asyncio.sleep(0.05)
+            if final is None or final.status != "completed":
+                fail(f"task did not reach completed: {final}")
+
+            payload = await session.experimental.get_task_result(
+                task_id, CallToolResult
+            )
+            payload_text = [
+                b.text for b in payload.content if getattr(b, "text", None)
+            ]
+            if not payload_text or "from-task" not in payload_text[0]:
+                fail(f"tasks/result payload mismatch: {payload}")
 
     print("OK")
 


### PR DESCRIPTION
## Summary

Two wire changes the interop harness flagged once Direction A started exercising the full long-running task flow:

### `tools/call` immediate response

**Before:** `{<<"taskId">>, <<"status">>}` (flat).
**After:** `{<<"task">> => {full Task fields}}` (spec `CreateTaskResult`).

The reference Python SDK rejects the flat shape with a pydantic `ValidationError` ("Field required: task"). Hosts that previously read `Result.taskId` directly need to read `Result.task.taskId`.

### `tasks/result` payload

**Before:** raw stored value (could be a bare binary).
**After:** spec-shaped `CallToolResult` map `{<<"content">>, <<"structuredContent">>?}`.

The JSON-RPC envelope validator in the Python SDK requires `result` to be a dict; bare strings caused validation failures.

### Interop coverage

Direction A now exercises `experimental.call_tool_as_task` → poll `experimental.get_task` until `completed` → fetch `experimental.get_task_result(..., CallToolResult)`. Both wire shapes are now validated against `mcp 1.27.0`'s pydantic models on every CI run.

eunit + ct + dialyzer + both interop directions green.

### Compatibility note

The flat `{taskId, status}` shape was non-conformant. Anyone using `long_running => true` against `barrel_mcp` was getting a non-spec response that would not interop with the reference clients. The fix is a wire change, but it's the right shape going forward.