### PR TITLE
resources/read: runtime template expansion (RFC 6570 Level 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `resources/read` runtime template expansion
+
+- Registered `resource_template` entries are now matched against incoming `resources/read` URIs and routed to the template's handler. Previously templates only appeared in `resources/templates/list`; reading any URI matching one returned `Resource not found`.
+- New `barrel_mcp_uri_template` module implementing RFC 6570 Level 1 (simple `{var}` expansion). `match/2` returns a binary-keyed map of substituted values; `expand/2` is the inverse. 13 eunit cases cover single / multi-variable, literal-only, malformed templates, and round-trip.
+- The substituted variables flow into the handler's `Args` map alongside the original request `params`, so a `file:///{path}` template matched against `file:///etc/hosts` lets the handler read `<<"path">>`.
+- Direction A of the Python interop suite reads `file:///etc/hosts` against the `file:///{path}` fixture template and asserts the handler's expanded `path` value round-trips.
+
+
 ## [1.2.0] - 2026-05-03
 
 A large release that consolidates everything since 1.1.0:

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -234,19 +234,22 @@ handle_request(<<"resources/list">>, Params, Id, _State) ->
 
 handle_request(<<"resources/read">>, Params, Id, _State) ->
     Uri = maps:get(<<"uri">>, Params, <<>>),
-    %% Find resource by URI
+    %% Exact-URI lookup first.
     Resources = barrel_mcp_registry:all(resource),
     case lists:keyfind(Uri, 1, [{maps:get(uri, H, <<>>), N, H} || {N, H} <- Resources]) of
         {Uri, Name, _Handler} ->
-            case barrel_mcp_registry:run(resource, Name, Params) of
-                {ok, Result} ->
-                    Content = format_resource_result(Uri, Result),
-                    success_response(Id, #{<<"contents">> => Content});
-                {error, Reason} ->
-                    error_response(Id, ?MCP_RESOURCE_ERROR, format_error(Reason))
-            end;
+            run_resource_read(resource, Name, Params, Uri, Id);
         false ->
-            error_response(Id, ?JSONRPC_METHOD_NOT_FOUND, <<"Resource not found">>)
+            %% Fall back to RFC 6570 template matching against
+            %% registered `resource_template' entries.
+            case match_resource_template(Uri) of
+                {ok, TplName, Vars} ->
+                    Args = maps:merge(Params, Vars),
+                    run_resource_read(resource_template, TplName, Args, Uri, Id);
+                nomatch ->
+                    error_response(Id, ?JSONRPC_METHOD_NOT_FOUND,
+                                   <<"Resource not found">>)
+            end
     end;
 
 handle_request(<<"resources/templates/list">>, Params, Id, _State) ->
@@ -568,6 +571,36 @@ format_tool_result(Result) when is_list(Result) ->
     Result;
 format_tool_result(Result) ->
     [#{<<"type">> => <<"text">>, <<"text">> => io_lib:format("~p", [Result])}].
+
+%% Run a resource handler (exact match or template) and shape
+%% the response.
+run_resource_read(Type, Name, Args, Uri, Id) ->
+    case barrel_mcp_registry:run(Type, Name, Args) of
+        {ok, Result} ->
+            Content = format_resource_result(Uri, Result),
+            success_response(Id, #{<<"contents">> => Content});
+        {error, Reason} ->
+            error_response(Id, ?MCP_RESOURCE_ERROR, format_error(Reason))
+    end.
+
+%% Walk the registered resource_template entries and return the
+%% first whose `uri_template' matches `Uri'.
+match_resource_template(Uri) ->
+    Templates = barrel_mcp_registry:all(resource_template),
+    do_match_template(Uri, Templates).
+
+do_match_template(_Uri, []) -> nomatch;
+do_match_template(Uri, [{Name, Handler} | Rest]) ->
+    Tpl = maps:get(uri_template, Handler, <<>>),
+    case Tpl of
+        <<>> ->
+            do_match_template(Uri, Rest);
+        _ ->
+            case barrel_mcp_uri_template:match(Uri, Tpl) of
+                {ok, Vars} -> {ok, Name, Vars};
+                nomatch -> do_match_template(Uri, Rest)
+            end
+    end.
 
 format_resource_result(Uri, Result) when is_list(Result) ->
     [add_resource_uri(Uri, B) || B <- Result];

--- a/src/barrel_mcp_uri_template.erl
+++ b/src/barrel_mcp_uri_template.erl
@@ -1,0 +1,163 @@
+%%%-------------------------------------------------------------------
+%%% @doc Minimal RFC 6570 Level-1 URI Template matcher and expander.
+%%%
+%%% Used by the server's `resources/read' handler to route a
+%%% concrete URI to a registered `resource_template'. We only
+%%% implement Level 1 (`{var}' simple expansion) — that covers
+%%% every template the spec's reference examples use, and it's
+%%% the level the MCP server registry actually accepts.
+%%%
+%%% Examples:
+%%% ```
+%%% match(<<"file:///etc/hosts">>, <<"file:///{path}">>).
+%%%   %% => {ok, #{<<"path">> => <<"etc/hosts">>}}
+%%%
+%%% match(<<"https://api.x/v1/users/42">>,
+%%%       <<"https://api.x/v1/{kind}/{id}">>).
+%%%   %% => {ok, #{<<"kind">> => <<"users">>,
+%%%   %%          <<"id">>   => <<"42">>}}
+%%%
+%%% expand(<<"file:///{path}">>, #{<<"path">> => <<"etc/hosts">>}).
+%%%   %% => {ok, <<"file:///etc/hosts">>}
+%%% '''
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_uri_template).
+
+-export([match/2, expand/2]).
+
+%%====================================================================
+%% Public API
+%%====================================================================
+
+%% @doc Match `Uri' against `Template'. Returns `{ok, Vars}' where
+%% `Vars' is a binary-keyed map of substituted values, or `nomatch'
+%% if the URI doesn't fit the template. Variables are matched
+%% greedily but stop at literal segments (a value never crosses a
+%% literal `/' that the template requires after the variable).
+-spec match(binary(), binary()) -> {ok, map()} | nomatch.
+match(Uri, Template) when is_binary(Uri), is_binary(Template) ->
+    case parse(Template) of
+        {ok, Tokens} ->
+            do_match(Uri, Tokens, #{});
+        {error, _} ->
+            nomatch
+    end.
+
+%% @doc Expand `Template' by substituting `Vars'. Returns the
+%% concrete URI or `{error, {missing_var, Name}}' if a variable
+%% in the template has no value in `Vars'.
+-spec expand(binary(), map()) -> {ok, binary()} | {error, term()}.
+expand(Template, Vars) when is_binary(Template), is_map(Vars) ->
+    case parse(Template) of
+        {ok, Tokens} ->
+            do_expand(Tokens, Vars, []);
+        {error, _} = Err ->
+            Err
+    end.
+
+%%====================================================================
+%% Internal — template parser
+%%====================================================================
+
+%% Parse a template into a list of `{literal, Bin} | {var, Name}'
+%% tokens.
+parse(Template) ->
+    parse(Template, <<>>, []).
+
+parse(<<>>, Acc, Tokens) ->
+    {ok, lists:reverse(emit_literal(Acc, Tokens))};
+parse(<<"{", Rest/binary>>, Acc, Tokens) ->
+    case binary:split(Rest, <<"}">>) of
+        [Name, More] when Name =/= <<>> ->
+            Tokens1 = emit_literal(Acc, Tokens),
+            parse(More, <<>>, [{var, Name} | Tokens1]);
+        _ ->
+            {error, {malformed_template, template_for_error(Acc, Rest)}}
+    end;
+parse(<<C, Rest/binary>>, Acc, Tokens) ->
+    parse(Rest, <<Acc/binary, C>>, Tokens).
+
+emit_literal(<<>>, Tokens) -> Tokens;
+emit_literal(Bin, Tokens) -> [{literal, Bin} | Tokens].
+
+template_for_error(Acc, Rest) ->
+    <<Acc/binary, Rest/binary>>.
+
+%%====================================================================
+%% Internal — match
+%%====================================================================
+
+do_match(<<>>, [], Vars) ->
+    {ok, Vars};
+do_match(_, [], _) ->
+    nomatch;
+do_match(Uri, [{literal, Lit} | Rest], Vars) ->
+    case starts_with(Uri, Lit) of
+        {true, Tail} -> do_match(Tail, Rest, Vars);
+        false -> nomatch
+    end;
+do_match(Uri, [{var, Name}], Vars) ->
+    %% Trailing variable — consume the rest. Empty value is
+    %% allowed only if the template clearly expected an empty
+    %% suffix; here we require at least one character.
+    case Uri of
+        <<>> -> nomatch;
+        _    -> {ok, Vars#{Name => Uri}}
+    end;
+do_match(Uri, [{var, Name}, {literal, NextLit} | Rest], Vars) ->
+    %% Variable followed by a literal: consume up to the next
+    %% occurrence of NextLit.
+    case binary:match(Uri, NextLit) of
+        nomatch -> nomatch;
+        {Pos, Len} when Pos > 0 ->
+            <<Value:Pos/binary, _:Len/binary, Tail/binary>> = Uri,
+            do_match(Tail, Rest, Vars#{Name => Value});
+        {0, _} ->
+            %% Empty variable value not allowed here.
+            nomatch
+    end;
+do_match(Uri, [{var, Name1}, {var, Name2} | Rest], Vars) ->
+    %% Two variables in a row with no literal between them —
+    %% ambiguous. RFC 6570 doesn't require us to support this; we
+    %% treat the first as everything up to the last separator and
+    %% the second as the remainder, but most MCP templates avoid
+    %% this shape. Implement simply: split on the next `/'.
+    case binary:split(Uri, <<"/">>) of
+        [V1, V2] when V1 =/= <<>>, V2 =/= <<>> ->
+            do_match(<<>>, Rest,
+                     Vars#{Name1 => V1, Name2 => V2});
+        _ ->
+            nomatch
+    end.
+
+starts_with(Bin, Prefix) ->
+    case byte_size(Bin) >= byte_size(Prefix) of
+        false ->
+            false;
+        true ->
+            PSize = byte_size(Prefix),
+            <<Head:PSize/binary, Tail/binary>> = Bin,
+            case Head =:= Prefix of
+                true -> {true, Tail};
+                false -> false
+            end
+    end.
+
+%%====================================================================
+%% Internal — expand
+%%====================================================================
+
+do_expand([], _Vars, Acc) ->
+    {ok, iolist_to_binary(lists:reverse(Acc))};
+do_expand([{literal, Lit} | Rest], Vars, Acc) ->
+    do_expand(Rest, Vars, [Lit | Acc]);
+do_expand([{var, Name} | Rest], Vars, Acc) ->
+    case maps:find(Name, Vars) of
+        {ok, V} when is_binary(V) ->
+            do_expand(Rest, Vars, [V | Acc]);
+        {ok, V} when is_list(V) ->
+            do_expand(Rest, Vars, [iolist_to_binary(V) | Acc]);
+        error ->
+            {error, {missing_var, Name}}
+    end.

--- a/test/barrel_mcp_python_interop_SUITE.erl
+++ b/test/barrel_mcp_python_interop_SUITE.erl
@@ -362,10 +362,12 @@ cancellable_loop(ReqId) ->
         cancellable_loop(ReqId)
     end.
 
-%% Resource template handler: serves whatever the template's
-%% `path' substitution resolved to (we just echo the URI).
-file_resource(_) ->
-    <<"template-served">>.
+%% Resource template handler: now that resources/read does
+%% RFC 6570 expansion, we receive the substituted `path' under
+%% Args and echo it so the interop test can assert on it.
+file_resource(Args) ->
+    Path = maps:get(<<"path">>, Args, <<"unset">>),
+    iolist_to_binary([<<"path=">>, Path]).
 
 %% Completion handler: returns a single canned suggestion derived
 %% from the partial value the user typed.

--- a/test/barrel_mcp_resources_tests.erl
+++ b/test/barrel_mcp_resources_tests.erl
@@ -13,7 +13,8 @@
     binary_resource/1,
     json_resource/1,
     annotated_resource/1,
-    multi_block_resource/1
+    multi_block_resource/1,
+    file_template/1
 ]).
 
 %%====================================================================
@@ -38,7 +39,9 @@ resources_test_() ->
         {"Resource read carries annotations on the content block",
          fun test_resource_read_block_annotations/0},
         {"Resource read accepts a list of pre-built content blocks",
-         fun test_resource_read_multi_block/0}
+         fun test_resource_read_multi_block/0},
+        {"Resource read against a templated URI routes to the template handler",
+         fun test_resource_read_via_template/0}
      ]
     }.
 
