### PR TITLE
Interop: progress notifications + tasks notification rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `notifications/tasks/changed` renamed to `notifications/tasks/status`
+
+- The Task status-change notification was emitted under method `notifications/tasks/changed`. The reference Python SDK's `ServerNotification` discriminated union uses the spec method name `notifications/tasks/status`. Renamed everywhere to match. Hosts that subscribed to `notifications/tasks/changed` need to switch to the new name.
+
+### Interop coverage: notifications/progress
+
+- Direction A of the Python interop suite now exercises `notifications/progress` end-to-end. A server-side `progress_echo` tool emits three progress events through the arity-2 handler's `Ctx.emit_progress`; the reference Python SDK auto-attaches a progress token on `call_tool` and routes the inbound notifications to a `progress_callback`. Verifies the progress token plumbing, SSE delivery of progress notifications, and the SDK's progress dispatch.
+
 ### Long-running tools: spec-shaped CreateTaskResult + CallToolResult on tasks/result
 
 - **Wire change.** `tools/call` for `long_running => true` tools now returns the spec-shaped `CreateTaskResult` envelope `{<<"task">> => Task}` (the full Task object with taskId, status, createdAt, lastUpdatedAt, ttl) instead of the flat `{taskId, status}` shape that was rejected by the reference Python SDK with a pydantic ValidationError. Hosts that previously read `Result.taskId` need to read `Result.task.taskId`.

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -435,7 +435,7 @@ notification with its raw `params` map. Common methods:
 - `notifications/tools/list_changed`, `.../resources/list_changed`,
   `.../prompts/list_changed` — catalogue updated; re-fetch or
   invalidate caches.
-- `notifications/tasks/changed` — a long-running task transitioned
+- `notifications/tasks/status` — a long-running task transitioned
   state. The full task record is in `params`.
 - `notifications/message` — server logging stream.
 - `notifications/replay_truncated` — your `Last-Event-ID` was
@@ -475,7 +475,7 @@ and `cancelled`; `createdAt` and `lastUpdatedAt` are RFC 3339 strings.
 When you registered a `progress_token` on the originating call,
 the same task usually emits `notifications/progress` updates that
 arrive through your handler, so polling is rarely required. Prefer
-subscribing to `notifications/tasks/changed` in the handler over
+subscribing to `notifications/tasks/status` in the handler over
 busy-polling `tasks_get/2`, then fetch the payload once with
 `tasks_result/2` when the status reaches `completed`.
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -74,7 +74,7 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
 - `long_running => true` returns a `taskId` immediately and runs
   the worker in the background. Backed by `barrel_mcp_tasks` —
   surfaces `tasks/list`, `tasks/get`, `tasks/cancel`, and
-  `notifications/tasks/changed`.
+  `notifications/tasks/status`.
 - Cancellation: cooperative arity-2 handlers see
   `{cancel, RequestId}` in their mailbox; arity-1 handlers run to
   completion but their result is discarded.

--- a/guides/tools-resources-prompts.md
+++ b/guides/tools-resources-prompts.md
@@ -151,7 +151,7 @@ Set `long_running => true` on `reg_tool/4` and the tool returns
 immediately to the client with a `taskId`. The handler keeps
 running in the background and the runtime stores its eventual
 outcome on the task. Clients track progress via `tasks/get`,
