### PR TITLE
client: notify_roots_list_changed/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `barrel_mcp_client:notify_roots_list_changed/1`
+
+- New client emitter for `notifications/roots/list_changed`. Hosts that mutate their roots after `initialize` (user opened a new workspace, granted access to a new directory, …) call this so the server picks up the change without polling. The server may follow up with `roots/list` against the host's handler.
+- The server-side dispatch hook (`application:set_env(barrel_mcp, roots_changed_handler, {Mod, Fun})`) was already in place; this PR closes the inverse direction.
+- New `test/barrel_mcp_client_roots_SUITE` integration test stands up a real Streamable HTTP server with a roots-changed handler that forwards to the test process; asserts the notification round-trips end-to-end.
+
 ### `resources/read` runtime template expansion
 
 - Registered `resource_template` entries are now matched against incoming `resources/read` URIs and routed to the template's handler. Previously templates only appeared in `resources/templates/list`; reading any URI matching one returned `Resource not found`.

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -354,6 +354,16 @@ The server can call into the client (`sampling/createMessage`,
 `roots/list`, `elicitation/create`). Implement
 `barrel_mcp_client_handler` and supply it as `handler => {Mod, Args}`.
 
+If the host's roots change after `initialize` (the user opened a
+new workspace, granted access to a new directory, etc.) inform
+the server so it can re-query:
+
+```erlang
+ok = barrel_mcp_client:notify_roots_list_changed(Pid).
+```
+
+The server may follow up with `roots/list` against your handler.
+
 Three return shapes from `handle_request/3`:
 
 - `{reply, Result, State}` — synchronous answer.

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -69,6 +69,7 @@
     set_log_level/2,
     ping/1,
     cancel/2,
+    notify_roots_list_changed/1,
     reply_async/3,
     %% Introspection
     server_info/1,
@@ -347,6 +348,15 @@ ping(Pid) ->
 cancel(Pid, RequestId) ->
     gen_statem:cast(Pid, {cancel, RequestId}).
 
