### PR TITLE
docs: surface the four spec-gap fixes in user-facing guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ client.
 
 ## Features
 
-- **Full MCP Protocol**: tools, resources, resource templates,
+- **Full MCP Protocol**: tools, resources, resource templates
+  (with runtime RFC 6570 expansion on `resources/read`),
   prompts, completions, sampling, **tasks** (long-running
-  operations), notifications (`*/list_changed`, `progress`,
-  `cancelled`, `resources/updated`, `tasks/changed`,
-  `replay_truncated`).
+  operations), `_meta` extension hook end-to-end, notifications
+  (`*/list_changed`, `progress`, `cancelled`,
+  `resources/updated`, `tasks/status`, `replay_truncated`).
 - **Tool handlers**: arity 1 or arity 2 (`(Args, Ctx)`) with
-  `Ctx`-driven progress and cancel hooks. Return shapes:
-  plain content, `{tool_error, ...}` (→ `isError: true`), or
-  `{structured, Data, ...}` (→ `structuredContent`).
+  `Ctx`-driven progress, cancel, and `_meta` hooks. Return
+  shapes: plain content, `{tool_error, ...}` (→ `isError: true`),
+  `{structured, Data, ...}` (→ `structuredContent`), or any of
+  the meta-bearing variants that attach `_meta` to the response.
 - **Schema validation**: opt-in `validate_input` /
   `validate_output` against registered JSON Schemas
   (`barrel_mcp_schema`).
@@ -27,7 +29,9 @@ client.
 - **Authentication**: bearer (JWT/opaque), API keys (peppered
   HMAC-SHA-256), basic (PBKDF2-SHA256), custom providers.
   Constant-time hash comparison; legacy SHA-256 hex digests still
-  verify for one release.
+  verify for one release. RFC 9728 Protected Resource Metadata
+  endpoint with spec-correct `WWW-Authenticate` for OAuth client
+  auto-discovery.
 - **Client library** (`barrel_mcp_client`): supervised
   `gen_statem` with stdio + Streamable HTTP transports, OAuth 2.1
   + PKCE, federation registry (one connection per server id),

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -392,6 +392,55 @@ Authentication failures return proper HTTP status codes and WWW-Authenticate hea
 | `invalid_credentials` | 401 | Wrong username/password or API key |
 | `insufficient_scope` | 403 | Token lacks required scopes |
 
+## OAuth Protected Resource Metadata (RFC 9728)
+
+For OAuth-protected deployments, MCP clients auto-discover the
+authorization server by:
+
+1. Hitting any endpoint and receiving a 401 with
+   `WWW-Authenticate: Bearer ... resource_metadata="<URL>"`.
+2. Following the URL to fetch the
+   [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)
+   Protected Resource Metadata document.
+3. Reading `authorization_servers` from the document and
+   completing the OAuth dance against one of them.
+
+The server side of this loop is opt-in via a `resource_metadata`
+option on `barrel_mcp:start_http_stream/1` (and
+`start_http/1`):
+
+```erlang
+{ok, _} = barrel_mcp:start_http_stream(#{
+    port => 8080,
+    auth => #{provider => barrel_mcp_auth_bearer,
+              provider_opts => #{secret => Secret}},
+    resource_metadata => #{
+        resource              => <<"http://localhost:8080/mcp">>,
+        authorization_servers => [<<"https://idp.example.com">>]
+    }
+}).
+```
+
+When set:
+
+- `/.well-known/oauth-protected-resource` is registered as a
+  cowboy route and serves the metadata document as JSON.
+- The bearer challenge on 401 emits
+  `resource_metadata="<absolute PRM URL>"`. The PRM URL is
+  derived from `resource` by default; pass
+  `metadata_url => <<"https://...">>` in the option map to
+  override.
+
+The audience-claim string in `state.resource` (used for token
+verification by `barrel_mcp_auth_bearer`) is unaffected; only
+the wire emission of `WWW-Authenticate` changed.
+
+The client side is implemented by
+`barrel_mcp_client_auth_oauth:parse_www_authenticate/1` and
+`discover_protected_resource/1` — together with the server side
+above, the MCP authorization sub-spec discovery flow works
+end-to-end.
+
 ## Security Best Practices
 
 1. **Always use TLS** in production

--- a/guides/features.md
+++ b/guides/features.md
@@ -42,7 +42,12 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
 
 - **Tools** — handlers may be arity 1 or arity 2. Arity-2
   handlers receive a `Ctx` map with `session_id`, `request_id`,
-  `progress_token`, and an `emit_progress` function.
+  `progress_token`, the inbound `meta` map (the spec's `_meta`
+  extension hook), and an `emit_progress` function.
+  Meta-bearing return shapes (`{result_meta, Result, Map}`,
+  `{structured_meta, Data, Content, Map}`,
+  `{tool_error, Content, Map}`) attach `_meta` to the response
+  envelope.
 - **Resources** — text/binary content, MIME types,
   `notifications/resources/updated` for live updates. Handlers
   may return a single block (`#{text := _}` /
@@ -50,7 +55,10 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
   `annotations`) or a list of pre-built content blocks for
   multi-part responses.
 - **Resource templates** — RFC 6570 URI templates, surfaced via
