### PR TITLE
Server-side cursor pagination on */list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Server-side cursor pagination on `*/list`
+
+- `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`, and `tasks/list` now accept an opaque `cursor` parameter and emit `nextCursor` when more entries remain. Page size is 50, sorted by name (or `taskId` for tasks). Existing single-shot callers see the first page transparently.
+- Direction A of the Python interop suite registers 60 dummy tools and walks `tools/list` via `cursor` until exhausted, asserting at least one `nextCursor` was emitted, no duplicates across pages, and that all fixture tools are visible across the walk.
+
 ## [1.3.0] - 2026-05-03
 
 This release is driven by a Python interop harness (PR #24) that

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -164,7 +164,10 @@ handle_request(<<"ping">>, _Params, Id, _State) ->
     success_response(Id, #{});
 
 %% Tools
-handle_request(<<"tools/list">>, _Params, Id, _State) ->
+handle_request(<<"tools/list">>, Params, Id, _State) ->
+    Cursor = maps:get(<<"cursor">>, Params, undefined),
+    {Page, Next} = paginate(barrel_mcp_registry:all(tool), Cursor,
+                             fun({N, _}) -> N end),
     Tools = lists:map(fun({Name, Handler}) ->
         Base = #{
             <<"name">> => Name,
@@ -177,8 +180,8 @@ handle_request(<<"tools/list">>, _Params, Id, _State) ->
             {<<"icons">>, icons},
             {<<"annotations">>, annotations}
         ])
-    end, barrel_mcp_registry:all(tool)),
-    success_response(Id, #{<<"tools">> => Tools});
+    end, Page),
+    success_response(Id, with_next_cursor(#{<<"tools">> => Tools}, Next));
 
 handle_request(<<"tools/call">>, Params, Id, _State) ->
     Name = maps:get(<<"name">>, Params, <<>>),
@@ -209,7 +212,10 @@ handle_request(<<"tools/call">>, Params, Id, _State) ->
     {async, Plan};
 
 %% Resources
-handle_request(<<"resources/list">>, _Params, Id, _State) ->
+handle_request(<<"resources/list">>, Params, Id, _State) ->
+    Cursor = maps:get(<<"cursor">>, Params, undefined),
+    {Page, Next} = paginate(barrel_mcp_registry:all(resource), Cursor,
+                             fun({N, _}) -> N end),
     Resources = lists:map(fun({_Name, Handler}) ->
         Base = #{
             <<"uri">> => maps:get(uri, Handler, <<>>),
@@ -222,8 +228,9 @@ handle_request(<<"resources/list">>, _Params, Id, _State) ->
             {<<"icons">>, icons},
             {<<"annotations">>, annotations}
         ])
-    end, barrel_mcp_registry:all(resource)),
-    success_response(Id, #{<<"resources">> => Resources});
+    end, Page),
+    success_response(Id, with_next_cursor(#{<<"resources">> => Resources},
+                                            Next));
 
 handle_request(<<"resources/read">>, Params, Id, _State) ->
     Uri = maps:get(<<"uri">>, Params, <<>>),
@@ -242,7 +249,10 @@ handle_request(<<"resources/read">>, Params, Id, _State) ->
             error_response(Id, ?JSONRPC_METHOD_NOT_FOUND, <<"Resource not found">>)
     end;
 
-handle_request(<<"resources/templates/list">>, _Params, Id, _State) ->
+handle_request(<<"resources/templates/list">>, Params, Id, _State) ->
+    Cursor = maps:get(<<"cursor">>, Params, undefined),
+    {Page, Next} = paginate(barrel_mcp_registry:all(resource_template),
+                             Cursor, fun({N, _}) -> N end),
     Templates = lists:map(fun({_Name, Handler}) ->
         Base = #{
             <<"uriTemplate">> => maps:get(uri_template, Handler, <<>>),
@@ -256,8 +266,10 @@ handle_request(<<"resources/templates/list">>, _Params, Id, _State) ->
             {<<"icons">>, icons},
             {<<"annotations">>, annotations}
         ])
-    end, barrel_mcp_registry:all(resource_template)),
-    success_response(Id, #{<<"resourceTemplates">> => Templates});
+    end, Page),
+    success_response(Id, with_next_cursor(
+                           #{<<"resourceTemplates">> => Templates},
+                           Next));
 
 handle_request(<<"resources/subscribe">>, Params, Id, State) ->
     Uri = maps:get(<<"uri">>, Params, <<>>),
@@ -282,7 +294,10 @@ handle_request(<<"resources/unsubscribe">>, Params, Id, State) ->
     end;
 
 %% Prompts
