### PR TITLE
chore: release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-03
+
+Builds on the 1.3.0 interop work with two new feature areas
+(server-side pagination, OAuth Client Credentials for unattended
+agent hosts) plus a runnable federation demo and one bug fix.
+No breaking wire changes.
+
 ### Cancellation race fix in Streamable HTTP
 
 - `wait_for_tool/2` now does a 50ms lookahead after every tool outcome to absorb a pending `{cancelled, _}` message that races with the worker's response. A cooperative arity-2 handler that returns `{tool_error, ...}` on cancel could deliver its outcome to the waiter's mailbox **before** the session-emitted `{cancelled, _}`, depending on scheduler — which made the HTTP path emit a JSON-RPC `isError: true` envelope instead of the spec-mandated 200 + empty body. With the lookahead the cancel always wins.

--- a/src/barrel_mcp.app.src
+++ b/src/barrel_mcp.app.src
@@ -1,13 +1,13 @@
 {application, barrel_mcp, [
     {description, "MCP Protocol Library for Erlang"},
-    {vsn, "1.3.0"},
+    {vsn, "1.4.0"},
     {registered, [barrel_mcp_registry, barrel_mcp_sup, barrel_mcp_session,
                   barrel_mcp_tasks, barrel_mcp_client_sup]},
     {mod, {barrel_mcp_app, []}},
     {applications, [kernel, stdlib, crypto, cowboy, hackney]},
     {env, [
         {server_name, <<"barrel">>},
-        {server_version, <<"1.3.0">>},
+        {server_version, <<"1.4.0">>},
         {protocol_version, <<"2025-11-25">>},
         {session_ttl, 1800000}  %% 30 minutes default
     ]},


### PR DESCRIPTION
## Summary

Rolls up the post-1.3.0 work. No breaking wire changes vs 1.3.0.

### Highlights

- **Server-side cursor pagination** on every `*/list` endpoint (PR #34). `tools/list`, `resources/list`, `resources/templates/list`, `prompts/list`, `tasks/list` accept `cursor`, emit `nextCursor`. Page size 50, sorted by name.
- **`examples/agent_host`** runnable federation demo (PR #35). Closes the docs loop for `barrel_mcp_agent`.
- **OAuth Client Credentials grant** (`auth => {oauth_client_credentials, Config}`) from MCP `ext-auth` (PR #37). Supports `client_secret_basic` and `private_key_jwt`. Eager fetch on `init`, re-acquire on 401.
- **Cancellation race fix** in Streamable HTTP (PR #37). 50ms lookahead on `wait_for_tool/2` absorbs a pending `{cancelled, _}` that races with a cooperative worker's `{tool_error, _}` on cancel.
- Doc cleanup of stale roadmap items + subscription session-scope clarification (PR #36).