+%% @doc Inform the connected server that the host's roots list has
+%% changed. The server may follow up with `roots/list' to fetch
+%% the new set. Hosts that mutate their roots after `initialize'
+%% (e.g. user opened a new workspace) call this so the server
+%% picks up the change without polling.
+-spec notify_roots_list_changed(pid()) -> ok.
+notify_roots_list_changed(Pid) ->
+    gen_statem:cast(Pid, notify_roots_list_changed).
+
 %% @doc Deliver a deferred reply for a server-initiated request that
 %% the handler answered with `{async, Tag, _}'. `Result' is either a
 %% plain term (sent as the JSON-RPC `result') or
@@ -466,6 +476,11 @@ ready({call, From}, {request, Method, Params, Timeout}, Data) ->
     end;
 ready(cast, {cancel, Id}, Data) ->
     do_cancel(Id, Data);
+ready(cast, notify_roots_list_changed, Data) ->
+    send_envelope(Data,
+        barrel_mcp_protocol:encode_notification(
+            <<"notifications/roots/list_changed">>, #{})),
+    {keep_state, Data};
 ready(cast, {add_subscriber, Uri, Pid}, Data) ->
     {keep_state, add_sub(Uri, Pid, Data)};
 ready(cast, {remove_subscriber, Uri, Pid}, Data) ->

--- a/test/barrel_mcp_client_roots_SUITE.erl
+++ b/test/barrel_mcp_client_roots_SUITE.erl
@@ -1,0 +1,118 @@
+%%%-------------------------------------------------------------------
+%%% @doc Integration suite for `barrel_mcp_client:notify_roots_list_changed/1'.
+%%%
+%%% Stands up a real Streamable HTTP server, configures the
+%%% `roots_changed_handler' application env to forward inbound
+%%% `notifications/roots/list_changed' to a test process, connects
+%%% a client, calls the new emitter, and asserts the server-side
+%%% handler observed the notification.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_client_roots_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1,
+         init_per_testcase/2, end_per_testcase/2]).
+-export([client_emits_roots_list_changed/1]).
+
+%% Roots-changed handler exported for the application env hook.
+-export([roots_changed/2]).
+
+-define(BASE_PORT, 22580).
+
+all() -> [client_emits_roots_list_changed].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    {ok, _} = application:ensure_all_started(hackney),
+    ok = barrel_mcp_registry:wait_for_ready(),
+    Config.
+
+end_per_suite(_Config) ->
+    catch barrel_mcp:stop_http_stream(),
+    application:unset_env(barrel_mcp, roots_changed_handler),
+    application:stop(barrel_mcp),
+    ok.
+
+init_per_testcase(TC, Config) ->
+    Port = ?BASE_PORT + erlang:phash2(TC, 100),
+    [{port, Port} | Config].
+
+end_per_testcase(_TC, _Config) ->
+    catch barrel_mcp:stop_http_stream(),
+    application:unset_env(barrel_mcp, roots_changed_handler),
+    timer:sleep(50),
+    ok.
+
+%%====================================================================
+%% Test
+%%====================================================================
+
+client_emits_roots_list_changed(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{port => Port,
+                                              session_enabled => true}),
+
+    %% Forward inbound notifications/roots/list_changed to ourselves.
+    Self = self(),
+    register_observer(Self),
+    application:set_env(barrel_mcp, roots_changed_handler,
+                        {?MODULE, roots_changed}),
+
+    Url = iolist_to_binary(io_lib:format("http://127.0.0.1:~B/mcp",
+                                          [Port])),
+    {ok, Pid} = barrel_mcp_client:start(#{
+        transport => {http, Url}
+    }),
+    ok = wait_ready(Pid, 30),
+
+    ok = barrel_mcp_client:notify_roots_list_changed(Pid),
+
+    receive
+        {roots_list_changed, _Params} -> ok
+    after 5000 ->
+        ct:fail("server did not observe notifications/roots/list_changed")
+    end,
+
+    barrel_mcp_client:close(Pid),
+    unregister_observer(),
+    ok.
+
+%%====================================================================
+%% roots_changed_handler hook
+%%====================================================================
+
+roots_changed(Params, _State) ->
+    case observer() of
+        undefined -> ok;
+        Pid -> Pid ! {roots_list_changed, Params}, ok
+    end.
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+%% Stash the test pid in persistent_term so the application-env
+%% callback can reach it without depending on registered names.
+register_observer(Pid) ->
+    persistent_term:put({?MODULE, observer}, Pid).
+
+unregister_observer() ->
+    catch persistent_term:erase({?MODULE, observer}),
+    ok.
+
+observer() ->
+    try persistent_term:get({?MODULE, observer})
+    catch _:_ -> undefined
+    end.
+
+wait_ready(_Pid, 0) -> {error, not_ready};
+wait_ready(Pid, N) ->
+    case catch barrel_mcp_client:server_capabilities(Pid) of
+        {ok, _} -> ok;
+        _ ->
+            timer:sleep(100),
+            wait_ready(Pid, N - 1)
+    end.


### PR DESCRIPTION
## Summary

Adds the missing client→server emitter for `notifications/roots/list_changed`. The server-side dispatch hook (`application:set_env(barrel_mcp, roots_changed_handler, {Mod, Fun})`) was already in place; this closes the inverse direction.

A host using `barrel_mcp_client` can now inform the connected server when its roots list changes (user opened a workspace, granted a directory). The server may follow up with `roots/list` against the host's handler.

## What changed

- New `barrel_mcp_client:notify_roots_list_changed/1`. Casts to the gen_statem; the `ready/3` clause sends the notification via the existing `encode_notification/2` + `send_envelope/2` plumbing.
- New `test/barrel_mcp_client_roots_SUITE` end-to-end CT case: real Streamable HTTP server, `roots_changed_handler` forwarding inbound notifications to the test process.
- Mention in `guides/building-a-client.md` §10.

## Verification

243 eunit + 32 ct + dialyzer green.