-  `resources/templates/list`.
+  `resources/templates/list`. `resources/read` against a URI
+  matching a registered template auto-expands the variables
+  (Level 1, simple `{var}` substitutions) and routes to the
+  template handler with the substituted values in `Args`.
 - **Prompts** — multi-message conversation templates with
   arguments.
 - **Completions** — keyed by `{prompt, Name, Arg}` or
@@ -101,6 +109,13 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
   `barrel_mcp_auth_apikey:hash_key/2` produces a peppered HMAC-SHA-256
   digest. Both verifiers accept legacy hex SHA-256 digests for one
   release. All comparisons are constant-time.
+- **OAuth 2.0 Protected Resource Metadata** (RFC 9728): pass
+  `resource_metadata => #{resource, authorization_servers}` to
+  `start_http_stream/1` / `start_http/1` to expose
+  `/.well-known/oauth-protected-resource' and have the bearer
+  challenge emit `WWW-Authenticate: Bearer ...
+  resource_metadata="<URL>"` so MCP clients auto-discover the
+  authorization server.
 
 ### Server-to-client primitives
 
@@ -149,6 +164,10 @@ by the spec.
   `barrel_mcp_pagination:walk/1`.
 - Cancellation: `barrel_mcp_client:cancel/2` sends
   `notifications/cancelled` and unblocks the caller.
+- Roots changes: `barrel_mcp_client:notify_roots_list_changed/1`
+  emits `notifications/roots/list_changed` to inform the server
+  the host's roots have changed. The server may re-issue
+  `roots/list`.
 - Progress: pass `progress_token` to `call_tool/4` and the caller
   receives `{mcp_progress, Token, Params}` for every matching
   `notifications/progress` until the request settles.

--- a/guides/tools-resources-prompts.md
+++ b/guides/tools-resources-prompts.md
@@ -126,6 +126,7 @@ argument is a context map the runtime fills in:
 %%   session_id     :: binary() | undefined,
 %%   request_id     :: integer() | binary(),
 %%   progress_token :: binary() | undefined,
+%%   meta           :: map(),  %% inbound _meta from the request
 %%   emit_progress  :: fun((Done, Total, Message | undefined) -> ok)
 download(Args, Ctx) ->
     Url = maps:get(<<"url">>, Args),
@@ -141,9 +142,25 @@ Arity-2 handlers are needed for tools that:
 - emit `notifications/progress` updates,
 - cooperate with `notifications/cancelled` (the worker receives
   `{cancel, RequestId}` in its mailbox),
-- need the calling session id for server→client primitives.
+- need the calling session id for server→client primitives,
+- read or echo the request's `_meta` extension hook (available
+  as `maps:get(meta, Ctx, #{})`).
 
 Arity-1 handlers continue to work; pick whichever arity you need.
+
+#### Returning `_meta` on the response
+
+Tool handlers may attach a `_meta` map to the response envelope
+by returning one of the meta-bearing tuples:
+
+- `{result_meta, Result, MetaMap}` — plain result + `_meta`.
+- `{structured_meta, Data, Content, MetaMap}` —
+  `structuredContent` + `_meta`.
+- `{tool_error, Content, MetaMap}` — error result + `_meta`.
+
+Empty maps are omitted from the wire. The plain
+`{tool_error, Content}` and `{structured, Data, Content}`
+shapes still work; `_meta` is opt-in.
 
 ### Long-running tools (tasks)
 
@@ -449,11 +466,21 @@ barrel_mcp:reg_resource_template(<<"file">>, my_resources, read_file_uri, #{
 }).
 ```
 
+`resources/read` against a templated URI is matched and routed
+to the template handler automatically — RFC 6570 Level 1
+substitutions (simple `{var}` expansion) cover what the spec's
+reference examples use. The substituted variables are merged
+into the handler's `Args` map under their template names:
+
+```erlang
+%% file:///{path} matched against file:///etc/hosts
+read_file_uri(#{<<"path">> := Path} = _Args) ->
+    file:read_file(<<"/", Path/binary>>).
+```
+
 `barrel_mcp:list_resource_templates/0` lists registrations.
-Templates surface on the wire via `resources/templates/list`. The
-matching `resources/read` request still goes through your normal
-resource handler (or directly through the template handler if you
-implement URI parsing yourself).
+Templates also surface on the wire via
+`resources/templates/list`.
 
 ## Completions
 


### PR DESCRIPTION
## Summary

Updates the guides + README to cover the four features that landed since v1.2.0. No code changes.

- **`guides/tools-resources-prompts.md`** — `resources/read` template expansion behaviour with example handler reading the substituted variable; Ctx documentation now shows the `meta` field; new section calling out the meta-bearing tool return shapes (`result_meta` / `structured_meta` / `tool_error` 3-tuple).
- **`guides/authentication.md`** — new section on RFC 9728 Protected Resource Metadata: the `resource_metadata` start option, the cowboy route, the spec-correct `WWW-Authenticate` emission, and how it pairs with the existing client-side discovery.
- **`guides/features.md`** — auth bullet adds OAuth PRM; client section adds `notify_roots_list_changed/1`; tool / resource bullets call out `_meta` and runtime template expansion.
- **`README.md`** — features list mentions runtime template expansion, `_meta` end-to-end, and PRM auto-discovery.

Doc snippet check still green.