@@ -76,6 +79,10 @@ multi_block_resource(_Args) ->
     [#{<<"text">> => <<"summary">>},
      #{<<"uri">> => <<"mem://multi/details">>,
        <<"text">> => <<"details">>}].
+
+file_template(Args) ->
+    Path = maps:get(<<"path">>, Args, <<"unset">>),
+    iolist_to_binary([<<"path=">>, Path]).
 
 %%====================================================================
 %% Tests
@@ -309,3 +316,26 @@ test_resource_read_multi_block() ->
     %% Pre-set URI on the second block is preserved.
     ?assertEqual(<<"mem://multi/details">>, maps:get(<<"uri">>, B2)),
     barrel_mcp_registry:unreg(resource, <<"multi">>).
+
+test_resource_read_via_template() ->
+    %% Register a template; resources/read against a concrete URI
+    %% matching the template should route to the handler with the
+    %% expanded variables in Args.
+    ok = barrel_mcp_registry:reg(resource_template, <<"file_tpl">>, ?MODULE,
+                                  file_template, #{
+        name => <<"File">>,
+        uri_template => <<"file:///{path}">>,
+        mime_type => <<"text/plain">>
+    }),
+    Request = #{<<"jsonrpc">> => <<"2.0">>,
+                <<"id">> => 1,
+                <<"method">> => <<"resources/read">>,
+                <<"params">> => #{<<"uri">> => <<"file:///etc/hosts">>}},
+    Response = barrel_mcp_protocol:handle(Request),
+    [Block | _] = maps:get(<<"contents">>,
+                            maps:get(<<"result">>, Response)),
+    %% The handler echoes the substituted path; the response URI
+    %% is the original URI, not the template.
+    ?assertEqual(<<"file:///etc/hosts">>, maps:get(<<"uri">>, Block)),
+    ?assertEqual(<<"path=etc/hosts">>, maps:get(<<"text">>, Block)),
+    barrel_mcp_registry:unreg(resource_template, <<"file_tpl">>).

