### PR TITLE
_meta end-to-end propagation on JSON-RPC envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `_meta` end-to-end propagation
+
+- The MCP spec defines `_meta` as the extensibility hook on every JSON-RPC envelope. Previously only `_meta.progressToken` was read on `tools/call`; everything else dropped on the floor. Now:
+  - **Inbound**: tool handler `Ctx` carries the full inbound `_meta` map under the `meta` key. `progress_token` stays for back-compat. The async plan emitted by `barrel_mcp_protocol:handle/1` for `tools/call` carries `meta` so transports without their own `_meta` extraction (stdio, legacy HTTP) get it via `barrel_mcp_protocol:drive_async_plan/2`.
+  - **Outbound**: new return shapes on tool handlers — `{result_meta, Result, MetaMap}`, `{structured_meta, Data, Content, MetaMap}`, `{tool_error, Content, MetaMap}` — surface `_meta` on the response. The existing tuple shapes are unchanged.
+  - **Envelope helpers**: new `barrel_mcp_protocol:success_response/3` and `error_response/4` accept an optional `_meta` map. Empty map omits the field. Used by every transport's tool-outcome path so the wire shape is consistent.
+- 8 new eunit cases cover the envelope helpers, `drive_async_plan` for the new result/structured/error meta variants, and an end-to-end `_meta` round-trip through a tool that echoes Ctx-supplied `_meta` back through the response.
+
 ### Server-side OAuth Protected Resource Metadata + spec-correct `WWW-Authenticate`
 
 - New `resource_metadata` start option on `barrel_mcp:start_http_stream/1` and `barrel_mcp:start_http/1`. When set, the server registers a cowboy route at `/.well-known/oauth-protected-resource` that returns the configured RFC 9728 PRM document as JSON, and threads the absolute PRM URL into the auth provider's challenge.

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -371,20 +371,19 @@ handle_async_tool_call(Req0, State, SessionId, _Method,
     Params = maps:get(<<"params">>, RequestWithAuth, #{}),
     ToolName = maps:get(<<"name">>, Params, <<>>),
     LongRunning = is_long_running_tool(ToolName),
-    ProgressToken = case Params of
-                        #{<<"_meta">> := #{<<"progressToken">> := T}} -> T;
-                        _ -> undefined
-                    end,
+    Meta = maps:get(<<"_meta">>, Params, #{}),
+    ProgressToken = maps:get(<<"progressToken">>, Meta, undefined),
     Self = self(),
     case LongRunning of
         true ->
             handle_long_running_call(Req0, State, SessionId, RequestId,
-                                      ToolName, ProgressToken, Spawn);
+                                      ToolName, ProgressToken, Meta, Spawn);
         false ->
             Ctx = #{
                 session_id => SessionId,
                 request_id => RequestId,
                 progress_token => ProgressToken,
+                meta => Meta,
                 emit_progress => emit_progress_fun(SessionId, ProgressToken),
                 reply_to => Self
             },
@@ -412,13 +411,14 @@ is_long_running_tool(Name) ->
 %% private collector that updates the task store, return the taskId
 %% to the caller right away.
 handle_long_running_call(Req0, State, SessionId, RequestId, ToolName,
-                          ProgressToken, Spawn) ->
+                          ProgressToken, Meta, Spawn) ->
     {ok, TaskId} = barrel_mcp_tasks:create(SessionId, ToolName, #{}),
     Collector = spawn_task_collector(SessionId, TaskId),
     Ctx = #{
         session_id => SessionId,
         request_id => RequestId,
         progress_token => ProgressToken,
+        meta => Meta,
         emit_progress => emit_progress_fun(SessionId, ProgressToken),
         reply_to => Collector
     },
@@ -477,10 +477,16 @@ emit_progress_fun(SessionId, Token) ->
 
 wait_for_tool(RequestId, Timeout) ->
     Outcome = receive
