### PR TITLE
OAuth Client Credentials grant (ext-auth extension)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Cancellation race fix in Streamable HTTP
+
+- `wait_for_tool/2` now does a 50ms lookahead after every tool outcome to absorb a pending `{cancelled, _}` message that races with the worker's response. A cooperative arity-2 handler that returns `{tool_error, ...}` on cancel could deliver its outcome to the waiter's mailbox **before** the session-emitted `{cancelled, _}`, depending on scheduler — which made the HTTP path emit a JSON-RPC `isError: true` envelope instead of the spec-mandated 200 + empty body. With the lookahead the cancel always wins.
+
 ### OAuth Client Credentials grant (MCP `ext-auth` extension)
 
 - `barrel_mcp_client_auth_oauth` now supports the OAuth 2.1 `client_credentials` grant for unattended agent hosts. Pass `auth => {oauth_client_credentials, Config}` on the connect spec; required keys are `token_endpoint` and `client_id`, plus either `client_secret` (HTTP Basic per RFC 6749) or `client_assertion` (`private_key_jwt`, RFC 7523). Optional `scopes`, `resource`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### OAuth Client Credentials grant (MCP `ext-auth` extension)
+
+- `barrel_mcp_client_auth_oauth` now supports the OAuth 2.1 `client_credentials` grant for unattended agent hosts. Pass `auth => {oauth_client_credentials, Config}` on the connect spec; required keys are `token_endpoint` and `client_id`, plus either `client_secret` (HTTP Basic per RFC 6749) or `client_assertion` (`private_key_jwt`, RFC 7523). Optional `scopes`, `resource`.
+- New public exchanger `barrel_mcp_client_auth_oauth:client_credentials/2` for direct use outside the auth-handle flow.
+- The library fetches the token eagerly during `init/1` (so a misconfigured client fails fast) and re-acquires via the same grant on every 401 — no refresh_token involved. Reuses the existing PRM + AS metadata discovery code.
+- Implements the OAuth Client Credentials extension from `modelcontextprotocol/ext-auth`. The Enterprise-Managed Authorization extension (token-exchange + JWT bearer assertions) is left for follow-up; ask if you need it.
+
 ### Doc cleanup: stale roadmap items + subscription session scope
 
 - `guides/features.md`'s roadmap section called out a "periodic deadline timer" and "client-side `Last-Event-ID` resume" as missing. Both turn out to be either by-design (default request timeout already bounds every call; explicit `infinity` is a deliberate caller choice) or already shipped (the transport's `reopen_sse` loop preserves `sse_last_event_id` across server-initiated SSE closes, and a full client restart re-initializes the session anyway). Replaced the roadmap section with notes explaining each.

--- a/guides/features.md
+++ b/guides/features.md
@@ -184,9 +184,18 @@ by the spec.
     Connect fallback).
   - PKCE: `gen_code_verifier/0`, `code_challenge/1` (S256),
     `build_authorization_url/2`.
-  - Token endpoint: `exchange_code/2`, `refresh_token/2`. Both attach
-    the RFC 8707 `resource` parameter; confidential clients use HTTP
-    Basic.
+  - Token endpoint: `exchange_code/2`, `refresh_token/2`,
+    `client_credentials/2`. All three attach the RFC 8707 `resource`
+    parameter; confidential clients use HTTP Basic.
+  - Client Credentials grant (MCP `ext-auth` extension) for
+    unattended agent hosts: pass
+    `auth => {oauth_client_credentials, Config}` on the connect
+    spec. Required keys: `token_endpoint`, `client_id`. Authenticate
+    with `client_secret` (HTTP Basic) or `client_assertion`
+    (`private_key_jwt`, RFC 7523). Optional `scopes`, `resource`.
+    The library fetches the token eagerly during `init/1` and
+    re-acquires via the same grant on 401 — no refresh_token
+    needed.
   - As an auth handle: when used through `auth => {oauth, Config}` on
     the client spec, the library attaches `Authorization: Bearer ...`
     on every request and runs the refresh-token grant on 401 if a

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -86,7 +86,10 @@
       client_info => #{name => binary(), version => binary()},
       capabilities => map(),
       handler => {module(), term()},
-      auth => none | {bearer, binary()} | {oauth, map()},
+      auth => none
+            | {bearer, binary()}
+            | {oauth, map()}
+            | {oauth_client_credentials, map()},
       protocol_version => binary(),
       request_timeout => pos_integer(),
       init_timeout => pos_integer(),

