### PR TITLE
docs: clear stale roadmap items + subscription session scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Doc cleanup: stale roadmap items + subscription session scope
+
+- `guides/features.md`'s roadmap section called out a "periodic deadline timer" and "client-side `Last-Event-ID` resume" as missing. Both turn out to be either by-design (default request timeout already bounds every call; explicit `infinity` is a deliberate caller choice) or already shipped (the transport's `reopen_sse` loop preserves `sse_last_event_id` across server-initiated SSE closes, and a full client restart re-initializes the session anyway). Replaced the roadmap section with notes explaining each.
+- `guides/tools-resources-prompts.md` now calls out that `resources/subscribe` is scoped to the calling `Mcp-Session-Id`: when a client re-initializes, the new session id has no carry-over subscriptions and must subscribe again. Matches the spec's session-lifecycle model; previously implicit.
+
 ### `examples/agent_host` — runnable multi-server federation demo
 
 - New example app showing the `barrel_mcp_agent` aggregator + router end-to-end. `agent_host:run/0` connects two clients to one in-process MCP server under different `ServerId`s, calls `barrel_mcp_agent:list_tools/0` to surface the namespaced catalog, and routes a `<<"beta:echo">>` call through the right client. CT case asserts the namespaced names appear and the routed result round-trips.

--- a/guides/features.md
+++ b/guides/features.md
@@ -235,10 +235,24 @@ case barrel_mcp_schema:validate(Args, ToolInputSchema) of
 end.
 ```
 
-### Roadmap
+### Notes on past roadmap items
 
-- Periodic deadline timer for in-flight requests beyond the per-call
-  timeout (today timeouts fire only when configured per-request).
-- Client-side `Last-Event-ID` resume (server-side replay is shipped;
-  client transport tracks the last id but does not yet replay on
-  reconnect from its own state).
+- *Periodic deadline timer.* Earlier docs flagged a missing
+  global sweep for in-flight requests with `infinity` timeout.
+  In practice the client applies `?DEFAULT_REQUEST_TIMEOUT`
+  (30s) per request unless the caller explicitly passes
+  `timeout => infinity`, so the default loop is already
+  time-bounded. Overriding an explicit `infinity` from a
+  background sweep would surprise callers who deliberately
+  disabled the deadline; the per-request timer is the right
+  hook.
+
+- *Client-side `Last-Event-ID` resume.* Earlier docs said the
+  transport tracked the id but did not replay on reconnect.
+  This actually does work today within the transport process
+  lifetime: `handle_sse_done` schedules `reopen_sse` which
+  preserves `sse_last_event_id`, and `start_get_sse` re-adds
+  the `last-event-id` header on the new GET. A full client
+  restart (gen_statem crash) does lose the cursor, but that
+  flow re-initializes the session anyway, so a fresh stream
+  is the correct outcome.

--- a/guides/tools-resources-prompts.md
+++ b/guides/tools-resources-prompts.md
@@ -512,7 +512,7 @@ SSE channel:
 
 | Notification | Façade |
 | --- | --- |
-| `notifications/resources/updated` | `barrel_mcp:notify_resource_updated/1,2` |
+| `notifications/resources/updated` | `barrel_mcp:notify_resource_updated/1,2`. Subscriptions are scoped to the calling `Mcp-Session-Id` — when a client re-initializes (or its session expires) the new session id has no carry-over subscriptions, and the host must subscribe again. This matches the spec's session-lifecycle model. |
 | `notifications/tools/list_changed`<br>`notifications/resources/list_changed`<br>`notifications/prompts/list_changed` | `barrel_mcp:notify_list_changed/1` (tool, resource, prompt). `reg_tool/4`/`unreg_tool/1` and friends emit it automatically; call the façade if you mutate the catalogue out of band. |
 | `notifications/progress` | `barrel_mcp:notify_progress/3,4` (or via `Ctx` from an arity-2 tool handler). |
 | `notifications/tasks/status` | Emitted by `barrel_mcp_tasks` on every status transition. |


### PR DESCRIPTION
## Summary

Cleans up the last items from the §A landscape audit. After tracing the code:

- **Periodic deadline timer** — already covered by the per-request `?DEFAULT_REQUEST_TIMEOUT` (30s); explicit `infinity` is a deliberate caller choice. A background sweep would override that surprise-fully and add no value at the default timeout. Removed from the roadmap; replaced with a note explaining the rationale.

- **Client-side `Last-Event-ID` resume** — works today inside the transport process lifetime. `handle_sse_done` schedules `reopen_sse` which preserves `sse_last_event_id`, and `start_get_sse` re-adds the `last-event-id` header on the new GET. A full client crash + restart loses the cursor, but that flow re-initializes the session anyway, so a fresh stream is the correct outcome. Removed from the roadmap.

- **Subscription persistence** — added a doc note in `guides/tools-resources-prompts.md` clarifying that `resources/subscribe` is scoped to the calling `Mcp-Session-Id`: a re-initialize yields a new session id with no carry-over subscriptions, matching the spec's session-lifecycle model.

No code changes. Hex.pm publish remains the one open release-coordination item but needs the maintainer to drive.

eunit + ct + dialyzer green.