-        {tool_result, RequestId, Result} -> {result, Result};
+        {tool_result, RequestId, Result} -> {result, Result, #{}};
+        {tool_result_meta, RequestId, Result, Meta} ->
+            {result, Result, Meta};
         {tool_structured, RequestId, Data, Content} ->
-            {structured, Data, Content};
-        {tool_error, RequestId, Content} -> {tool_error, Content};
+            {structured, Data, Content, #{}};
+        {tool_structured_meta, RequestId, Data, Content, Meta} ->
+            {structured, Data, Content, Meta};
+        {tool_error, RequestId, Content} -> {tool_error, Content, #{}};
+        {tool_error_meta, RequestId, Content, Meta} ->
+            {tool_error, Content, Meta};
         {tool_failed, RequestId, Reason} -> {failed, Reason};
         {tool_validation_failed, RequestId, Errors} ->
             {validation_failed, Errors};
@@ -516,20 +522,20 @@ deliver_tool_outcome(Req0, State, SessionId, _RequestId, cancelled) ->
                 cors_response_headers(Req0, State, #{}), SessionId),
     Req = cowboy_req:reply(200, Headers, <<>>, Req0),
     {ok, Req, State};
-deliver_tool_outcome(Req0, State, SessionId, RequestId, {result, Result}) ->
+deliver_tool_outcome(Req0, State, SessionId, RequestId, {result, Result, Meta}) ->
     Content = barrel_mcp_protocol:format_tool_result_external(Result),
     send_tool_envelope(Req0, State, SessionId, RequestId,
-                       #{<<"content">> => Content});
+                       #{<<"content">> => Content}, Meta);
 deliver_tool_outcome(Req0, State, SessionId, RequestId,
-                      {structured, Data, Content}) ->
+                      {structured, Data, Content, Meta}) ->
     send_tool_envelope(Req0, State, SessionId, RequestId,
                        #{<<"content">> => Content,
-                         <<"structuredContent">> => Data});
+                         <<"structuredContent">> => Data}, Meta);
 deliver_tool_outcome(Req0, State, SessionId, RequestId,
-                      {tool_error, Content}) ->
+                      {tool_error, Content, Meta}) ->
     send_tool_envelope(Req0, State, SessionId, RequestId,
                        #{<<"content">> => Content,
-                         <<"isError">> => true});
+                         <<"isError">> => true}, Meta);
 deliver_tool_outcome(Req0, State, SessionId, RequestId,
                       {validation_failed, Errors}) ->
     Msg = iolist_to_binary(io_lib:format("Invalid tool input: ~p", [Errors])),
@@ -546,9 +552,10 @@ deliver_tool_outcome(Req0, State, SessionId, RequestId, timeout) ->
                                 ?MCP_TOOL_ERROR, <<"Tool timed out">>).
 
 send_tool_envelope(Req0, State, SessionId, RequestId, Result) ->
-    Resp = #{<<"jsonrpc">> => <<"2.0">>,
-             <<"id">> => RequestId,
-             <<"result">> => Result},
+    send_tool_envelope(Req0, State, SessionId, RequestId, Result, #{}).
+
+send_tool_envelope(Req0, State, SessionId, RequestId, Result, Meta) ->
+    Resp = barrel_mcp_protocol:success_response(RequestId, Result, Meta),
     Json = barrel_mcp_protocol:encode(Resp),
     Headers = add_session_header(
                 cors_response_headers(Req0, State, #{

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -15,6 +15,9 @@
     handle/1,
     handle/2,
     error_response/3,
+    error_response/4,
+    success_response/2,
+    success_response/3,
     notification_response/0
 ]).
 
@@ -98,14 +101,24 @@ handle(_, _State) ->
 %% @doc Create an error response.
 -spec error_response(term(), integer(), binary()) -> map().
 error_response(Id, Code, Message) ->
-    #{
+    error_response(Id, Code, Message, #{}).
+
+%% Optional `_meta' map on the error envelope. Empty map is
+%% omitted from the wire; the spec's `_meta' is the
+%% extensibility hook that lets server / client extensions thread
+%% state without changing the JSON-RPC surface.
+-spec error_response(term(), integer(), binary(), map()) -> map().
+error_response(Id, Code, Message, Meta) ->
+    Err = #{
+        <<"code">> => Code,
+        <<"message">> => Message
+    },
+    Env = #{
         <<"jsonrpc">> => <<"2.0">>,
         <<"id">> => Id,
-        <<"error">> => #{
-            <<"code">> => Code,
-            <<"message">> => Message
-        }
-    }.
+        <<"error">> => Err
+    },
+    add_meta(Env, Meta).
 
 %% @doc Return a marker for no response (notifications).
 -spec notification_response() -> no_response.
@@ -192,8 +205,10 @@ handle_request(<<"tools/call">>, Params, Id, _State) ->
     %% `{tool_result, _, _}', `{tool_error, _, _}',
     %% `{tool_failed, _, _}', `{tool_validation_failed, _, _}', or
     %% `{cancelled, _}' (sent by `barrel_mcp_session:cancel_in_flight/2').