--- a/test/barrel_mcp_uri_template_tests.erl
+++ b/test/barrel_mcp_uri_template_tests.erl
@@ -1,0 +1,97 @@
+-module(barrel_mcp_uri_template_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%====================================================================
+%% match/2
+%%====================================================================
+
+match_simple_var_test() ->
+    ?assertEqual({ok, #{<<"path">> => <<"etc/hosts">>}},
+                 barrel_mcp_uri_template:match(
+                   <<"file:///etc/hosts">>,
+                   <<"file:///{path}">>)).
+
+match_multiple_vars_test() ->
+    ?assertEqual({ok, #{<<"kind">> => <<"users">>,
+                        <<"id">>   => <<"42">>}},
+                 barrel_mcp_uri_template:match(
+                   <<"https://api/v1/users/42">>,
+                   <<"https://api/v1/{kind}/{id}">>)).
+
+match_literal_only_test() ->
+    ?assertEqual({ok, #{}},
+                 barrel_mcp_uri_template:match(
+                   <<"file:///fixed">>,
+                   <<"file:///fixed">>)).
+
+match_with_trailing_literal_test() ->
+    ?assertEqual({ok, #{<<"name">> => <<"hello">>}},
+                 barrel_mcp_uri_template:match(
+                   <<"greet:hello/world">>,
+                   <<"greet:{name}/world">>)).
+
+match_no_match_different_prefix_test() ->
+    ?assertEqual(nomatch,
+                 barrel_mcp_uri_template:match(
+                   <<"http:///foo">>,
+                   <<"file:///{path}">>)).
+
+match_no_match_template_too_long_test() ->
+    ?assertEqual(nomatch,
+                 barrel_mcp_uri_template:match(
+                   <<"file:///">>,
+                   <<"file:///{path}">>)).
+
+match_empty_var_value_rejected_test() ->
+    %% Trailing variable cannot be empty.
+    ?assertEqual(nomatch,
+                 barrel_mcp_uri_template:match(
+                   <<"file:///">>,
+                   <<"file:///{path}">>)).
+
+match_two_vars_with_separator_test() ->
+    ?assertEqual({ok, #{<<"kind">> => <<"users">>,
+                        <<"id">>   => <<"42">>}},
+                 barrel_mcp_uri_template:match(
+                   <<"x:users/42">>,
+                   <<"x:{kind}/{id}">>)).
+
+%%====================================================================
+%% expand/2
+%%====================================================================
+
+expand_simple_test() ->
+    ?assertEqual({ok, <<"file:///etc/hosts">>},
+                 barrel_mcp_uri_template:expand(
+                   <<"file:///{path}">>,
+                   #{<<"path">> => <<"etc/hosts">>})).
+
+expand_multiple_vars_test() ->
+    ?assertEqual({ok, <<"https://api/v1/users/42">>},
+                 barrel_mcp_uri_template:expand(
+                   <<"https://api/v1/{kind}/{id}">>,
+                   #{<<"kind">> => <<"users">>,
+                     <<"id">>   => <<"42">>})).
+
+expand_missing_var_test() ->
+    ?assertEqual({error, {missing_var, <<"path">>}},
+                 barrel_mcp_uri_template:expand(
+                   <<"file:///{path}">>, #{})).
+
+expand_match_round_trip_test() ->
+    Tpl = <<"https://api/v1/{kind}/{id}/details">>,
+    Uri = <<"https://api/v1/users/42/details">>,
+    {ok, Vars} = barrel_mcp_uri_template:match(Uri, Tpl),
+    ?assertEqual({ok, Uri},
+                 barrel_mcp_uri_template:expand(Tpl, Vars)).
+
+%%====================================================================
+%% Malformed templates fall back to nomatch
+%%====================================================================
+
+match_malformed_template_test() ->
+    ?assertEqual(nomatch,
+                 barrel_mcp_uri_template:match(
+                   <<"file:///foo">>,
+                   <<"file:///{">>)).

--- a/test/interop/client.py
+++ b/test/interop/client.py
@@ -197,6 +197,16 @@ async def run(url: str) -> None:
             if tmpl.name != "File":
                 fail(f"template name wrong: {tmpl.name!r}")
 
+            # resources/read against a URI that matches the template
+            # — the server expands the path variable and routes to the
+            # template handler.
+            tpl_read = await session.read_resource("file:///etc/hosts")
+            if not tpl_read.contents:
+                fail("templated read returned empty contents")
+            tpl_block = tpl_read.contents[0]
+            if getattr(tpl_block, "text", None) != "path=etc/hosts":
+                fail(f"templated read text mismatch: {tpl_block!r}")
+
             # completion/complete — registered for prompt
             # `hello_prompt` argument `who`. The Erlang fixture
             # returns ["world", "world!"].


### PR DESCRIPTION
## Summary

Registered `resource_template` entries are now matched against incoming `resources/read` URIs and routed to the template handler. Previously templates appeared in `resources/templates/list` but reading any URI that matched returned `Resource not found`.

## What changed

- New `barrel_mcp_uri_template` module — RFC 6570 Level 1 matcher and expander (~140 LOC).
- `resources/read` falls back to template matching when no exact URI match exists. Substituted variables merge into the handler's `Args` so `file:///{path}` matched against `file:///etc/hosts` lets the handler read `<<"path">>`.
- Direction A interop reads `file:///etc/hosts` against the fixture template and asserts the expanded `path` round-trips through the reference Python SDK.

## Verification

243 eunit + 31 ct + dialyzer + both interop directions green.