### PR TITLE
chore: release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-03
+
+This release is driven by a Python interop harness (PR #24) that
+exercises every spec wire surface against the official `mcp 1.27.0`
+Python SDK in both directions on every CI run. The harness
+surfaced several wire bugs we then fixed; this release captures
+all of them. Breaking wire-level changes are listed up front.
+
+**Breaking wire-level changes since 1.2.0** — hosts that produced
+or consumed these envelopes need to update:
+
+- `notifications/tasks/changed` was renamed to `notifications/tasks/status` (the spec method name).
+- `tools/call` for `long_running => true` tools wraps the immediate response as `CreateTaskResult` (`{<<"task">> => Task}`) instead of the flat `{taskId, status}`.
+- Task envelopes now use `lastUpdatedAt` (was `updatedAt`) and include a `ttl` field (always `null` for now).
+- `tasks/cancel` returns the cancelled `Task` instead of `{}`.
+- `tasks/result` returns a `CallToolResult` (`{<<"content">>, <<"structuredContent">>?}`) instead of the raw stored value.
+- `initialize` advertises `tasks.list` / `get` / `cancel` / `result` as objects, not bare booleans.
+
 ### Interop assertions tightened to value level
 
 - Direction A's `list_tools`, `list_resources`, `read_resource`, `list_prompts`, `get_prompt`, `list_resource_templates`, and `complete` now assert the actual field values returned by the Erlang server (descriptions, mime types, prompt argument names, content text, completion suggestions) instead of just presence checks. Same for Direction B against the Python FastMCP server.

--- a/src/barrel_mcp.app.src
+++ b/src/barrel_mcp.app.src
@@ -1,13 +1,13 @@
 {application, barrel_mcp, [
     {description, "MCP Protocol Library for Erlang"},
-    {vsn, "1.2.0"},
+    {vsn, "1.3.0"},
     {registered, [barrel_mcp_registry, barrel_mcp_sup, barrel_mcp_session,
                   barrel_mcp_tasks, barrel_mcp_client_sup]},
     {mod, {barrel_mcp_app, []}},
     {applications, [kernel, stdlib, crypto, cowboy, hackney]},
     {env, [
         {server_name, <<"barrel">>},
-        {server_version, <<"1.2.0">>},
+        {server_version, <<"1.3.0">>},
         {protocol_version, <<"2025-11-25">>},
         {session_ttl, 1800000}  %% 30 minutes default
     ]},


### PR DESCRIPTION
## Summary

Cuts 1.3.0. This release captures the wire-fix sweep driven by the Python interop harness (`mcp 1.27.0`) that landed after 1.2.0.

The harness exercises every spec wire surface against the reference SDK in both directions on every CI run. It surfaced a handful of wire-shape bugs that this release rolls up.

### Breaking wire-level changes since 1.2.0

- `notifications/tasks/changed` → `notifications/tasks/status` (PR #30).
- `tools/call` for `long_running` tools wraps as `CreateTaskResult` (`{task: Task}`) instead of flat `{taskId, status}` (PR #29).
- Task envelopes use `lastUpdatedAt` (was `updatedAt`) and include `ttl` (PR #25).
- `tasks/cancel` returns the cancelled `Task` instead of `{}` (PR #25).
- `tasks/result` returns a `CallToolResult`-shaped payload (PR #29).
- `initialize` advertises `tasks.list/get/cancel/result` as objects, not booleans (PR #24).

### Other 1.3.0 highlights

- Full interop coverage: tools, resources (incl. subscribe + notify), prompts, completion, ping, logging, list_tasks, sampling, elicitation, roots, long-running tools, progress, cancellation, list_changed.
- Tightened all interop assertions to the value level (PR #32).