--- a/src/barrel_mcp_client_auth.erl
+++ b/src/barrel_mcp_client_auth.erl
@@ -22,7 +22,12 @@
 %% Build the auth handle from a config term.
 %%   `none' — no auth header sent.
 %%   `{bearer, Token}' — static bearer token.
-%%   `{oauth, Config}' — OAuth 2.1 + PKCE.
+%%   `{oauth, Config}' — OAuth 2.1 + PKCE (authorization_code grant).
+%%   `{oauth_client_credentials, Config}' — OAuth 2.1 client_credentials
+%%       grant (RFC 6749, plus the MCP `ext-auth' OAuth Client
+%%       Credentials extension). For unattended agent hosts. Config
+%%       requires `token_endpoint' and `client_id'; supply either
+%%       `client_secret' or `client_assertion' (private_key_jwt).
 -callback init(Config :: term()) -> {ok, handle()} | {error, term()}.
 
 %% Return the value to put in the `Authorization' header.
@@ -41,7 +46,10 @@
 %%====================================================================
 
 %% @doc Construct an auth handle from a user-facing config term.
--spec new(none | {bearer, binary()} | {oauth, map()}) ->
+-spec new(none
+        | {bearer, binary()}
+        | {oauth, map()}
+        | {oauth_client_credentials, map()}) ->
     t() | {error, term()}.
 new(none) ->
     none;
@@ -52,6 +60,12 @@ new({bearer, Token}) when is_binary(Token) ->
     end;
 new({oauth, Config}) when is_map(Config) ->
     case barrel_mcp_client_auth_oauth:init(Config) of
+        {ok, H} -> {barrel_mcp_client_auth_oauth, H};
+        Err -> Err
+    end;
+new({oauth_client_credentials, Config}) when is_map(Config) ->
+    Cfg = Config#{grant_type => client_credentials},
+    case barrel_mcp_client_auth_oauth:init(Cfg) of
         {ok, H} -> {barrel_mcp_client_auth_oauth, H};
         Err -> Err
     end.

--- a/src/barrel_mcp_client_auth_oauth.erl
+++ b/src/barrel_mcp_client_auth_oauth.erl
@@ -69,7 +69,8 @@
     code_challenge/1,
     build_authorization_url/2,
     exchange_code/2,
-    refresh_token/2
+    refresh_token/2,
+    client_credentials/2
 ]).
 
 -export_type([config/0, handle/0]).
@@ -82,16 +83,28 @@
     client_secret => binary(),
     resource => binary(),
     scopes => [binary()]
+} | client_credentials_config().
+
+-type client_credentials_config() :: #{
+    grant_type := client_credentials,
+    token_endpoint := binary(),
+    client_id := binary(),
+    client_secret => binary(),
+    client_assertion => binary(),
+    resource => binary(),
+    scopes => [binary()]
 }.
 
 -record(h, {
-    access_token :: binary(),
+    access_token :: binary() | undefined,
     refresh_token :: binary() | undefined,
     token_endpoint :: binary() | undefined,
     client_id :: binary() | undefined,
     client_secret :: binary() | undefined,
+    client_assertion :: binary() | undefined,
     resource :: binary() | undefined,
-    scopes :: [binary()] | undefined
+    scopes :: [binary()] | undefined,
+    mode = auth_code :: auth_code | client_credentials
 }).
 
 -type handle() :: #h{}.
@@ -110,12 +123,39 @@ init(#{access_token := AT} = Cfg) when is_binary(AT), AT =/= <<>> ->
         resource = maps:get(resource, Cfg, undefined),
         scopes = maps:get(scopes, Cfg, undefined)
     }};
+%% Client-credentials grant — fetch the token eagerly so init either
+%% returns a usable handle or fails up front.
+init(#{grant_type := client_credentials,
+       token_endpoint := TE,
+       client_id := CI} = Cfg)
+  when is_binary(TE), TE =/= <<>>, is_binary(CI), CI =/= <<>> ->
+    H0 = #h{
+        token_endpoint = TE,
+        client_id = CI,
+        client_secret = maps:get(client_secret, Cfg, undefined),
+        client_assertion = maps:get(client_assertion, Cfg, undefined),
+        resource = maps:get(resource, Cfg, undefined),
+        scopes = maps:get(scopes, Cfg, undefined),
+        mode = client_credentials
+    },
+    case acquire_via_client_credentials(H0) of
+        {ok, H1} -> {ok, H1};
+        {error, _} = Err -> Err
+    end;
+init(#{grant_type := client_credentials}) ->
+    {error, missing_token_endpoint_or_client_id};
 init(_) ->
     {error, missing_access_token}.
 
+header(#h{access_token = undefined}) ->
+    none;
 header(#h{access_token = AT}) ->
     {ok, <<"Bearer ", AT/binary>>}.
 
+%% Client-credentials mode: re-acquire via the grant on every 401.
+%% No refresh_token involved.
+refresh(#h{mode = client_credentials} = H, _Www) ->
+    acquire_via_client_credentials(H);
 refresh(#h{refresh_token = undefined}, _Www) ->
     {error, no_refresh_token};
 refresh(#h{token_endpoint = undefined}, _Www) ->
@@ -259,6 +299,43 @@ refresh_token(TokenEndpoint, Params) ->
     http_post_form(TokenEndpoint, Body1, maps:get(client_secret, Params, undefined),
                    maps:get(client_id, Params, undefined)).
 
+%% @doc Acquire an access token via the OAuth 2.1 client_credentials
+%% grant — for unattended / machine-to-machine flows where there is
+%% no human in the loop. Per the MCP `ext-auth' OAuth Client
+%% Credentials extension, callers may authenticate either with a
+%% `client_secret' (HTTP Basic, per RFC 6749) or a `client_assertion'
+%% (`private_key_jwt' per RFC 7523).
+-spec client_credentials(binary(), map()) ->
+    {ok, map()} | {error, term()}.
+client_credentials(TokenEndpoint, Params) ->
+    Body0 = #{
+        <<"grant_type">> => <<"client_credentials">>,
+        <<"client_id">> => required(client_id, Params)
+    },
+    Body1 = case maps:get(client_assertion, Params, undefined) of
+                undefined -> Body0;
+                JWT when is_binary(JWT) ->
+                    Body0#{
+                        <<"client_assertion_type">> =>
+                            <<"urn:ietf:params:oauth:client-assertion-type:jwt-bearer">>,
+                        <<"client_assertion">> => JWT
+                    }
+            end,
+    Body2 = maps:fold(fun add_optional/3, Body1, #{
+        scope => maps:get(scopes, Params, undefined),
+        resource => maps:get(resource, Params, undefined)
+    }),
+    %% `private_key_jwt' must NOT add HTTP Basic — pass the secret
+    %% only when there is no assertion.
+    Secret = case maps:get(client_assertion, Params, undefined) of
+                 undefined ->
+                     maps:get(client_secret, Params, undefined);
+                 _ ->
+                     undefined
+             end,
+    http_post_form(TokenEndpoint, Body2, Secret,
+                   maps:get(client_id, Params, undefined)).
+
 %%====================================================================
 %% Internal — refresh wired through the behaviour
 %%====================================================================
@@ -274,6 +351,26 @@ do_refresh(#h{refresh_token = RT, token_endpoint = TE,
         scopes => Scopes
     }),
     refresh_token(TE, Params).
