### PR TITLE
Interop: tighten assertions to value level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Interop assertions tightened to value level
+
+- Direction A's `list_tools`, `list_resources`, `read_resource`, `list_prompts`, `get_prompt`, `list_resource_templates`, and `complete` now assert the actual field values returned by the Erlang server (descriptions, mime types, prompt argument names, content text, completion suggestions) instead of just presence checks. Same for Direction B against the Python FastMCP server.
+
 ### Interop coverage: full feature surface
 
 Direction A (Python client → Erlang server) now exercises every wire surface defined by the MCP spec:

--- a/test/barrel_mcp_python_interop_SUITE.erl
+++ b/test/barrel_mcp_python_interop_SUITE.erl
@@ -113,8 +113,8 @@ erlang_client_against_python_server(Config) ->
     ?assert(lists:member(<<"mem://greeting">>, ResUris)),
     {ok, ReadRes} = barrel_mcp_client:read_resource(
                        Pid, <<"mem://greeting">>),
-    Contents = maps:get(<<"contents">>, ReadRes),
-    ?assert(is_list(Contents) andalso Contents =/= []),
+    [Block | _] = maps:get(<<"contents">>, ReadRes),
+    ?assertEqual(<<"hello, world">>, maps:get(<<"text">>, Block)),
 
     %% prompts/list + prompts/get
     {ok, Prompts} = barrel_mcp_client:list_prompts(Pid),