-handle_request(<<"prompts/list">>, _Params, Id, _State) ->
+handle_request(<<"prompts/list">>, Params, Id, _State) ->
+    Cursor = maps:get(<<"cursor">>, Params, undefined),
+    {Page, Next} = paginate(barrel_mcp_registry:all(prompt), Cursor,
+                             fun({N, _}) -> N end),
     Prompts = lists:map(fun({Name, Handler}) ->
         Base = #{
             <<"name">> => Name,
@@ -300,8 +315,9 @@ handle_request(<<"prompts/list">>, _Params, Id, _State) ->
             {<<"icons">>, icons},
             {<<"annotations">>, annotations}
         ])
-    end, barrel_mcp_registry:all(prompt)),
-    success_response(Id, #{<<"prompts">> => Prompts});
+    end, Page),
+    success_response(Id, with_next_cursor(#{<<"prompts">> => Prompts},
+                                            Next));
 
 handle_request(<<"prompts/get">>, Params, Id, _State) ->
     Name = maps:get(<<"name">>, Params, <<>>),
@@ -319,10 +335,13 @@ handle_request(<<"prompts/get">>, Params, Id, _State) ->
     end;
 
 %% Tasks
-handle_request(<<"tasks/list">>, _Params, Id, State) ->
+handle_request(<<"tasks/list">>, Params, Id, State) ->
     SessionId = maps:get(session_id, State, undefined),
