### PR TITLE
examples/agent_host: runnable federation demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `examples/agent_host` — runnable multi-server federation demo
+
+- New example app showing the `barrel_mcp_agent` aggregator + router end-to-end. `agent_host:run/0` connects two clients to one in-process MCP server under different `ServerId`s, calls `barrel_mcp_agent:list_tools/0` to surface the namespaced catalog, and routes a `<<"beta:echo">>` call through the right client. CT case asserts the namespaced names appear and the routed result round-trips.
+- Closes the docs loop for `barrel_mcp_agent` (the module shipped without a runnable example).
+- Picked up by `make examples-test` automatically (the existing `for ex in examples/*/` loop).
+
 ### Server-side cursor pagination on `*/list`
 
 - `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`, and `tasks/list` now accept an opaque `cursor` parameter and emit `nextCursor` when more entries remain. Page size is 50, sorted by name (or `taskId` for tasks). Existing single-shot callers see the first page transparently.

--- a/examples/agent_host/README.md
+++ b/examples/agent_host/README.md
@@ -1,0 +1,64 @@
+# `agent_host` example
+
+Demonstrates how `barrel_mcp_agent` aggregates tools across two
+federated MCP clients into one namespaced catalog and routes a
+call back to the right server.
+
+## What it does
+
+```erlang
+{ok, _} = barrel_mcp:start_client(<<"alpha">>, Spec),
+{ok, _} = barrel_mcp:start_client(<<"beta">>,  Spec),
+
+Tools = barrel_mcp_agent:to_anthropic(),  %% or :to_openai/0,
+                                          %% or :list_tools/0
+%% Hand `Tools' to your LLM, capture its tool_use block, then:
+{NamespacedName, Args} =
+    barrel_mcp_tool_format:from_anthropic_call(Block),
+{ok, Result} = barrel_mcp_agent:call_tool(NamespacedName, Args).
+```
+
+`barrel_mcp_agent:list_tools/0` returns the union of every
+connected client's `tools/list`, with each tool's `name`
+rewritten to `<<"ServerId:ToolName">>`. `call_tool/2` parses
+the namespaced name and dispatches to the right `ServerId`.
+
+## In production vs in this example
+
+In production the two `start_client/2` calls would point at
+**distinct** external MCP servers, each typed by a different
+`ServerId`. Each server returns its own catalog and the
+aggregator surfaces every tool exactly once.
+
+For a self-contained example we boot one in-process Streamable
+HTTP server with a single `echo` tool and connect both clients
+to it. The aggregator surfaces `echo` twice (`alpha:echo` and
+`beta:echo`) and routing still dispatches deterministically by
+prefix — so the round-trip exercises the same code paths a real
+multi-server setup would use.
+
+## Run it
+
+```sh
+make examples-setup        # creates the _checkouts symlink
+cd examples/agent_host
+rebar3 ct                  # runs the federation_round_trip case
+```
+
+Or interactively:
+
+```sh
+cd examples/agent_host
+rebar3 shell --eval 'agent_host:run().'
+```
+
+## Companion modules
+
+- `barrel_mcp_agent` — the aggregator and router this example
+  showcases. See `guides/features.md` and the module's edoc.
+- `barrel_mcp_tool_format` — translate the namespaced catalog
+  to the Anthropic Messages API or OpenAI Chat Completions tool
+  shape, and translate a model's tool-call back to
+  `(Name, Args)`.
+- `barrel_mcp_clients` — the federation registry that backs
+  `barrel_mcp:start_client/2`.

--- a/examples/agent_host/rebar.config
+++ b/examples/agent_host/rebar.config
@@ -1,0 +1,16 @@
+%% Standalone build configuration for the agent_host example.
+%%
+%% Inside this repository, the build picks up `barrel_mcp' via
+%% `_checkouts/barrel_mcp', which is a symlink back to the parent
+%% directory created by `make examples-setup' (or by hand:
+%% `mkdir -p _checkouts && ln -s ../../.. _checkouts/barrel_mcp').
+
+{erl_opts, [debug_info, warnings_as_errors]}.
+
+{deps, [
+    {barrel_mcp, {git, "https://github.com/barrel-platform/barrel_mcp.git", {branch, "main"}}}
+]}.
+
+{shell, [{apps, [barrel_mcp, agent_host]}]}.
+
+{eunit_opts, [verbose]}.

--- a/examples/agent_host/src/agent_host.app.src
+++ b/examples/agent_host/src/agent_host.app.src
@@ -1,0 +1,9 @@
+{application, agent_host, [
+    {description, "barrel_mcp multi-server agent host example"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {applications, [kernel, stdlib, barrel_mcp]},
+    {env, []},
+    {modules, []},
+    {licenses, ["Apache-2.0"]}
+]}.

--- a/examples/agent_host/src/agent_host.erl
+++ b/examples/agent_host/src/agent_host.erl
@@ -1,0 +1,88 @@
+%%%-------------------------------------------------------------------
+%%% @doc Multi-server agent host example.
+%%%
+%%% Demonstrates how `barrel_mcp_agent' aggregates tools across two
+%%% federated MCP clients into one namespaced catalog and routes a
+%%% call back to the right server. See the README for the full
+%%% pattern.
+%%%
+%%% In production, the two `start_client/2' calls would point at
+%%% distinct external MCP servers (each typed by `ServerId'). For a
+%%% self-contained example we boot one in-process Streamable HTTP
+%%% server and connect two clients to it under different `ServerId's;
+%%% the aggregator surfaces every tool twice (under each prefix) and
+%%% routing dispatches deterministically by prefix.
+%%%
+%%% Run with `rebar3 shell -eval 'agent_host:run().'' or via the
+%%% common_test suite under `test/agent_host_SUITE'.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(agent_host).
+
+-export([run/0, run/1]).
+-export([echo_tool/1]).
+
+-define(DEFAULT_PORT, 18091).
+
+%% @doc End-to-end run. Returns `{Catalog, Routed}' where `Catalog'
+%% is the aggregated tools/list (namespaced names) and `Routed' is
+%% the result of routing a `call_tool' through the aggregator to a
+%% specific server.
+-spec run() -> {[map()], map()}.
+run() -> run(?DEFAULT_PORT).
+
+-spec run(pos_integer()) -> {[map()], map()}.
+run(Port) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    ok = barrel_mcp_registry:wait_for_ready(),
+    ok = ensure_tool(),
+    {ok, _} = ensure_server(Port),
+    Url = iolist_to_binary(io_lib:format("http://127.0.0.1:~B/mcp",
+                                         [Port])),
+    Spec = #{transport => {http, Url}},
+    {ok, Alpha} = barrel_mcp:start_client(<<"alpha">>, Spec),
+    {ok, Beta}  = barrel_mcp:start_client(<<"beta">>, Spec),
+    ok = wait_ready(Alpha, 30),
+    ok = wait_ready(Beta, 30),
+
+    Catalog = barrel_mcp_agent:list_tools(),
+
+    {ok, Routed} = barrel_mcp_agent:call_tool(
+                      <<"beta:echo">>,
+                      #{<<"text">> => <<"hello from beta">>}),
+
+    ok = barrel_mcp:stop_client(<<"alpha">>),
+    ok = barrel_mcp:stop_client(<<"beta">>),
+    {Catalog, Routed}.
+
+%%====================================================================
+%% Tool fixture
+%%====================================================================
+
+echo_tool(#{<<"text">> := T}) -> T.
+
+ensure_tool() ->
+    barrel_mcp_registry:reg(tool, <<"echo">>, ?MODULE, echo_tool, #{
+        description => <<"Echo the input text back unchanged">>,
+        input_schema => #{<<"type">> => <<"object">>,
+                           <<"required">> => [<<"text">>],
+                           <<"properties">> =>
+                               #{<<"text">> =>
+                                     #{<<"type">> => <<"string">>}}}
+    }).
+
+ensure_server(Port) ->
+    case barrel_mcp_http_stream:start(#{port => Port,
+                                        session_enabled => true}) of
+        {ok, _} = Ok -> Ok;
+        {error, {already_started, Pid}} -> {ok, Pid}
+    end.
+
+wait_ready(_Pid, 0) -> {error, not_ready};
+wait_ready(Pid, N) ->
+    case catch barrel_mcp_client:server_capabilities(Pid) of
+        {ok, _} -> ok;
+        _ ->
+            timer:sleep(100),
+            wait_ready(Pid, N - 1)
+    end.