+    Meta = maps:get(<<"_meta">>, Params, #{}),
     Plan = #{
         request_id => Id,
+        meta => Meta,
         spawn => fun(Ctx) ->
             case barrel_mcp_registry:run_tool(Name, Args, Ctx) of
                 {ok, Pid} -> Pid;
@@ -501,11 +516,22 @@ handle_notification(_, _Params, _State) ->
 %%====================================================================
 
 success_response(Id, Result) ->
-    #{
+    success_response(Id, Result, #{}).
+
+success_response(Id, Result, Meta) ->
+    Env = #{
         <<"jsonrpc">> => <<"2.0">>,
         <<"id">> => Id,
         <<"result">> => Result
-    }.
+    },
+    add_meta(Env, Meta).
+
+%% Add `_meta' to a JSON-RPC envelope only when the supplied map
+%% is non-empty. Keeps wire payloads compact.
+add_meta(Env, Meta) when is_map(Meta), map_size(Meta) > 0 ->
+    Env#{<<"_meta">> => Meta};
+add_meta(Env, _) ->
+    Env.
 
 %% @doc Format a tool handler's plain return value into the MCP
 %% content-block list shape. Public so transports driving async
@@ -526,9 +552,11 @@ drive_async_plan(Plan, Timeout) ->
     Self = self(),
     RequestId = maps:get(request_id, Plan),
     Spawn = maps:get(spawn, Plan),
+    Meta = maps:get(meta, Plan, #{}),
     Ctx = #{request_id => RequestId,
             session_id => undefined,
             progress_token => undefined,
+            meta => Meta,
             emit_progress => fun(_, _, _) -> ok end,
             reply_to => Self},
     _Pid = Spawn(Ctx),
@@ -536,14 +564,28 @@ drive_async_plan(Plan, Timeout) ->
         {tool_result, RequestId, Result} ->
             success_response(RequestId,
                 #{<<"content">> => format_tool_result_external(Result)});
+        {tool_result_meta, RequestId, Result, RespMeta} ->
+            success_response(RequestId,
+                #{<<"content">> => format_tool_result_external(Result)},
+                RespMeta);
         {tool_structured, RequestId, Data, Content} ->
             success_response(RequestId,
                 #{<<"content">> => Content,
                   <<"structuredContent">> => Data});
+        {tool_structured_meta, RequestId, Data, Content, RespMeta} ->
+            success_response(RequestId,
+                #{<<"content">> => Content,
+                  <<"structuredContent">> => Data},
+                RespMeta);
         {tool_error, RequestId, Content} ->
             success_response(RequestId,
                 #{<<"content">> => Content,
                   <<"isError">> => true});
+        {tool_error_meta, RequestId, Content, RespMeta} ->
+            success_response(RequestId,
+                #{<<"content">> => Content,
+                  <<"isError">> => true},
+                RespMeta);
         {tool_validation_failed, RequestId, Errors} ->
             Msg = iolist_to_binary(io_lib:format(
                 "Invalid tool input: ~p", [Errors])),

--- a/src/barrel_mcp_registry.erl
+++ b/src/barrel_mcp_registry.erl
@@ -328,17 +328,29 @@ invoke_tool_handler(Args, Ctx, #{module := M, function := F} = Handler,
 
 deliver_tool_result({tool_error, Content}, _Handler, ReplyTo, RequestId) ->
     ReplyTo ! {tool_error, RequestId, Content};
+deliver_tool_result({tool_error, Content, Meta}, _Handler, ReplyTo, RequestId)
+  when is_map(Meta) ->
+    ReplyTo ! {tool_error_meta, RequestId, Content, Meta};
 deliver_tool_result({structured, Data}, Handler, ReplyTo, RequestId) ->
-    deliver_structured(Data, default_content_for(Data), Handler, ReplyTo, RequestId);
+    deliver_structured(Data, default_content_for(Data), #{}, Handler,
+                       ReplyTo, RequestId);
 deliver_tool_result({structured, Data, Content}, Handler, ReplyTo, RequestId) ->
-    deliver_structured(Data, Content, Handler, ReplyTo, RequestId);
+    deliver_structured(Data, Content, #{}, Handler, ReplyTo, RequestId);
+deliver_tool_result({structured_meta, Data, Content, Meta}, Handler,
+                     ReplyTo, RequestId) when is_map(Meta) ->
+    deliver_structured(Data, Content, Meta, Handler, ReplyTo, RequestId);
+deliver_tool_result({result_meta, Result, Meta}, _Handler, ReplyTo, RequestId)
+  when is_map(Meta) ->
+    ReplyTo ! {tool_result_meta, RequestId, Result, Meta};
 deliver_tool_result(Result, _Handler, ReplyTo, RequestId) ->
     ReplyTo ! {tool_result, RequestId, Result}.
 
-deliver_structured(Data, Content, Handler, ReplyTo, RequestId) ->
+deliver_structured(Data, Content, Meta, Handler, ReplyTo, RequestId) ->
     case validate_tool_output(Data, Handler) of
-        ok ->
+        ok when map_size(Meta) =:= 0 ->
             ReplyTo ! {tool_structured, RequestId, Data, Content};
+        ok ->
+            ReplyTo ! {tool_structured_meta, RequestId, Data, Content, Meta};
         {error, Errors} ->
             ReplyTo ! {tool_validation_failed, RequestId,
                        {output, Errors}}

--- a/test/barrel_mcp_protocol_envelope_tests.erl
+++ b/test/barrel_mcp_protocol_envelope_tests.erl
@@ -170,3 +170,75 @@ drive_async_plan_timeout_test() ->
     ?assertMatch(#{<<"error">> := #{<<"code">> := -32000,
                                     <<"message">> := <<"Tool timed out">>}},
                  Resp).
+
+%%====================================================================
+%% _meta propagation on JSON-RPC envelopes and tool outcomes
+%%====================================================================
+
+success_response_without_meta_omits_field_test() ->
+    Resp = barrel_mcp_protocol:success_response(1, #{<<"k">> => 1}),
+    ?assertNot(maps:is_key(<<"_meta">>, Resp)).
+
+success_response_with_meta_carries_field_test() ->
+    Meta = #{<<"requestId">> => <<"abc">>},
+    Resp = barrel_mcp_protocol:success_response(1, #{<<"k">> => 1}, Meta),
+    ?assertEqual(Meta, maps:get(<<"_meta">>, Resp)).
+
+success_response_with_empty_meta_omits_field_test() ->
+    Resp = barrel_mcp_protocol:success_response(1, #{<<"k">> => 1}, #{}),
+    ?assertNot(maps:is_key(<<"_meta">>, Resp)).
+
+error_response_with_meta_carries_field_test() ->
+    Meta = #{<<"trace">> => <<"xyz">>},
+    Resp = barrel_mcp_protocol:error_response(1, -32000, <<"boom">>, Meta),
+    ?assertEqual(Meta, maps:get(<<"_meta">>, Resp)).
+
+drive_async_plan_result_meta_test() ->
+    Meta = #{<<"requestId">> => <<"abc">>},
+    Plan = #{
+        request_id => 21,
+        spawn => fun(Ctx) ->
+            ReplyTo = maps:get(reply_to, Ctx),
+            spawn(fun() ->
+                ReplyTo ! {tool_result_meta, 21, <<"ok">>, Meta}
+            end)
+        end
+    },
+    Resp = barrel_mcp_protocol:drive_async_plan(Plan, 1000),
+    ?assertEqual(Meta, maps:get(<<"_meta">>, Resp)).
+
+drive_async_plan_structured_meta_test() ->
+    Meta = #{<<"version">> => 1},
+    Data = #{<<"x">> => 1},
+    Content = [#{<<"type">> => <<"text">>, <<"text">> => <<"x=1">>}],
+    Plan = #{
+        request_id => 22,
+        spawn => fun(Ctx) ->
+            ReplyTo = maps:get(reply_to, Ctx),
+            spawn(fun() ->
+                ReplyTo ! {tool_structured_meta, 22, Data, Content, Meta}
+            end)
+        end
+    },
+    Resp = barrel_mcp_protocol:drive_async_plan(Plan, 1000),
+    ?assertEqual(Meta, maps:get(<<"_meta">>, Resp)),
+    ?assertEqual(Data,
+                 maps:get(<<"structuredContent">>,
+                          maps:get(<<"result">>, Resp))).
+
+drive_async_plan_tool_error_meta_test() ->
+    Meta = #{<<"hint">> => <<"retryable">>},
+    Content = [#{<<"type">> => <<"text">>, <<"text">> => <<"oops">>}],
+    Plan = #{
+        request_id => 23,
+        spawn => fun(Ctx) ->
+            ReplyTo = maps:get(reply_to, Ctx),
+            spawn(fun() ->
+                ReplyTo ! {tool_error_meta, 23, Content, Meta}
+            end)
+        end
+    },
+    Resp = barrel_mcp_protocol:drive_async_plan(Plan, 1000),
+    ?assertEqual(Meta, maps:get(<<"_meta">>, Resp)),
+    Result = maps:get(<<"result">>, Resp),
+    ?assertEqual(true, maps:get(<<"isError">>, Result)).

--- a/test/barrel_mcp_tools_tests.erl
+++ b/test/barrel_mcp_tools_tests.erl
@@ -12,7 +12,8 @@
     echo_tool/1,
     error_tool/1,
     map_result_tool/1,
-    list_result_tool/1
+    list_result_tool/1,
+    result_meta_tool/2
 ]).
 
 %%====================================================================
@@ -33,7 +34,9 @@ tools_test_() ->
         {"Call tool with error returns error response", fun test_call_tool_error/0},
         {"Tool with input schema is listed correctly", fun test_tool_input_schema/0},
         {"Tool annotations are surfaced in tools/list",
-         fun test_tool_annotations/0}
+         fun test_tool_annotations/0},
+        {"Tool returning {result_meta, _, _} surfaces _meta on the wire",
+         fun test_tool_result_meta/0}
      ]
     }.
 
@@ -67,6 +70,15 @@ list_result_tool(_Args) ->
         #{<<"type">> => <<"text">>, <<"text">> => <<"First">>},
         #{<<"type">> => <<"text">>, <<"text">> => <<"Second">>}
     ].
+
+%% Echoes the inbound `_meta' from Ctx so the test can verify
+%% the spec extension hook flows through end to end. Returns the
+%% `{result_meta, Result, MetaMap}' shape introduced for `_meta'
+%% propagation on responses.
+result_meta_tool(_Args, Ctx) ->
+    Inbound = maps:get(meta, Ctx, #{}),
+    {result_meta, <<"ok">>,
+     Inbound#{<<"echoedBy">> => <<"barrel_mcp">>}}.
 
 %%====================================================================
 %% Tests
@@ -236,3 +248,29 @@ test_tool_annotations() ->
     ?assertNot(maps:is_key(<<"annotations">>, PlainTool)),
     barrel_mcp_registry:unreg(tool, <<"reader">>),
     barrel_mcp_registry:unreg(tool, <<"plain">>).
+
+test_tool_result_meta() ->
+    %% The arity-2 result_meta_tool reads `_meta' from Ctx and
+    %% echoes it back via the `{result_meta, Result, MetaMap}'
+    %% return shape. Verifies _meta flows in (Ctx) and out
+    %% (response envelope).
+    ok = barrel_mcp_registry:reg(tool, <<"meta_echo">>, ?MODULE,
+                                  result_meta_tool, #{}),
+    Inbound = #{<<"requestId">> => <<"abc-123">>},
+    Request = #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => 1,
+        <<"method">> => <<"tools/call">>,
+        <<"params">> => #{<<"name">> => <<"meta_echo">>,
+                          <<"arguments">> => #{},
+                          <<"_meta">> => Inbound}
+    },
+    {async, Plan} = barrel_mcp_protocol:handle(Request),
+    Resp = barrel_mcp_protocol:drive_async_plan(Plan, 2000),
+    %% drive_async_plan threads `_meta' through Ctx, so the
+    %% echoed response should carry both the inbound key and the
+    %% one the handler added.
+    Meta = maps:get(<<"_meta">>, Resp),
+    ?assertEqual(<<"abc-123">>, maps:get(<<"requestId">>, Meta)),
+    ?assertEqual(<<"barrel_mcp">>, maps:get(<<"echoedBy">>, Meta)),
+    barrel_mcp_registry:unreg(tool, <<"meta_echo">>).


### PR DESCRIPTION
## Summary

`_meta` is the spec's extensibility hook on every JSON-RPC envelope. Previously only `_meta.progressToken` was read on `tools/call`; everything else dropped on the floor, so any spec extension relying on `_meta` couldn't round-trip.

## Inbound (`_meta` reaches the handler)

- Tool handler `Ctx` now carries the full inbound `_meta` map under the `meta` key. `progress_token` stays for back-compat.
- The async plan emitted by `barrel_mcp_protocol:handle/1` for `tools/call` carries `meta`. Transports without their own `_meta` extraction (stdio, legacy HTTP) get it through `drive_async_plan/2`.

## Outbound (`_meta` rides back on the response)

New tool return shapes:
- `{result_meta, Result, MetaMap}`
- `{structured_meta, Data, Content, MetaMap}`
- `{tool_error, Content, MetaMap}` (existing 2-tuple still works)

New envelope helpers `barrel_mcp_protocol:success_response/3` and `error_response/4` accept an optional `_meta` map. Empty map omits the wire field. Every transport's tool-outcome path threads through these.

## Verification

8 new eunit cases. 251 eunit + 34 ct + dialyzer + both interop directions green.

## Subtle bug caught while writing tests

`drive_async_plan/2`'s receive originally used `Meta` as the pattern variable, shadowing the inbound `Meta` from the outer scope. Renamed to `RespMeta`.