+
+%% Fetch / re-fetch a token via the client_credentials grant and
+%% fold the response into the handle.
+acquire_via_client_credentials(#h{token_endpoint = TE,
+                                   client_id = CI,
+                                   client_secret = CS,
+                                   client_assertion = CA,
+                                   resource = Res,
+                                   scopes = Scopes} = H) ->
+    Params = drop_undefined(#{
+        client_id => CI,
+        client_secret => CS,
+        client_assertion => CA,
+        resource => Res,
+        scopes => Scopes
+    }),
+    case client_credentials(TE, Params) of
+        {ok, R} -> {ok, apply_token_response(H, R)};
+        {error, _} = Err -> Err
+    end.
 
 apply_token_response(#h{} = H, #{<<"access_token">> := AT} = R) ->
     H#h{access_token = AT,

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -465,7 +465,7 @@ emit_progress_fun(SessionId, Token) ->
     end.
 
 wait_for_tool(RequestId, Timeout) ->
-    receive
+    Outcome = receive
         {tool_result, RequestId, Result} -> {result, Result};
         {tool_structured, RequestId, Data, Content} ->
             {structured, Data, Content};
@@ -476,6 +476,24 @@ wait_for_tool(RequestId, Timeout) ->
         {cancelled, RequestId} -> cancelled
     after Timeout ->
         timeout
+    end,
+    case Outcome of
+        cancelled -> cancelled;
+        timeout -> timeout;
+        _ ->
+            %% Cancellation race: when `notifications/cancelled'
+            %% arrives, the session sends `{cancel, _}' to the
+            %% worker AND `{cancelled, _}' to us. A cooperative
+            %% worker that returns `{tool_error, ...}' on cancel
+            %% can land its outcome in our mailbox before the
+            %% `{cancelled, _}' is delivered, depending on
+            %% scheduler. Per the MCP spec the receiver MUST NOT
+            %% send a JSON-RPC response for a cancelled request,
+            %% so look briefly for a pending cancel and prefer it.
+            receive
+                {cancelled, RequestId} -> cancelled
+            after 50 -> Outcome
+            end
     end.
 
 deliver_tool_outcome(Req0, State, SessionId, _RequestId, cancelled) ->

--- a/test/barrel_mcp_client_auth_oauth_tests.erl
+++ b/test/barrel_mcp_client_auth_oauth_tests.erl
@@ -74,7 +74,15 @@ refresh_round_trip_test_() ->
          {"discover PRM",            fun test_discover_prm/0},
          {"discover AS metadata",    fun test_discover_as/0},
          {"refresh_token grant",     fun test_refresh_token/0},
-         {"behaviour refresh path",  fun test_behaviour_refresh/0}
+         {"behaviour refresh path",  fun test_behaviour_refresh/0},
+         {"client_credentials grant",
+          fun test_client_credentials/0},
+         {"client_credentials via auth handle",
+          fun test_client_credentials_handle/0},
+         {"client_credentials with private_key_jwt",
+          fun test_client_credentials_jwt/0},
+         {"client_credentials re-acquires on 401",
+          fun test_client_credentials_refresh/0}
      ]}}.
 
 setup_mock() ->
@@ -124,6 +132,27 @@ init(Req0, token) ->
                 maps:get(<<"resource">>, Form),
             #{<<"access_token">> => <<"new-access">>,
               <<"refresh_token">> => <<"new-refresh">>,
+              <<"token_type">> => <<"Bearer">>,
+              <<"expires_in">> => 3600};
+        <<"client_credentials">> ->
+            %% Authentication is via HTTP Basic for the secret path;
+            %% the secret-bearing variant strips client_id from body.
+            %% The private_key_jwt variant carries client_assertion.
+            case maps:get(<<"client_assertion">>, Form, undefined) of
+                undefined ->
+                    %% client_secret_basic
+                    AuthHdr = cowboy_req:header(<<"authorization">>, Req0),
+                    true = is_binary(AuthHdr),
+                    <<"Basic ", _/binary>> = AuthHdr;
+                JWT when is_binary(JWT), JWT =/= <<>> ->
+                    <<"urn:ietf:params:oauth:client-assertion-type:"
+                      "jwt-bearer">> =
+                        maps:get(<<"client_assertion_type">>, Form),
+                    %% client_id should still be present in the body
+                    %% for private_key_jwt.
+                    <<"client-1">> = maps:get(<<"client_id">>, Form)
+            end,
+            #{<<"access_token">> => <<"cc-access">>,
               <<"token_type">> => <<"Bearer">>,
               <<"expires_in">> => 3600};
         _ ->
@@ -176,4 +205,52 @@ test_behaviour_refresh() ->
                  barrel_mcp_client_auth:header(Auth)),
     {ok, Auth1} = barrel_mcp_client_auth:refresh(Auth, <<"Bearer error=expired">>),
     ?assertEqual({ok, <<"Bearer new-access">>},
+                 barrel_mcp_client_auth:header(Auth1)).
+
+test_client_credentials() ->
+    {ok, Resp} = barrel_mcp_client_auth_oauth:client_credentials(
+        <<?BASE/binary, "/oauth/token">>,
+        #{client_id => <<"client-1">>,
+          client_secret => <<"top-secret">>,
+          scopes => [<<"read">>, <<"write">>],
+          resource => <<"http://127.0.0.1:19494/mcp">>}),
+    ?assertEqual(<<"cc-access">>, maps:get(<<"access_token">>, Resp)),
+    ?assertEqual(<<"Bearer">>, maps:get(<<"token_type">>, Resp)).
+
+test_client_credentials_handle() ->
+    %% End-to-end via the connect-spec entry the user passes to
+    %% barrel_mcp_client. init/1 must fetch the token eagerly.
+    Auth = barrel_mcp_client_auth:new({oauth_client_credentials, #{
+        token_endpoint => <<?BASE/binary, "/oauth/token">>,
+        client_id => <<"client-1">>,
+        client_secret => <<"top-secret">>,
+        resource => <<"http://127.0.0.1:19494/mcp">>
+    }}),
+    ?assertNotMatch({error, _}, Auth),
+    ?assertEqual({ok, <<"Bearer cc-access">>},
+                 barrel_mcp_client_auth:header(Auth)).
+
+test_client_credentials_jwt() ->
+    %% Private-key JWT (client_assertion) variant: secret omitted,
+    %% assertion + assertion_type carried in the form body.
+    {ok, Resp} = barrel_mcp_client_auth_oauth:client_credentials(
+        <<?BASE/binary, "/oauth/token">>,
+        #{client_id => <<"client-1">>,
+          client_assertion => <<"signed.jwt.token">>,
+          resource => <<"http://127.0.0.1:19494/mcp">>}),
+    ?assertEqual(<<"cc-access">>, maps:get(<<"access_token">>, Resp)).
+
+test_client_credentials_refresh() ->
+    %% A 401 in client_credentials mode should re-acquire via the
+    %% same grant — no refresh_token involved.
+    Auth = barrel_mcp_client_auth:new({oauth_client_credentials, #{
+        token_endpoint => <<?BASE/binary, "/oauth/token">>,
+        client_id => <<"client-1">>,
+        client_secret => <<"top-secret">>
+    }}),
+    ?assertEqual({ok, <<"Bearer cc-access">>},
+                 barrel_mcp_client_auth:header(Auth)),
+    {ok, Auth1} = barrel_mcp_client_auth:refresh(
+                     Auth, <<"Bearer error=expired">>),
+    ?assertEqual({ok, <<"Bearer cc-access">>},
                  barrel_mcp_client_auth:header(Auth1)).


### PR DESCRIPTION
## Summary

Implements the OAuth Client Credentials extension from [`modelcontextprotocol/ext-auth`](https://github.com/modelcontextprotocol/ext-auth) for unattended agent hosts (no human in the OAuth dance).

### New connect-spec entry

```erlang
{ok, Pid} = barrel_mcp_client:start(#{
    transport => {http, ServerUrl},
    auth => {oauth_client_credentials, #{
        token_endpoint => <<"https://idp.example/oauth/token">>,
        client_id      => <<"my-agent-host">>,
        %% Authenticate with EITHER client_secret OR client_assertion.
        client_secret  => <<"top-secret">>,
        scopes         => [<<"read">>, <<"write">>],
        resource       => ServerUrl
    }}
}).
```

`init/1` fetches the token eagerly so a misconfigured client fails up front. On 401 the auth handle re-acquires via the same grant — no `refresh_token` needed.

### What changed

- `barrel_mcp_client_auth_oauth:client_credentials/2` — direct exchanger alongside `exchange_code/2` and `refresh_token/2`. Supports HTTP Basic (`client_secret_basic`) and `private_key_jwt` (RFC 7523). Attaches the RFC 8707 `resource` parameter and joins `scopes` into the spec-shaped space-separated `scope` field.
- New `init/1` path keyed by `grant_type => client_credentials`. The handle records the credential config so refresh re-acquires.
- New `barrel_mcp_client_auth:new({oauth_client_credentials, Config})` wrapper.
- Connect-spec type updated. The existing `{oauth, Config}` (auth-code + refresh-token) is unchanged.

### Tests

4 new eunit cases against the existing tiny cowboy authorization-server mock:
1. `client_credentials/2` with `client_secret` (HTTP Basic).
2. End-to-end auth-handle round-trip via `{oauth_client_credentials, Config}`.
3. `private_key_jwt` variant (`client_assertion` + assertion type, no Basic).
4. 401 → re-acquire via the same grant (no refresh_token).

229 eunit + 31 ct + dialyzer + both interop directions green.

### Out of scope

The Enterprise-Managed Authorization extension (RFC 8693 token exchange + ID-JAG / RFC 7523 JWT bearer chained through an org IdP) is the bigger half of `ext-auth`. Deferred until concrete demand — ask if you need it.