-    {ok, Tasks} = barrel_mcp_tasks:list(SessionId, #{}),
-    success_response(Id, #{<<"tasks">> => Tasks});
+    Cursor = maps:get(<<"cursor">>, Params, undefined),
+    {ok, AllTasks} = barrel_mcp_tasks:list(SessionId, #{}),
+    {Page, Next} = paginate(AllTasks, Cursor,
+                             fun(T) -> maps:get(<<"taskId">>, T) end),
+    success_response(Id, with_next_cursor(#{<<"tasks">> => Page}, Next));
 
 handle_request(<<"tasks/get">>, Params, Id, State) ->
     SessionId = maps:get(session_id, State, undefined),
@@ -622,6 +641,37 @@ with_optional_fields(Envelope, Handler, Fields) ->
             V -> Acc#{WireKey => V}
         end
     end, Envelope, Fields).
+
+%%====================================================================
+%% Cursor pagination for `*/list' handlers
+%%====================================================================
+
+-define(PAGE_SIZE, 50).
+
+%% Sort `Items' by `KeyFn(Item)', drop everything up to and
+%% including `Cursor', take up to `?PAGE_SIZE'. Returns
+%% `{Page, NextCursor}' where `NextCursor' is the last key of the
+%% page when more items remain, or `undefined' otherwise.
+%% `Cursor' is the opaque last-seen key from a prior response.
+paginate(Items, Cursor, KeyFn) ->
+    Sorted = lists:sort(fun(A, B) -> KeyFn(A) =< KeyFn(B) end, Items),
+    AfterCursor = drop_until_after(Sorted, Cursor, KeyFn),
+    case lists:split(min(?PAGE_SIZE, length(AfterCursor)),
+                     AfterCursor) of
+        {Page, []} ->
+            {Page, undefined};
+        {Page, _Rest} ->
+            Last = lists:last(Page),
+            {Page, KeyFn(Last)}
+    end.
+
+drop_until_after(Items, undefined, _) ->
+    Items;
+drop_until_after(Items, Cursor, KeyFn) ->
+    lists:dropwhile(fun(I) -> KeyFn(I) =< Cursor end, Items).
+
+with_next_cursor(Resp, undefined) -> Resp;
+with_next_cursor(Resp, Cursor) -> Resp#{<<"nextCursor">> => Cursor}.
 
 %% Pick the protocol version to advertise in the `initialize'
 %% response. If the client's requested version is one we speak, echo

--- a/test/barrel_mcp_python_interop_SUITE.erl
+++ b/test/barrel_mcp_python_interop_SUITE.erl
@@ -211,6 +211,16 @@ ensure_fixture() ->
     }),
     ok = barrel_mcp:reg_completion({prompt, <<"hello_prompt">>, <<"who">>},
                                     ?MODULE, echo_completion, #{}),
+    %% Register enough dummy tools to force multi-page behaviour
+    %% on tools/list (the server paginates at 50 entries per page).
+    [ok = barrel_mcp_registry:reg(tool,
+                                    iolist_to_binary(io_lib:format(
+                                      "dummy_~3..0B", [N])),
+                                    ?MODULE, echo_tool, #{
+        description => <<"dummy">>,
+        input_schema => #{<<"type">> => <<"object">>}
+      })
+     || N <- lists:seq(1, 60)],
     ok = barrel_mcp_registry:reg(resource, <<"greeting">>, ?MODULE,
                                   greeting_resource, #{
         name => <<"Greeting">>,
@@ -243,6 +253,9 @@ cleanup_fixture() ->
     catch barrel_mcp_registry:unreg(prompt, <<"hello_prompt">>),
     catch barrel_mcp:unreg_completion({prompt, <<"hello_prompt">>,
                                                 <<"who">>}),
+    [catch barrel_mcp_registry:unreg(tool,
+              iolist_to_binary(io_lib:format("dummy_~3..0B", [N])))
+     || N <- lists:seq(1, 60)],
     ok.
 
 echo_tool(#{<<"text">> := T}) -> T.

--- a/test/interop/client.py
+++ b/test/interop/client.py
@@ -105,12 +105,20 @@ async def run(url: str) -> None:
         ) as session:
             await session.initialize()
 
-            tools = await session.list_tools()
-            tool_by_name = {t.name: t for t in tools.tools}
+            # Walk every page so we see fixtures regardless of where
+            # they fall alphabetically.
+            tool_by_name: dict = {}
+            cursor = None
+            for _ in range(50):
+                page = await session.list_tools(cursor=cursor)
+                tool_by_name.update({t.name: t for t in page.tools})
+                cursor = page.nextCursor
+                if cursor is None:
+                    break
             if EXPECTED_TOOL not in tool_by_name:
                 fail(
                     f"echo tool missing from list_tools: "
-                    f"{list(tool_by_name)}"
+                    f"{sorted(tool_by_name)[:10]}..."
                 )
             echo_tool = tool_by_name[EXPECTED_TOOL]
             if echo_tool.description != "Echo a string":
@@ -376,6 +384,37 @@ async def run(url: str) -> None:
             # tasks; assert at least one transition was observed.
             if not task_status_seen:
                 fail("no notifications/tasks/status observed")
+
+            # Pagination: explicitly walk every tool via the cursor.
+            # The Erlang server paginates in chunks of ?PAGE_SIZE (50)
+            # and emits nextCursor when more items remain. The fixture
+            # registers 60 dummy tools so this exercises at least two
+            # pages.
+            collected_names: list[str] = []
+            saw_next_cursor = False
+            cursor = None
+            for _ in range(50):
+                page = await session.list_tools(cursor=cursor)
+                collected_names.extend(t.name for t in page.tools)
+                if page.nextCursor is not None:
+                    saw_next_cursor = True
+                cursor = page.nextCursor
+                if cursor is None:
+                    break
+            if not saw_next_cursor:
+                fail(
+                    "expected at least one nextCursor across "
+                    "tools/list pages"
+                )
+            if len(collected_names) != len(set(collected_names)):
+                fail(
+                    f"pagination duplicated entries: {collected_names}"
+                )
+            if EXPECTED_TOOL not in collected_names:
+                fail(
+                    "paginated walk did not surface the echo tool: "
+                    f"{sorted(collected_names)[:10]}..."
+                )
 
     print("OK")
 


### PR DESCRIPTION
## Summary

Closes the last big roadmap item from §A. The server now paginates every `*/list` endpoint on demand:

- `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`, `tasks/list` accept an opaque `cursor` parameter and emit `nextCursor` when more entries remain.
- Page size is 50; ordered lexicographically by name (or `taskId` for tasks).
- Existing single-shot callers see the first page transparently. Clients that walk pagination (`barrel_mcp_client:list_tools_all/1`, the Python SDK's cursor argument, etc.) get every entry.

### Interop coverage

Direction A registers 60 dummy tools, walks `tools/list` via `cursor` until exhausted, and asserts:

- At least one `nextCursor` is emitted (proving multi-page behaviour).
- No duplicates across pages.
- The fixture's `echo` tool is visible somewhere in the walk.

### Implementation

New helpers in `barrel_mcp_protocol`:
- `paginate/3` — sorts by a key function, drops up to the cursor, slices the next page, returns `{Page, NextCursor}`.
- `with_next_cursor/2` — adds `nextCursor` to the response only when present.

Cursor format is the last-seen key (a binary). It's opaque to clients; future changes can swap encoding without breaking the wire.

### Verification

- 225 eunit + 31 ct + dialyzer + both interop directions green locally.
- Single-shot callers (existing tests) keep working — the first page returns up to 50 entries, which all current fixtures fit within.