### PR TITLE
Server-side OAuth Protected Resource Metadata + spec-correct WWW-Authenticate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Server-side OAuth Protected Resource Metadata + spec-correct `WWW-Authenticate`
+
+- New `resource_metadata` start option on `barrel_mcp:start_http_stream/1` and `barrel_mcp:start_http/1`. When set, the server registers a cowboy route at `/.well-known/oauth-protected-resource` that returns the configured RFC 9728 PRM document as JSON, and threads the absolute PRM URL into the auth provider's challenge.
+- **Wire change.** `barrel_mcp_auth_bearer`'s 401 challenge now emits `Bearer realm="...", resource_metadata="<URL>"` (RFC 9728 / MCP auth sub-spec) instead of the previous non-conformant `resource="..."` parameter (which conflated the RFC 8707 audience claim with the metadata URL). MCP clients can now auto-discover a barrel_mcp deployment's authorization server end-to-end by parsing `WWW-Authenticate` and following `resource_metadata`.
+- New `barrel_mcp_prm_handler` cowboy handler. Two new helpers exported from `barrel_mcp_http_stream`: `normalize_resource_metadata/1`, `inject_resource_metadata_url/2` (legacy `barrel_mcp_http` reuses them).
+- New CT cases `prm_endpoint_serves_metadata` and `bearel_challenge_includes_resource_metadata` in `barrel_mcp_http_stream_security_SUITE`.
+
 ### `barrel_mcp_client:notify_roots_list_changed/1`
 
 - New client emitter for `notifications/roots/list_changed`. Hosts that mutate their roots after `initialize` (user opened a new workspace, granted access to a new directory, …) call this so the server picks up the change without polling. The server may follow up with `roots/list` against the host's handler.

--- a/src/barrel_mcp_auth_bearer.erl
+++ b/src/barrel_mcp_auth_bearer.erl
@@ -79,12 +79,18 @@ authenticate(Request, State) ->
     {integer(), map(), binary()}.
 challenge(Reason, State) ->
     Realm = maps:get(realm, State, <<"mcp">>),
-    Resource = maps:get(resource, State, undefined),
+    %% RFC 9728 / MCP auth: emit `resource_metadata="<URL>"' so
+    %% the client can discover the AS via PRM. We previously
+    %% emitted a non-conformant `resource="..."' parameter (the
+    %% audience-claim string from RFC 8707, conflated with the
+    %% RFC 9728 metadata URL). Drop it.
+    MetaUrl = maps:get(resource_metadata_url, State, undefined),
 
     {StatusCode, ErrorCode, ErrorDesc} = error_details(Reason),
 