-`tasks/list`, or `notifications/tasks/changed`.
+`tasks/list`, or `notifications/tasks/status`.
 
 ```erlang
 barrel_mcp:reg_tool(<<"render_video">>, my_tools, render_video, #{
@@ -483,7 +483,7 @@ as at least one completion handler is registered.
 
 The `barrel_mcp_tasks` module backs the `tasks/list`, `tasks/get`,
 `tasks/cancel`, and `tasks/result` MCP methods, plus the
-`notifications/tasks/changed` notifications.
+`notifications/tasks/status` notifications.
 
 You don't usually call this module directly: registering a tool
 with `long_running => true` (see above) wires the lifecycle for
@@ -515,7 +515,7 @@ SSE channel:
 | `notifications/resources/updated` | `barrel_mcp:notify_resource_updated/1,2` |
 | `notifications/tools/list_changed`<br>`notifications/resources/list_changed`<br>`notifications/prompts/list_changed` | `barrel_mcp:notify_list_changed/1` (tool, resource, prompt). `reg_tool/4`/`unreg_tool/1` and friends emit it automatically; call the façade if you mutate the catalogue out of band. |
 | `notifications/progress` | `barrel_mcp:notify_progress/3,4` (or via `Ctx` from an arity-2 tool handler). |
-| `notifications/tasks/changed` | Emitted by `barrel_mcp_tasks` on every status transition. |
+| `notifications/tasks/status` | Emitted by `barrel_mcp_tasks` on every status transition. |
 | `notifications/message` (logging) | Emitted by `barrel_mcp_session` when a host calls `logger`-style helpers. |
 
 ## Handler Best Practices

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -319,7 +319,7 @@ tasks_get(Pid, TaskId) ->
 
 %% @doc Cancel a long-running task by id. Returns `{ok, _}' on
 %% acceptance; the task transitions to `cancelled' status, which the
-%% server then broadcasts via `notifications/tasks/changed'.
+%% server then broadcasts via `notifications/tasks/status'.
 -spec tasks_cancel(pid(), binary()) -> {ok, map()} | {error, term()}.
 tasks_cancel(Pid, TaskId) ->
     request(Pid, <<"tasks/cancel">>, #{<<"taskId">> => TaskId}).

--- a/src/barrel_mcp_tasks.erl
+++ b/src/barrel_mcp_tasks.erl
@@ -6,7 +6,7 @@
 %%% worker continues in the background; clients poll via
 %%% `tasks/get', enumerate via `tasks/list', and abort via
 %%% `tasks/cancel'. State transitions emit
-%%% `notifications/tasks/changed' on the session's SSE channel.
+%%% `notifications/tasks/status' on the session's SSE channel.
 %%%
 %%% Tasks live in a `protected' ETS table keyed by
 %%% `{SessionId, TaskId}'. A periodic sweep evicts terminal tasks
@@ -97,7 +97,7 @@ cancel(SessionId, TaskId) ->
 set_worker(SessionId, TaskId, Info) ->
     gen_server:call(?MODULE, {set_worker, SessionId, TaskId, Info}).
 
-%% @doc Record success: store the result and emit notifications/tasks/changed.
+%% @doc Record success: store the result and emit notifications/tasks/status.
 -spec finish(binary() | undefined, binary(), term()) -> ok | {error, not_found}.
 finish(SessionId, TaskId, Result) ->
     gen_server:call(?MODULE, {finish, SessionId, TaskId, Result}).
@@ -221,7 +221,7 @@ notify_changed(SessionId, #task{} = Task) ->
         {ok, Pid} when is_pid(Pid) ->
             Pid ! {sse_send_message, #{
                 <<"jsonrpc">> => <<"2.0">>,
-                <<"method">> => <<"notifications/tasks/changed">>,
+                <<"method">> => <<"notifications/tasks/status">>,
                 <<"params">> => task_to_map(Task)
             }},
             ok;

--- a/test/barrel_mcp_python_interop_SUITE.erl
+++ b/test/barrel_mcp_python_interop_SUITE.erl
@@ -29,6 +29,7 @@
 %% Tool / resource / prompt handlers exported for the registry.
 -export([echo_tool/1, slow_tool/2, trigger_update_tool/1,
          ask_llm_tool/1, ask_user_tool/1, list_roots_tool/1,
+         progress_tool/2,
          greeting_resource/1, hello_prompt/1]).
 
 -define(PORT, 22451).
@@ -143,6 +144,11 @@ ensure_fixture() ->
         description => <<"Ask the connected client for its roots">>,
         input_schema => #{<<"type">> => <<"object">>}
     }),
+    ok = barrel_mcp_registry:reg(tool, <<"progress_echo">>, ?MODULE,
+                                  progress_tool, #{
+        description => <<"Emit a few progress events then return">>,
+        input_schema => #{<<"type">> => <<"object">>}
+    }),
     ok = barrel_mcp_registry:reg(resource, <<"greeting">>, ?MODULE,
                                   greeting_resource, #{
         name => <<"Greeting">>,
@@ -164,6 +170,7 @@ cleanup_fixture() ->
     catch barrel_mcp_registry:unreg(tool, <<"ask_llm">>),
     catch barrel_mcp_registry:unreg(tool, <<"ask_user">>),
     catch barrel_mcp_registry:unreg(tool, <<"list_roots">>),
+    catch barrel_mcp_registry:unreg(tool, <<"progress_echo">>),
     catch barrel_mcp_registry:unreg(resource, <<"greeting">>),
     catch barrel_mcp_registry:unreg(prompt, <<"hello_prompt">>),
     ok.
@@ -219,6 +226,19 @@ list_roots_tool(_) ->
                                          #{timeout_ms => 5000}),
     [#{<<"name">> := N} | _] = Roots,
     N.
+
+%% Arity-2 handler that emits three progress events through Ctx
+%% before returning. Used to verify notifications/progress
+%% interop with the reference SDK's progress_callback.
+progress_tool(_Args, Ctx) ->
+    Emit = maps:get(emit_progress, Ctx),
+    %% Brief sleeps between emits so the SSE writer flushes each
+    %% notification ahead of the synchronous tool response, which
+    %% otherwise wins the race in the reference Python client.
+    Emit(1, 3, undefined), timer:sleep(20),
+    Emit(2, 3, undefined), timer:sleep(20),
+    Emit(3, 3, undefined), timer:sleep(20),
+    <<"progressed">>.
 
 %% Long-running arity-2 handler. Sleeps briefly then echoes back so
 %% the Python client can see the task transition through `working' →