@@ -123,8 +123,11 @@ erlang_client_against_python_server(Config) ->
     {ok, PromptResult} = barrel_mcp_client:get_prompt(
                             Pid, <<"hello_prompt">>,
                             #{<<"who">> => <<"interop">>}),
-    PromptMsgs = maps:get(<<"messages">>, PromptResult),
-    ?assert(is_list(PromptMsgs) andalso PromptMsgs =/= []),
+    [PromptMsg | _] = maps:get(<<"messages">>, PromptResult),
+    ?assertEqual(<<"user">>, maps:get(<<"role">>, PromptMsg)),
+    %% Python FastMCP wraps the message text under content.text.
+    Content = maps:get(<<"content">>, PromptMsg),
+    ?assertEqual(<<"hello, interop">>, maps:get(<<"text">>, Content)),
 
     %% ping
     {ok, _} = barrel_mcp_client:ping(Pid),

--- a/test/interop/client.py
+++ b/test/interop/client.py
@@ -106,9 +106,17 @@ async def run(url: str) -> None:
             await session.initialize()
 
             tools = await session.list_tools()
-            names = [t.name for t in tools.tools]
-            if EXPECTED_TOOL not in names:
-                fail(f"echo tool missing from list_tools: {names}")
+            tool_by_name = {t.name: t for t in tools.tools}
+            if EXPECTED_TOOL not in tool_by_name:
+                fail(
+                    f"echo tool missing from list_tools: "
+                    f"{list(tool_by_name)}"
+                )
+            echo_tool = tool_by_name[EXPECTED_TOOL]
+            if echo_tool.description != "Echo a string":
+                fail(f"echo description wrong: {echo_tool.description!r}")
+            if "text" not in (echo_tool.inputSchema.get("required") or []):
+                fail(f"echo input schema lost `text`: {echo_tool.inputSchema}")
 
             result = await session.call_tool(
                 EXPECTED_TOOL, arguments={"text": "hello"}
@@ -120,18 +128,34 @@ async def run(url: str) -> None:
                 fail(f"echo did not round-trip: {text_blocks[0].text!r}")
 
             resources = await session.list_resources()
-            uris = [str(r.uri) for r in resources.resources]
-            if EXPECTED_RESOURCE_URI not in uris:
-                fail(f"sample resource missing from list_resources: {uris}")
+            res_by_uri = {str(r.uri): r for r in resources.resources}
+            if EXPECTED_RESOURCE_URI not in res_by_uri:
+                fail(f"sample resource missing: {list(res_by_uri)}")
+            sample_res = res_by_uri[EXPECTED_RESOURCE_URI]
+            if sample_res.name != "Greeting":
+                fail(f"resource name wrong: {sample_res.name!r}")
+            if sample_res.mimeType != "text/plain":
+                fail(f"resource mimeType wrong: {sample_res.mimeType!r}")
 
             read_result = await session.read_resource(EXPECTED_RESOURCE_URI)
             if not read_result.contents:
                 fail("read_resource returned empty contents")
+            block = read_result.contents[0]
+            if getattr(block, "text", None) != "hello, world":
+                fail(f"read_resource text mismatch: {block!r}")
+            if str(block.uri) != EXPECTED_RESOURCE_URI:
+                fail(f"read_resource uri mismatch: {block.uri!r}")
 
             prompts = await session.list_prompts()
-            prompt_names = [p.name for p in prompts.prompts]
-            if EXPECTED_PROMPT not in prompt_names:
-                fail(f"sample prompt missing from list_prompts: {prompt_names}")
+            prompt_by_name = {p.name: p for p in prompts.prompts}
+            if EXPECTED_PROMPT not in prompt_by_name:
+                fail(f"sample prompt missing: {list(prompt_by_name)}")
+            sample_prompt = prompt_by_name[EXPECTED_PROMPT]
+            if not sample_prompt.arguments:
+                fail(f"prompt has no arguments declared: {sample_prompt}")
+            arg_names = [a.name for a in sample_prompt.arguments]
+            if "who" not in arg_names:
+                fail(f"prompt missing `who` argument: {arg_names}")
 
             await session.set_logging_level("warning")
 
@@ -145,26 +169,36 @@ async def run(url: str) -> None:
             prompt_result = await session.get_prompt(
                 EXPECTED_PROMPT, arguments={"who": "interop"}
             )
-            if not prompt_result.messages:
-                fail(f"get_prompt returned no messages: {prompt_result}")
+            if len(prompt_result.messages) != 1:
+                fail(f"get_prompt expected 1 message: {prompt_result}")
+            msg = prompt_result.messages[0]
+            if msg.role != "user":
+                fail(f"prompt message role wrong: {msg.role!r}")
+            if getattr(msg.content, "text", None) != "hello, interop":
+                fail(f"prompt message text mismatch: {msg.content!r}")
 
             # resources/templates/list — registered fixture has one
             # template (`file:///{path}`).
             templates = await session.list_resource_templates()
-            template_uris = [
-                t.uriTemplate for t in templates.resourceTemplates
-            ]
-            if "file:///{path}" not in template_uris:
-                fail(f"resource template missing: {template_uris}")
+            tmpl_by_uri = {
+                t.uriTemplate: t for t in templates.resourceTemplates
+            }
+            if "file:///{path}" not in tmpl_by_uri:
+                fail(f"resource template missing: {list(tmpl_by_uri)}")
+            tmpl = tmpl_by_uri["file:///{path}"]
+            if tmpl.name != "File":
+                fail(f"template name wrong: {tmpl.name!r}")
 
             # completion/complete — registered for prompt
-            # `hello_prompt` argument `who`.
+            # `hello_prompt` argument `who`. The Erlang fixture
+            # returns ["world", "world!"].
             comp = await session.complete(
                 ref={"type": "ref/prompt", "name": EXPECTED_PROMPT},
                 argument={"name": "who", "value": "wo"},
             )
-            if not comp.completion.values:
-                fail(f"completion returned no values: {comp}")
+            values = comp.completion.values
+            if values != ["world", "world!"]:
+                fail(f"completion values mismatch: {values}")
 
             # Tool returning structuredContent.
             structured_result = await session.call_tool(


### PR DESCRIPTION
## Summary

Both directions of the interop suite now assert actual field values, not just presence. Each surface is a real round-trip that catches wire bugs which would otherwise slip through.

### Direction A (Python client → Erlang server)

| Surface | Was checking | Now also asserts |
|---|---|---|
| `list_tools` | `echo` in names | description text, `inputSchema.required` includes `text` |
| `list_resources` | URI in list | `name == "Greeting"`, `mimeType == "text/plain"` |
| `read_resource` | contents non-empty | `text == "hello, world"`, `uri == "mem://greeting"` |
| `list_prompts` | name in list | `arguments` contains `who` |
| `get_prompt` | messages non-empty | exactly 1 message, role `user`, content text `hello, interop` |
| `list_resource_templates` | URI template in list | name `File` |
| `complete` | values non-empty | exact suggestion list `["world", "world!"]` |

### Direction B (Erlang client → Python FastMCP server)

`read_resource` now asserts `text == "hello, world"`, and `get_prompt` asserts the user message text is `hello, interop`.

eunit + ct + dialyzer + both interop directions green.