-    %% Build WWW-Authenticate header per RFC 6750 and MCP spec
-    Challenge = build_challenge(Realm, ErrorCode, ErrorDesc, Resource),
+    %% Build WWW-Authenticate header per RFC 6750 + RFC 9728 /
+    %% MCP authorization sub-spec.
+    Challenge = build_challenge(Realm, ErrorCode, ErrorDesc, MetaUrl),
 
     Body = iolist_to_binary(json:encode(#{
         <<"error">> => ErrorCode,
@@ -306,7 +312,7 @@ error_details({error, _}) ->
 error_details(_) ->
     {401, <<"invalid_token">>, <<"Authentication failed">>}.
 
-build_challenge(Realm, ErrorCode, ErrorDesc, Resource) ->
+build_challenge(Realm, ErrorCode, ErrorDesc, ResourceMetadataUrl) ->
     Parts = [<<"Bearer realm=\"", Realm/binary, "\"">>],
     Parts1 = case ErrorCode of
         <<"invalid_request">> -> Parts;
@@ -316,9 +322,9 @@ build_challenge(Realm, ErrorCode, ErrorDesc, Resource) ->
         <<>> -> Parts1;
         _ -> Parts1 ++ [<<" error_description=\"", ErrorDesc/binary, "\"">>]
     end,
-    Parts3 = case Resource of
+    Parts3 = case ResourceMetadataUrl of
         undefined -> Parts2;
-        R -> Parts2 ++ [<<" resource=\"", R/binary, "\"">>]
+        Url -> Parts2 ++ [<<" resource_metadata=\"", Url/binary, "\"">>]
     end,
     iolist_to_binary(lists:join(<<",">>, Parts3)).
 

--- a/src/barrel_mcp_http.erl
+++ b/src/barrel_mcp_http.erl
@@ -52,18 +52,28 @@ start(Opts) ->
         {error, _} = Err -> Err;
         {ok, AllowedOrigins} ->
             AllowMissing = maps:get(allow_missing_origin, Opts, Loopback),
-            AuthConfig = init_auth(maps:get(auth, Opts, #{})),
+            ResourceMetadata = barrel_mcp_http_stream:normalize_resource_metadata(
+                                  maps:get(resource_metadata, Opts, undefined)),
+            AuthConfig0 = init_auth(maps:get(auth, Opts, #{})),
+            AuthConfig =
+                barrel_mcp_http_stream:inject_resource_metadata_url(
+                  AuthConfig0, ResourceMetadata),
             HandlerState = #{
                 auth_config => AuthConfig,
                 allowed_origins => AllowedOrigins,
                 allow_missing_origin => AllowMissing
             },
-            Routes = [
-                {'_', [
-                    {"/mcp", ?MODULE, HandlerState},
-                    {"/", ?MODULE, HandlerState}
-                ]}
+            BaseRoutes = [
+                {"/mcp", ?MODULE, HandlerState},
+                {"/", ?MODULE, HandlerState}
             ],
+            PrmRoute = case ResourceMetadata of
+                undefined -> [];
+                #{document := Doc} ->
+                    [{"/.well-known/oauth-protected-resource",
+                        barrel_mcp_prm_handler, Doc}]
+            end,
+            Routes = [{'_', PrmRoute ++ BaseRoutes}],
             Dispatch = cowboy_router:compile(Routes),
             cowboy:start_clear(?HTTP_LISTENER, [
                 {port, Port},

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -34,7 +34,9 @@
     resolve_allowed_origins/2,
     validate_origin/2,
     cors_response_headers/3,
-    extract_headers/2
+    extract_headers/2,
+    normalize_resource_metadata/1,
+    inject_resource_metadata_url/2
 ]).
 
 %% Cowboy loop handler callbacks
@@ -104,7 +106,11 @@ start(Opts) ->
                 false -> ok
             end,
 
-            AuthConfig = init_auth(maps:get(auth, Opts, #{})),
+            ResourceMetadata = normalize_resource_metadata(
+                                  maps:get(resource_metadata, Opts, undefined)),
+            AuthConfig0 = init_auth(maps:get(auth, Opts, #{})),
+            AuthConfig = inject_resource_metadata_url(AuthConfig0,
+                                                       ResourceMetadata),
 
             HandlerState = #{
                 auth_config => AuthConfig,
@@ -114,12 +120,17 @@ start(Opts) ->
                 sse_buffer_size => maps:get(sse_buffer_size, Opts, 256)
             },
 
-            Routes = [
-                {'_', [
-                    {"/mcp", ?MODULE, HandlerState},
-                    {"/", ?MODULE, HandlerState}
-                ]}
+            BaseRoutes = [
+                {"/mcp", ?MODULE, HandlerState},
+                {"/", ?MODULE, HandlerState}
             ],
+            PrmRoute = case ResourceMetadata of
+                undefined -> [];
+                #{document := Doc} ->
+                    [{"/.well-known/oauth-protected-resource",
+                        barrel_mcp_prm_handler, Doc}]
+            end,
+            Routes = [{'_', PrmRoute ++ BaseRoutes}],
             Dispatch = cowboy_router:compile(Routes),
 
             case maps:get(ssl, Opts, undefined) of
@@ -851,6 +862,50 @@ init_auth(#{provider := Provider} = AuthOpts) ->
     AuthOpts#{provider_state => ProviderState};
 init_auth(AuthOpts) ->
     init_auth(AuthOpts#{provider => barrel_mcp_auth_none}).
+
+%% Normalise the user-facing `resource_metadata' option into the
+%% pair we need internally:
+%%   #{document := Doc, url := MetaUrl}
+%% where `Doc' is the JSON map served at the well-known URL and
+%% `url' is the absolute URL to advertise in WWW-Authenticate.
+normalize_resource_metadata(undefined) ->
+    undefined;
+normalize_resource_metadata(#{resource := ResourceUrl} = M) ->
+    Doc = maps:without([metadata_url], M),
+    MetaUrl = case maps:get(metadata_url, M, undefined) of
+        undefined -> derive_prm_url(ResourceUrl);
+        Explicit when is_binary(Explicit) -> Explicit
+    end,
+    #{document => Doc, url => MetaUrl}.
+
+%% Derive the well-known URL from the resource URL: strip path,
+%% append `/.well-known/oauth-protected-resource'.
+derive_prm_url(Resource) when is_binary(Resource) ->
+    case uri_string:parse(Resource) of
+        #{scheme := Scheme, host := Host} = Parsed ->
+            PortPart = case maps:get(port, Parsed, undefined) of
+                undefined -> <<>>;
+                P -> iolist_to_binary([<<":">>, integer_to_binary(P)])
+            end,
+            iolist_to_binary([Scheme, <<"://">>, Host, PortPart,
+                              <<"/.well-known/oauth-protected-resource">>]);
+        _ ->
+            %% Couldn't parse — fall back to appending the path
+            %% directly (will likely 404, but better than crashing
+            %% startup).
+            <<Resource/binary, "/.well-known/oauth-protected-resource">>
+    end.
+
+%% Make the PRM URL available to the auth provider's challenge
+%% so 401 responses include `resource_metadata="<URL>"' per
+%% RFC 9728 / the MCP authorization sub-spec.
+inject_resource_metadata_url(AuthConfig, undefined) ->
+    AuthConfig;
+inject_resource_metadata_url(#{provider_state := State} = AuthConfig,
+                              #{url := Url}) when is_map(State) ->
+    AuthConfig#{provider_state => State#{resource_metadata_url => Url}};
+inject_resource_metadata_url(AuthConfig, _) ->
+    AuthConfig.
 
 authenticate(#{provider := barrel_mcp_auth_none}, _Request) ->
     barrel_mcp_auth_none:authenticate(#{}, undefined);

--- a/src/barrel_mcp_prm_handler.erl
+++ b/src/barrel_mcp_prm_handler.erl
@@ -1,0 +1,28 @@
+%%%-------------------------------------------------------------------
+%%% @doc Cowboy handler for `/.well-known/oauth-protected-resource'.
+%%%
+%%% Returns the OAuth Protected Resource Metadata document
+%%% ([RFC 9728]) as JSON. Configured via the `resource_metadata'
+%%% option on `barrel_mcp_http_stream:start/1' /
+%%% `barrel_mcp_http:start/1'.
+%%%
+%%% This is the server-side counterpart of
+%%% `barrel_mcp_client_auth_oauth:discover_protected_resource/1'.
+%%% MCP clients hitting an OAuth-protected barrel_mcp server
+%%% receive a 401 with `WWW-Authenticate: Bearer ...
+%%% resource_metadata="<URL>"', follow that URL, and land here.
+%%%
+%%% [RFC 9728]: https://datatracker.ietf.org/doc/html/rfc9728
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_prm_handler).
+
+-export([init/2]).
+
+init(Req0, Metadata) when is_map(Metadata) ->
+    Body = iolist_to_binary(json:encode(Metadata)),
+    Req = cowboy_req:reply(200, #{
+        <<"content-type">> => <<"application/json">>,
+        <<"cache-control">> => <<"public, max-age=300">>
+    }, Body, Req0),
+    {ok, Req, Metadata}.

--- a/test/barrel_mcp_http_stream_security_SUITE.erl
+++ b/test/barrel_mcp_http_stream_security_SUITE.erl
@@ -33,7 +33,9 @@
     accept_only_json_rejected/1,
     accept_only_sse_rejected/1,
     accept_wildcard_ok/1,
-    initialize_with_unknown_session_returns_404/1
+    initialize_with_unknown_session_returns_404/1,
+    prm_endpoint_serves_metadata/1,
+    bearer_challenge_includes_resource_metadata/1
 ]).
 
 -define(BASE_PORT, 21100).
@@ -57,7 +59,9 @@ all() -> [
     accept_only_json_rejected,
     accept_only_sse_rejected,
     accept_wildcard_ok,
-    initialize_with_unknown_session_returns_404
+    initialize_with_unknown_session_returns_404,
+    prm_endpoint_serves_metadata,
+    bearer_challenge_includes_resource_metadata
 ].
 
 init_per_suite(Config) ->
@@ -368,6 +372,66 @@ ping_body() ->
     json:encode(#{<<"jsonrpc">> => <<"2.0">>,
                   <<"id">> => 99,
                   <<"method">> => <<"ping">>}).
+
+%%====================================================================
+%% OAuth Protected Resource Metadata (RFC 9728)
+%%====================================================================
+
+prm_endpoint_serves_metadata(Config) ->
+    Port = ?config(port, Config),
+    ResourceUrl = iolist_to_binary(io_lib:format(
+                                     "http://127.0.0.1:~B/mcp", [Port])),
+    {ok, _} = barrel_mcp:start_http_stream(#{
+        port => Port,
+        session_enabled => true,
+        resource_metadata => #{
+            resource => ResourceUrl,
+            authorization_servers => [<<"https://idp.example.com">>]
+        }
+    }),
+    PrmUrl = iolist_to_binary(io_lib:format(
+        "http://127.0.0.1:~B/.well-known/oauth-protected-resource",
+        [Port])),
+    {ok, 200, Headers, Body} = hackney:request(get, PrmUrl,
+                                                [], <<>>, [with_body]),
+    %% application/json content-type.
+    <<"application/json", _/binary>> =
+        proplists:get_value(<<"content-type">>, Headers,
+                            <<"application/json">>),
+    Doc = json:decode(Body),
+    ?assertEqual(ResourceUrl, maps:get(<<"resource">>, Doc)),
+    ?assertEqual([<<"https://idp.example.com">>],
+                 maps:get(<<"authorization_servers">>, Doc)),
+    ok.
+
+bearer_challenge_includes_resource_metadata(Config) ->
+    Port = ?config(port, Config),
+    ResourceUrl = iolist_to_binary(io_lib:format(
+                                     "http://127.0.0.1:~B/mcp", [Port])),
+    {ok, _} = barrel_mcp:start_http_stream(#{
+        port => Port,
+        session_enabled => true,
+        auth => #{provider => barrel_mcp_auth_bearer,
+                   provider_opts => #{secret => <<"top-secret">>}},
+        resource_metadata => #{
+            resource => ResourceUrl,
+            authorization_servers => [<<"https://idp.example.com">>]
+        }
+    }),
+    %% No Authorization header → 401 with the new challenge.
+    {ok, 401, Headers, _} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>}],
+        ping_body(), [with_body]),
+    Challenge = proplists:get_value(<<"www-authenticate">>, Headers),
+    ?assert(is_binary(Challenge)),
+    ExpectedSubstr = <<"resource_metadata=\"http://127.0.0.1:",
+                        (integer_to_binary(Port))/binary,
+                        "/.well-known/oauth-protected-resource\"">>,
+    ?assertNotEqual(nomatch, binary:match(Challenge, ExpectedSubstr)),
+    %% Make sure the legacy non-conformant `resource="..."' is gone.
+    ?assertEqual(nomatch, binary:match(Challenge, <<" resource=\"">>)),
+    ok.
 
 post_init(Port, ExtraHeaders) ->
     Headers = [{<<"content-type">>, <<"application/json">>},


### PR DESCRIPTION
## Summary

Closes the server-side half of the RFC 9728 / MCP auth-discovery flow. The client side already parses `WWW-Authenticate` and follows the metadata URL; until this PR the server emitted the wrong parameter name and never hosted the metadata document, so the auto-discovery loop was open at one end.

## New start option

```erlang
resource_metadata => #{
    resource              => <<"http://127.0.0.1:8080/mcp">>,
    authorization_servers => [<<"https://idp.example.com">>]
}
```

When set, the server registers `/.well-known/oauth-protected-resource` (new `barrel_mcp_prm_handler` module) and threads the absolute PRM URL into the auth provider so the bearer challenge picks it up.

## Wire change in `WWW-Authenticate`

Before: `Bearer realm="...", error="...", resource="<audience>"` — conflated the RFC 8707 audience claim with the RFC 9728 metadata URL.

After: `Bearer realm="...", error="...", resource_metadata="<absolute PRM URL>"`.

Audience-claim string stays in `state.resource` for token verification (its real purpose); only the wire emission changed.

## Verification

243 eunit + 34 ct (+2 new) + dialyzer + both interop directions green.