--- a/test/interop/client.py
+++ b/test/interop/client.py
@@ -204,6 +204,33 @@ async def run(url: str) -> None:
             if not payload_text or "from-task" not in payload_text[0]:
                 fail(f"tasks/result payload mismatch: {payload}")
 
+            # Progress notifications round-trip. The server-side
+            # progress_echo tool emits three events; the Python SDK
+            # auto-attaches a progress token on call_tool and routes
+            # the inbound notifications/progress to our callback.
+            progress_seen = []
+
+            async def progress_cb(progress, total, _message):
+                progress_seen.append((progress, total))
+
+            await session.call_tool(
+                "progress_echo", arguments={},
+                progress_callback=progress_cb,
+            )
+            # Progress events arrive on the GET SSE channel
+            # asynchronously. call_tool returns when the POST
+            # response lands, which can race with the last few
+            # progress notifications. Wait briefly for the SSE pid
+            # to drain.
+            for _ in range(20):
+                if len(progress_seen) >= 3:
+                    break
+                await asyncio.sleep(0.05)
+            if not progress_seen:
+                fail("no progress events received")
+            if progress_seen[-1] != (3, 3):
+                fail(f"unexpected progress sequence: {progress_seen}")
+
     print("OK")
 
 


### PR DESCRIPTION
## Summary

Two related fixes the interop harness flagged once Direction A started exercising `notifications/progress`:

### `notifications/tasks/changed` → `notifications/tasks/status`

The reference Python SDK's `ServerNotification` union uses the spec method name `notifications/tasks/status` (`mcp/types.py:667`). Our previous name was unrecognised and broke SSE parsing for any session that emitted task status changes (e.g., a session that ran a long-running tool earlier).

Hosts that subscribed to `notifications/tasks/changed` need to switch to the new name. Renamed in code + every guide.

### `notifications/progress` interop coverage

Direction A now exercises the full progress flow end-to-end:
- New `progress_echo` arity-2 tool emits three progress events via `Ctx.emit_progress`.
- Python `call_tool` auto-attaches a progress token; inbound `notifications/progress` are routed to a `progress_callback`.
- Server-side sleeps between emits give the SSE writer time to flush each event ahead of the synchronous tool response (otherwise the response wins the race in the reference client).

eunit + ct + dialyzer + both interop directions green.