--- a/examples/agent_host/test/agent_host_SUITE.erl
+++ b/examples/agent_host/test/agent_host_SUITE.erl
@@ -1,0 +1,36 @@
+%%%-------------------------------------------------------------------
+%%% @doc Common-test suite for the agent_host example.
+%%%
+%%% Runs the federation aggregator end to end: starts an in-process
+%%% MCP server, connects two clients under different ServerIds,
+%%% asserts that `barrel_mcp_agent:list_tools/0' surfaces the same
+%%% tool under both `alpha:' and `beta:' prefixes, and that
+%%% `call_tool/2' routes a `<<"beta:echo">>' to the right client.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(agent_host_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([federation_round_trip/1]).
+
+all() -> [federation_round_trip].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    Config.
+
+end_per_suite(_Config) ->
+    catch barrel_mcp_http_stream:stop(),
+    application:stop(barrel_mcp),
+    ok.
+
+federation_round_trip(_Config) ->
+    {Catalog, Routed} = agent_host:run(28091),
+    Names = [maps:get(<<"name">>, T) || T <- Catalog],
+    true = lists:member(<<"alpha:echo">>, Names),
+    true = lists:member(<<"beta:echo">>, Names),
+    [#{<<"text">> := <<"hello from beta">>} | _] =
+        maps:get(<<"content">>, Routed),
+    ok.


### PR DESCRIPTION
## Summary

Closes the docs loop for `barrel_mcp_agent`. The module shipped in 1.2.0 (PR #21) but had only a CT test — no runnable example. This adds one alongside `echo_client` and `sampling_host`.

`agent_host:run/0`:
1. Boots an in-process `barrel_mcp_http_stream` with a registered `echo` tool.
2. Connects two clients to it under `ServerId`s `<<"alpha">>` and `<<"beta">>` via `barrel_mcp:start_client/2`.
3. Calls `barrel_mcp_agent:list_tools/0` — surfaces `alpha:echo` and `beta:echo`.
4. Calls `barrel_mcp_agent:call_tool(<<"beta:echo">>, ...)` — verifies routing dispatches to the right client.

CT case asserts the namespaced names appear and the routed call round-trips. `make examples-test` picks it up via the existing `for ex in examples/*/` loop.

The README calls out the single-server simplification: in production the two `start_client/2` calls would point at distinct external MCP servers, but the aggregator + routing behaviour exercised is identical.

All three example suites (`echo_client`, `sampling_host`, `agent_host`) green locally.