### PR TITLE
Enterprise-Managed Authorization grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Enterprise-Managed Authorization grant
+
+- New connect-spec entry `auth => {oauth_enterprise, Config}` chains an IdP-issued ID Token (or SAML assertion) through RFC 8693 token-exchange (at the IdP) and RFC 7523 jwt-bearer (at the AS) into a short-lived MCP access token. Required Config keys: `idp_token_endpoint`, `as_token_endpoint`, `client_id`, `subject_token`, `subject_token_type`, `audience`, `resource`. Optional `client_secret` / `client_assertion`, `scopes`. Implements the second half of `modelcontextprotocol/ext-auth` for SSO-driven MCP hosts.
+- New public exchangers `barrel_mcp_client_auth_oauth:token_exchange/2` and `jwt_bearer/2` for hosts that want to drive each step directly.
+- The handle re-walks the chain on every 401 (no `refresh_token` involved). When the IdP returns `invalid_grant` the library surfaces the typed `{error, subject_token_expired}` so the host can re-acquire from its IdP without parsing JSON.
+
 ### `_meta` end-to-end propagation
 
 - The MCP spec defines `_meta` as the extensibility hook on every JSON-RPC envelope. Previously only `_meta.progressToken` was read on `tools/call`; everything else dropped on the floor. Now:

--- a/docs/pending-features.md
+++ b/docs/pending-features.md
@@ -10,202 +10,56 @@ If you want one of these prioritised, open an issue.
 
 ---
 
-## Enterprise-Managed Authorization (MCP `ext-auth` extension)
+## Dynamic Client Registration (RFC 7591)
 
 > **Status:** not implemented.
-> **Spec:** [`modelcontextprotocol/ext-auth` —
-> `enterprise-managed-authorization`][ema-spec].
-> **Companion already shipped:** OAuth Client Credentials grant
-> (`auth => {oauth_client_credentials, Config}`).
+> **Spec:** [RFC 7591][rfc7591].
 
-### Why
-
-Enterprise deployments where every MCP client (and every other
-internal tool) trusts the org's central Identity Provider, and a
-user's existing SSO session should grant access to MCP servers
-**without** a fresh OAuth dance per server. The flow chains an
-ID Token from the IdP through an RFC 8693 token-exchange and an
-RFC 7523 JWT-bearer access-token request to land on a
-short-lived MCP access token.
-
-For agent hosts running unattended, the existing Client
-Credentials grant already covers the M2M case. EMA only matters
-when there's a real user behind the agent and the host wants
-their identity to flow through to the MCP server.
-
-### Wire flow (verbatim from the spec)
-
-1. **User authenticates at IdP** via OIDC or SAML (host
-   responsibility — the library does not drive a browser).
-   Output: an ID Token (`urn:ietf:params:oauth:token-type:id_token`)
-   or SAML assertion (`urn:ietf:params:oauth:token-type:saml2`).
-
-2. **Token exchange at IdP**'s token endpoint
-   ([RFC 8693][rfc8693]):
-
-   - `grant_type` = `urn:ietf:params:oauth:grant-type:token-exchange`
-   - `requested_token_type` = `urn:ietf:params:oauth:token-type:id-jag`
-   - `audience` = AS issuer URL (the MCP server's authorization
-     server)
-   - `resource` = MCP server's RFC 9728 resource identifier
-   - `subject_token` = ID Token / SAML assertion from step 1
-   - `subject_token_type` = matches the input token type
-
-   Returns an Identity Assertion JWT (the "ID-JAG"). The JWT
-   header `typ` MUST be `oauth-id-jag+jwt`. Required claims:
-   `iss`, `sub`, `aud`, `resource`, `client_id`, `jti`, `exp`,
-   `iat`.
-
-3. **Access-token request at AS**'s token endpoint
-   ([RFC 7523][rfc7523]):
-
-   - `grant_type` = `urn:ietf:params:oauth:grant-type:jwt-bearer`
-   - `assertion` = ID-JAG from step 2
-
-   The `aud` of the assertion MUST be the AS issuer URL.
-   `client_id` of the assertion MUST match the authenticating
-   client.
-
-4. **Bearer token returned** — used like any OAuth access token
-   on subsequent MCP requests.
+Hosts that don't have a pre-issued `client_id` for the target
+authorization server can register one programmatically. Common
+when distributing an MCP host (each user instance gets its own
+client) or in lab / dev setups against a fresh AS. The AS
+metadata document advertises the endpoint via
+`registration_endpoint`.
 
 ### Library work
 
-Most of the plumbing already exists from `client_credentials/2`
-and the auth-code grant; EMA is a thin set of additions on top.
-
-#### `barrel_mcp_client_auth_oauth`
-
-Add two new exchangers:
+A single new exchanger:
 
 ```erlang
--spec token_exchange(IdpTokenEndpoint, Params) ->
-    {ok, IdJagJwt :: binary()} | {error, term()} when
-    Params :: #{
-        client_id := binary(),
-        client_secret => binary() | undefined,
-        client_assertion => binary() | undefined,
-        subject_token := binary(),
-        subject_token_type := binary(),  %% id_token | saml2
-        audience := binary(),            %% AS issuer URL
-        resource := binary()             %% MCP server URL
-    }.
-%% Sends the RFC 8693 request, returns the ID-JAG (extracted
-%% from `access_token' field of the response per RFC 8693).
-
--spec jwt_bearer(AsTokenEndpoint, Params) ->
-    {ok, AccessTokenResponse :: map()} | {error, term()} when
-    Params :: #{
-        client_id := binary(),
-        client_secret => binary() | undefined,
-        assertion := binary(),           %% the ID-JAG
-        scopes => [binary()],
-        resource => binary()
-    }.
-%% Sends the RFC 7523 request, returns the standard token
-%% response (`access_token`, `expires_in`, optional
-%% `refresh_token`).
+-spec register_client(RegistrationEndpoint :: binary(),
+                       Metadata :: map()) ->
+    {ok, ClientInfo :: map()} | {error, term()}.
 ```
 
-Both reuse `http_post_form/4` from the existing module. The
-`Authorization` header for client authentication mirrors what
-`client_credentials/2` does today: HTTP Basic when a
-`client_secret` is supplied, body-only when only `client_id`,
-`private_key_jwt` when a `client_assertion` is supplied.
+`Metadata` is the RFC 7591 client metadata map (`redirect_uris`,
+`client_name`, `grant_types`, `response_types`, `scope`,
+`token_endpoint_auth_method`, …). The response — `client_id`,
+optional `client_secret`, `client_id_issued_at`,
+`client_secret_expires_at`, plus any echoed metadata — flows
+back to the caller verbatim. The host then feeds the returned
+`client_id` (and `client_secret`, if any) into a subsequent
+`{oauth, ...}` / `{oauth_client_credentials, ...}` /
+`{oauth_enterprise, ...}` connect spec.
 
-#### A new `init/1` mode and connect-spec entry
+This stays a **standalone exchanger** — not auto-wired into
+`init/1`. Auto-registration on first connect would need the
+library to persist credentials somewhere (file? ETS?), which
+is host policy.
 
-```erlang
-init(#{grant_type := enterprise_managed,
-       idp_token_endpoint := IDP,
-       as_token_endpoint := AS,
-       client_id := CI,
-       subject_token := ST,
-       subject_token_type := STT,
-       audience := Aud,
-       resource := Res} = Cfg) ->
-    case token_exchange(IDP, ...) of
-        {ok, IDJAG} ->
-            case jwt_bearer(AS, #{client_id => CI,
-                                   client_secret => ...,
-                                   assertion => IDJAG,
-                                   resource => Res,
-                                   scopes => maps:get(scopes, Cfg, undefined)}) of
-                {ok, #{<<"access_token">> := AT} = R} ->
-                    {ok, #h{
-                        access_token = AT,
-                        ...,
-                        mode = enterprise_managed,
-                        idp_token_endpoint = IDP,
-                        as_token_endpoint = AS,
-                        subject_token = ST,
-                        subject_token_type = STT,
-                        audience = Aud,
-                        resource = Res
-                    }};
-                ...
-            end;
-        ...
-    end.
-```
+### Tests
 
-`refresh/2` in `enterprise_managed` mode re-walks the chain
-(token-exchange + jwt-bearer) using the stored `subject_token`.
-If the IdP returns `invalid_grant` (subject token expired), the
-library surfaces `{error, subject_token_expired}` and the host
-must re-acquire the ID Token from the IdP — that's a host
-responsibility, the library doesn't drive browser flows.
+Extend the existing cowboy mock in
+`test/barrel_mcp_client_auth_oauth_tests.erl` with a
+`/oauth/register` route. Cases:
 
-#### `barrel_mcp_client_auth`
-
-```erlang
-new({oauth_enterprise, Config}) when is_map(Config) ->
-    Cfg = Config#{grant_type => enterprise_managed},
-    case barrel_mcp_client_auth_oauth:init(Cfg) of
-        {ok, H} -> {barrel_mcp_client_auth_oauth, H};
-        Err -> Err
-    end;
-```
-
-Plus type-spec update on `barrel_mcp_client:connect_spec()`.
-
-#### Tests
-
-Mirror the existing `barrel_mcp_client_auth_oauth_tests`
-pattern — extend the cowboy mock to handle two endpoints (IdP
-token-exchange + AS jwt-bearer):
-
-1. `token_exchange/2` happy path: assert grant_type,
-   `requested_token_type`, `subject_token`, response JWT
-   captured.
-2. `jwt_bearer/2` happy path: assert the `assertion` parameter
-   carries the ID-JAG, response yields a Bearer token.
-3. End-to-end via `{oauth_enterprise, Config}` connect-spec
-   entry. Header surfaces the access_token. 401 triggers a
-   re-walk and a new access_token.
-4. `subject_token_expired` path: IdP returns
-   `invalid_grant` → `refresh/2` returns the typed error.
-
-### Out-of-band concerns
-
-- **JWT validation** of the ID-JAG is the AS's job, not the
-  client's. We don't need to verify or sign anything.
-- **IdP discovery** is out of scope: the spec assumes the host
-  knows the IdP token endpoint up front (it's enterprise
-  config, not a per-server discovery). RFC 9728 PRM only points
-  at the AS, not the IdP.
-- **SAML flows** (`subject_token_type:saml2`) reuse the same
-  RFC 8693 wire shape. The library treats `subject_token` as
-  opaque — both OIDC and SAML modes hit the same code path.
+1. AS returns just `client_id`; function returns the response
+   map verbatim.
+2. AS issues both `client_id` and `client_secret`.
+3. 4xx error path returns `{error, {http_error, 4xx, Body}}`.
 
 ### Estimated size
 
-~300 LOC across `barrel_mcp_client_auth_oauth.erl`,
-`barrel_mcp_client_auth.erl`, and the connect-spec type, plus
-~150 LOC of tests. Reuses existing `http_post_form/4`,
-`urlencode/1`, `add_optional/3`, and the cowboy mock pattern in
-the existing eunit suite.
+~80 LOC + ~50 LOC of tests.
 
-[ema-spec]: https://github.com/modelcontextprotocol/ext-auth/blob/main/specification/draft/enterprise-managed-authorization.mdx
-[rfc8693]: https://datatracker.ietf.org/doc/html/rfc8693
-[rfc7523]: https://datatracker.ietf.org/doc/html/rfc7523
+[rfc7591]: https://datatracker.ietf.org/doc/html/rfc7591

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -392,6 +392,151 @@ Authentication failures return proper HTTP status codes and WWW-Authenticate hea
 | `invalid_credentials` | 401 | Wrong username/password or API key |
 | `insufficient_scope` | 403 | Token lacks required scopes |
 
+## OAuth grant flows
+
+`barrel_mcp_client` ships three grants; pick by **who is in the
+loop and when**:
+
+### Authorization Code + PKCE — interactive
+
+For flows where a real user authorises the host. Browser
+redirect, PKCE prevents code interception, refresh on 401.
+
+```
+User    Host                   AS                  MCP server
+ │  click "connect"             │                       │
+ │──►│ redirect + PKCE          │                       │
+ │   │─────────────────────────►│                       │
+ │   │ login + consent          │                       │
+ │   │◄─────────────────────────│                       │
+ │   │ exchange_code +          │                       │
+ │   │ code_verifier            │                       │
+ │   │─────────────────────────►│                       │
+ │   │ access_token +           │                       │
+ │   │ refresh_token            │                       │
+ │   │◄─────────────────────────│                       │
+ │   │ Bearer access_token                              │
+ │   │──────────────────────────────────────────────────►│
+ │   │       (on 401: refresh_token grant)              │
+```
+
+```erlang
+auth => {oauth, #{
+    access_token   => <<"...">>,            % required
+    refresh_token  => <<"...">>,            % optional, enables refresh
+    token_endpoint => <<"https://idp/oauth/token">>,
+    client_id      => <<"...">>,
+    client_secret  => <<"...">>,            % optional confidential client
+    resource       => <<"https://mcp/...">>,
+    scopes         => [<<"mcp.read">>, <<"mcp.write">>]
+}}
+```
+
+The host drives the browser dance and feeds the resulting tokens
+in. The library handles the refresh.
+
+### Client Credentials — unattended (M2M)
+
+For agent hosts running without a human. The host already has
+its own credentials.
+
+```
+Host                              AS                  MCP server
+ │  POST /token                    │                       │
+ │  grant=client_credentials       │                       │
+ │  + Basic <client_id:secret>     │                       │
+ │────────────────────────────────►│                       │
+ │  access_token                   │                       │
+ │◄────────────────────────────────│                       │
+ │  Bearer access_token                                    │
+ │────────────────────────────────────────────────────────►│
+ │             (on 401: re-acquire via same grant)         │
+```
+
+```erlang
+auth => {oauth_client_credentials, #{
+    token_endpoint   => <<"https://idp/oauth/token">>,
+    client_id        => <<"my-agent-host">>,
+    client_secret    => <<"...">>,          % OR client_assertion (JWT)
+    resource         => <<"https://mcp/...">>,
+    scopes           => [<<"mcp.read">>]
+}}
+```
+
+Eager fetch on init — a misconfigured client fails up front.
+Re-acquires via the same grant on 401. No `refresh_token` is
+involved.
+
+### Enterprise-Managed Authorization — SSO chain
+
+For SSO-driven hosts. The user already has a session at the org
+IdP; their identity flows into a short-lived MCP access token
+without re-prompting. Two-step chain (RFC 8693 → RFC 7523).
+
+```
+User    Host        IdP             AS                MCP server
+ │  active SSO session              │                       │
+ │  ID Token                        │                       │
+ │ ─────────►│                      │                       │
+ │           │ POST /token          │                       │
+ │           │ grant=token-exchange │                       │
+ │           │ subject_token=<id_token>                     │
+ │           │ audience=<AS issuer> │                       │
+ │           │ resource=<MCP url>   │                       │
+ │           │─────────────────────►│                       │
+ │           │ ID-JAG (signed JWT)  │                       │
+ │           │◄─────────────────────│                       │
+ │           │ POST /token          │                       │
+ │           │ grant=jwt-bearer     │                       │
+ │           │ assertion=<ID-JAG>   │                       │
+ │           │─────────────────────►│                       │
+ │           │  access_token        │                       │
+ │           │◄─────────────────────│                       │
+ │           │  Bearer access_token                         │
+ │           │─────────────────────────────────────────────►│
+ │           │ (on 401: re-walk the chain)                 │
+ │           │ (id_token expires →                         │
+ │           │  {error, subject_token_expired})            │
+```
+
+```erlang
+auth => {oauth_enterprise, #{
+    idp_token_endpoint => <<"https://idp/oauth/token">>,
+    as_token_endpoint  => <<"https://as/oauth/token">>,
+    client_id          => <<"...">>,
+    client_secret      => <<"...">>,        % OR client_assertion
+    subject_token      => <IdToken>,        % from IdP, opaque
+    subject_token_type =>
+        <<"urn:ietf:params:oauth:token-type:id_token">>, % or saml2
+    audience           => <<"https://as">>,
+    resource           => <<"https://mcp/...">>,
+    scopes             => [<<"mcp.read">>]
+}}
+```
+
+The library treats `subject_token` as opaque — both OIDC and
+SAML modes hit the same code path. The browser flow at the IdP
+stays a host concern.
+
+### Where they overlap on the wire
+
+All three grants hit the same OAuth-server token endpoint with
+`application/x-www-form-urlencoded` bodies. Confidential clients
+authenticate with HTTP Basic; `private_key_jwt` clients pass a
+`client_assertion` instead. RFC 8707 `resource` is attached on
+every grant. The MCP `2025-11-25` auth sub-spec layers
+[RFC 9728 PRM](#oauth-protected-resource-metadata-rfc-9728) on
+top so any of the three can be auto-discovered from a `401`
+response.
+
+### When to pick which
+
+| Situation | Grant |
+|---|---|
+| Real user, browser available, host wants their identity | `auth_code` (`{oauth, ...}`) |
+| Background agent / cron / unattended host | `client_credentials` (`{oauth_client_credentials, ...}`) |
+| Enterprise SSO; user identity must flow to MCP | `enterprise_managed` (`{oauth_enterprise, ...}`) |
+
 ## OAuth Protected Resource Metadata (RFC 9728)
 
 For OAuth-protected deployments, MCP clients auto-discover the

--- a/guides/features.md
+++ b/guides/features.md
@@ -204,8 +204,9 @@ by the spec.
   - PKCE: `gen_code_verifier/0`, `code_challenge/1` (S256),
     `build_authorization_url/2`.
   - Token endpoint: `exchange_code/2`, `refresh_token/2`,
-    `client_credentials/2`. All three attach the RFC 8707 `resource`
-    parameter; confidential clients use HTTP Basic.
+    `client_credentials/2`, `token_exchange/2`, `jwt_bearer/2`.
+    All attach the RFC 8707 `resource` parameter; confidential
+    clients use HTTP Basic.
   - Client Credentials grant (MCP `ext-auth` extension) for
     unattended agent hosts: pass
     `auth => {oauth_client_credentials, Config}` on the connect
@@ -215,6 +216,17 @@ by the spec.
     The library fetches the token eagerly during `init/1` and
     re-acquires via the same grant on 401 — no refresh_token
     needed.
+  - Enterprise-Managed Authorization (MCP `ext-auth` EMA) for
+    SSO-driven hosts: pass `auth => {oauth_enterprise, Config}`.
+    Required keys: `idp_token_endpoint`, `as_token_endpoint`,
+    `client_id`, `subject_token` (an IdP ID Token / SAML
+    assertion the host obtained out of band),
+    `subject_token_type`, `audience`, `resource`. The handle
+    chains RFC 8693 token-exchange at the IdP through
+    RFC 7523 jwt-bearer at the AS and re-walks the same chain
+    on 401. An expired subject token surfaces as
+    `{error, subject_token_expired}` so the host can re-acquire
+    from the IdP.
   - As an auth handle: when used through `auth => {oauth, Config}` on
     the client spec, the library attaches `Authorization: Bearer ...`
     on every request and runs the refresh-token grant on 401 if a

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -90,7 +90,8 @@
       auth => none
             | {bearer, binary()}
             | {oauth, map()}
-            | {oauth_client_credentials, map()},
+            | {oauth_client_credentials, map()}
+            | {oauth_enterprise, map()},
       protocol_version => binary(),
       request_timeout => pos_integer(),
       init_timeout => pos_integer(),

--- a/src/barrel_mcp_client_auth.erl
+++ b/src/barrel_mcp_client_auth.erl
@@ -28,6 +28,13 @@
 %%       Credentials extension). For unattended agent hosts. Config
 %%       requires `token_endpoint' and `client_id'; supply either
 %%       `client_secret' or `client_assertion' (private_key_jwt).
+%%   `{oauth_enterprise, Config}' — Enterprise-Managed Authorization
+%%       (MCP `ext-auth' EMA). Chains an IdP-issued ID Token through
+%%       RFC 8693 token-exchange and RFC 7523 jwt-bearer to mint a
+%%       short-lived MCP access token. For SSO-driven hosts. Config
+%%       requires `idp_token_endpoint', `as_token_endpoint',
+%%       `client_id', `subject_token', `subject_token_type',
+%%       `audience', `resource'.
 -callback init(Config :: term()) -> {ok, handle()} | {error, term()}.
 
 %% Return the value to put in the `Authorization' header.
@@ -49,7 +56,8 @@
 -spec new(none
         | {bearer, binary()}
         | {oauth, map()}
-        | {oauth_client_credentials, map()}) ->
+        | {oauth_client_credentials, map()}
+        | {oauth_enterprise, map()}) ->
     t() | {error, term()}.
 new(none) ->
     none;
@@ -65,6 +73,12 @@ new({oauth, Config}) when is_map(Config) ->
     end;
 new({oauth_client_credentials, Config}) when is_map(Config) ->
     Cfg = Config#{grant_type => client_credentials},
+    case barrel_mcp_client_auth_oauth:init(Cfg) of
+        {ok, H} -> {barrel_mcp_client_auth_oauth, H};
+        Err -> Err
+    end;
+new({oauth_enterprise, Config}) when is_map(Config) ->
+    Cfg = Config#{grant_type => enterprise_managed},
     case barrel_mcp_client_auth_oauth:init(Cfg) of
         {ok, H} -> {barrel_mcp_client_auth_oauth, H};
         Err -> Err

--- a/src/barrel_mcp_client_auth_oauth.erl
+++ b/src/barrel_mcp_client_auth_oauth.erl
@@ -70,7 +70,9 @@
     build_authorization_url/2,
     exchange_code/2,
     refresh_token/2,
-    client_credentials/2
+    client_credentials/2,
+    token_exchange/2,
+    jwt_bearer/2
 ]).
 
 -export_type([config/0, handle/0]).
@@ -83,7 +85,8 @@
     client_secret => binary(),
     resource => binary(),
     scopes => [binary()]
-} | client_credentials_config().
+} | client_credentials_config()
+  | enterprise_managed_config().
 
 -type client_credentials_config() :: #{
     grant_type := client_credentials,
@@ -92,6 +95,27 @@
     client_secret => binary(),
     client_assertion => binary(),
     resource => binary(),
+    scopes => [binary()]
+}.
+
+-type enterprise_managed_config() :: #{
+    grant_type := enterprise_managed,
+    %% IdP token endpoint (RFC 8693 token-exchange).
+    idp_token_endpoint := binary(),
+    %% Authorization server token endpoint (RFC 7523 jwt-bearer).
+    as_token_endpoint := binary(),
+    client_id := binary(),
+    client_secret => binary(),
+    client_assertion => binary(),
+    %% IdP-issued ID Token or SAML assertion the host obtained
+    %% out of band (browser flow, SSO).
+    subject_token := binary(),
+    %% Spec URN: `id_token' or `saml2'.
+    subject_token_type := binary(),
+    %% AS issuer URL — the `aud' the IdP signs into the ID-JAG.
+    audience := binary(),
+    %% MCP server's RFC 9728 resource identifier.
+    resource := binary(),
     scopes => [binary()]
 }.
 
@@ -104,7 +128,12 @@
     client_assertion :: binary() | undefined,
     resource :: binary() | undefined,
     scopes :: [binary()] | undefined,
-    mode = auth_code :: auth_code | client_credentials
+    mode = auth_code :: auth_code | client_credentials | enterprise_managed,
+    %% Enterprise-managed-only state (RFC 8693 + RFC 7523 chain).
+    idp_token_endpoint :: binary() | undefined,
+    subject_token :: binary() | undefined,
+    subject_token_type :: binary() | undefined,
+    audience :: binary() | undefined
 }).
 
 -type handle() :: #h{}.
@@ -144,6 +173,43 @@ init(#{grant_type := client_credentials,
     end;
 init(#{grant_type := client_credentials}) ->
     {error, missing_token_endpoint_or_client_id};
+%% Enterprise-managed authorization (MCP `ext-auth' EMA):
+%% RFC 8693 token-exchange at the IdP -> ID-JAG, then RFC 7523
+%% jwt-bearer at the AS -> short-lived MCP access token.
+init(#{grant_type := enterprise_managed,
+       idp_token_endpoint := IDP,
+       as_token_endpoint := AS,
+       client_id := CI,
+       subject_token := ST,
+       subject_token_type := STT,
+       audience := Aud,
+       resource := Res} = Cfg)
+  when is_binary(IDP), IDP =/= <<>>,
+       is_binary(AS),  AS  =/= <<>>,
+       is_binary(CI),  CI  =/= <<>>,
+       is_binary(ST),  ST  =/= <<>>,
+       is_binary(STT), STT =/= <<>>,
+       is_binary(Aud), Aud =/= <<>>,
+       is_binary(Res), Res =/= <<>> ->
+    H0 = #h{
+        token_endpoint = AS,
+        client_id = CI,
+        client_secret = maps:get(client_secret, Cfg, undefined),
+        client_assertion = maps:get(client_assertion, Cfg, undefined),
+        resource = Res,
+        scopes = maps:get(scopes, Cfg, undefined),
+        mode = enterprise_managed,
+        idp_token_endpoint = IDP,
+        subject_token = ST,
+        subject_token_type = STT,
+        audience = Aud
+    },
+    case acquire_via_ema(H0) of
+        {ok, H1} -> {ok, H1};
+        {error, _} = Err -> Err
+    end;
+init(#{grant_type := enterprise_managed}) ->
+    {error, missing_endpoints_or_subject_token};
 init(_) ->
     {error, missing_access_token}.
 
@@ -156,6 +222,8 @@ header(#h{access_token = AT}) ->
 %% No refresh_token involved.
 refresh(#h{mode = client_credentials} = H, _Www) ->
     acquire_via_client_credentials(H);
+refresh(#h{mode = enterprise_managed} = H, _Www) ->
+    acquire_via_ema(H);
 refresh(#h{refresh_token = undefined}, _Www) ->
     {error, no_refresh_token};
 refresh(#h{token_endpoint = undefined}, _Www) ->
@@ -336,6 +404,95 @@ client_credentials(TokenEndpoint, Params) ->
     http_post_form(TokenEndpoint, Body2, Secret,
                    maps:get(client_id, Params, undefined)).
 
+%% @doc RFC 8693 OAuth 2.0 Token Exchange. Used by the MCP
+%% `ext-auth' Enterprise-Managed Authorization extension to
+%% exchange an IdP-issued ID Token (or SAML assertion) for an
+%% Identity Assertion JWT Authorization Grant (the "ID-JAG"),
+%% scoped to a specific MCP server resource.
+%%
+%% Returns `{ok, IdJag}' where `IdJag' is the binary token
+%% extracted from the response's `access_token' field, or an
+%% error describing the failure. A 4xx with `invalid_grant'
+%% surfaces the typed `{error, subject_token_expired}' (the
+%% RFC 8693 error semantic for an expired or revoked subject
+%% token).
+-spec token_exchange(binary(), map()) ->
+    {ok, binary()} | {error, term()}.
+token_exchange(TokenEndpoint, Params) ->
+    Body0 = #{
+        <<"grant_type">> =>
+            <<"urn:ietf:params:oauth:grant-type:token-exchange">>,
+        <<"client_id">> => required(client_id, Params),
+        <<"requested_token_type">> =>
+            <<"urn:ietf:params:oauth:token-type:id-jag">>,
+        <<"subject_token">> => required(subject_token, Params),
+        <<"subject_token_type">> =>
+            required(subject_token_type, Params),
+        <<"audience">> => required(audience, Params),
+        <<"resource">> => required(resource, Params)
+    },
+    Body1 = case maps:get(client_assertion, Params, undefined) of
+                undefined -> Body0;
+                JWT when is_binary(JWT) ->
+                    Body0#{
+                        <<"client_assertion_type">> =>
+                            <<"urn:ietf:params:oauth:client-assertion-type:jwt-bearer">>,
+                        <<"client_assertion">> => JWT
+                    }
+            end,
+    Secret = case maps:get(client_assertion, Params, undefined) of
+                 undefined ->
+                     maps:get(client_secret, Params, undefined);
+                 _ -> undefined
+             end,
+    case http_post_form(TokenEndpoint, Body1, Secret,
+                        maps:get(client_id, Params, undefined)) of
+        {ok, #{<<"access_token">> := IdJag}} ->
+            {ok, IdJag};
+        {ok, R} ->
+            {error, {missing_id_jag, R}};
+        {error, {http_error, Status, Body}} when Status >= 400, Status < 500 ->
+            case is_invalid_grant(Body) of
+                true -> {error, subject_token_expired};
+                false -> {error, {http_error, Status, Body}}
+            end;
+        {error, _} = Err -> Err
+    end.
+
+%% @doc RFC 7523 JWT Bearer access-token request. The second
+%% step of the EMA chain: present the ID-JAG to the MCP server's
+%% authorization-server token endpoint and receive a short-lived
+%% access token.
+-spec jwt_bearer(binary(), map()) ->
+    {ok, map()} | {error, term()}.
+jwt_bearer(TokenEndpoint, Params) ->
+    Body0 = #{
+        <<"grant_type">> =>
+            <<"urn:ietf:params:oauth:grant-type:jwt-bearer">>,
+        <<"client_id">> => required(client_id, Params),
+        <<"assertion">> => required(assertion, Params)
+    },
+    Body1 = case maps:get(client_assertion, Params, undefined) of
+                undefined -> Body0;
+                JWT when is_binary(JWT) ->
+                    Body0#{
+                        <<"client_assertion_type">> =>
+                            <<"urn:ietf:params:oauth:client-assertion-type:jwt-bearer">>,
+                        <<"client_assertion">> => JWT
+                    }
+            end,
+    Body2 = maps:fold(fun add_optional/3, Body1, #{
+        scope => maps:get(scopes, Params, undefined),
+        resource => maps:get(resource, Params, undefined)
+    }),
+    Secret = case maps:get(client_assertion, Params, undefined) of
+                 undefined ->
+                     maps:get(client_secret, Params, undefined);
+                 _ -> undefined
+             end,
+    http_post_form(TokenEndpoint, Body2, Secret,
+                   maps:get(client_id, Params, undefined)).
+
 %%====================================================================
 %% Internal — refresh wired through the behaviour
 %%====================================================================
@@ -371,6 +528,58 @@ acquire_via_client_credentials(#h{token_endpoint = TE,
         {ok, R} -> {ok, apply_token_response(H, R)};
         {error, _} = Err -> Err
     end.
+
+%% Walk the EMA chain: token-exchange at the IdP, then
+%% jwt-bearer at the AS, fold the resulting access token into
+%% the handle. Surfaces `subject_token_expired' on the typed
+%% RFC 6749 `invalid_grant' error so hosts can re-acquire from
+%% the IdP without parsing JSON themselves.
+acquire_via_ema(#h{idp_token_endpoint = IDP,
+                   token_endpoint = AS,
+                   client_id = CI,
+                   client_secret = CS,
+                   client_assertion = CA,
+                   subject_token = ST,
+                   subject_token_type = STT,
+                   audience = Aud,
+                   resource = Res,
+                   scopes = Scopes} = H) ->
+    Step1 = drop_undefined(#{
+        client_id => CI,
+        client_secret => CS,
+        client_assertion => CA,
+        subject_token => ST,
+        subject_token_type => STT,
+        audience => Aud,
+        resource => Res
+    }),
+    case token_exchange(IDP, Step1) of
+        {ok, IdJag} ->
+            Step2 = drop_undefined(#{
+                client_id => CI,
+                client_secret => CS,
+                client_assertion => CA,
+                assertion => IdJag,
+                resource => Res,
+                scopes => Scopes
+            }),
+            case jwt_bearer(AS, Step2) of
+                {ok, R} -> {ok, apply_token_response(H, R)};
+                {error, _} = Err -> Err
+            end;
+        {error, _} = Err -> Err
+    end.
+
+%% RFC 6749 token-error parsing: a 4xx body MAY be JSON with
+%% `{"error": "invalid_grant"}'. Used by `token_exchange/2' to
+%% surface the typed `subject_token_expired' value.
+is_invalid_grant(Body) when is_binary(Body) ->
+    try json:decode(Body) of
+        #{<<"error">> := <<"invalid_grant">>} -> true;
+        _ -> false
+    catch _:_ -> false
+    end;
+is_invalid_grant(_) -> false.
 
 apply_token_response(#h{} = H, #{<<"access_token">> := AT} = R) ->
     H#h{access_token = AT,

--- a/test/barrel_mcp_client_auth_oauth_tests.erl
+++ b/test/barrel_mcp_client_auth_oauth_tests.erl
@@ -82,7 +82,17 @@ refresh_round_trip_test_() ->
          {"client_credentials with private_key_jwt",
           fun test_client_credentials_jwt/0},
          {"client_credentials re-acquires on 401",
-          fun test_client_credentials_refresh/0}
+          fun test_client_credentials_refresh/0},
+         {"token_exchange grant returns the ID-JAG",
+          fun test_token_exchange/0},
+         {"jwt_bearer grant returns the access token",
+          fun test_jwt_bearer/0},
+         {"enterprise-managed chain via auth handle",
+          fun test_enterprise_managed_handle/0},
+         {"enterprise-managed re-acquires on 401",
+          fun test_enterprise_managed_refresh/0},
+         {"expired subject_token surfaces typed error",
+          fun test_enterprise_managed_subject_token_expired/0}
      ]}}.
 
 setup_mock() ->
@@ -91,7 +101,9 @@ setup_mock() ->
     Dispatch = cowboy_router:compile([{'_', [
         {"/.well-known/oauth-protected-resource", ?MODULE, prm},
         {"/.well-known/oauth-authorization-server", ?MODULE, as},
-        {"/oauth/token", ?MODULE, token}
+        {"/oauth/token", ?MODULE, token},
+        %% IdP token endpoint for the EMA token-exchange step.
+        {"/idp/token", ?MODULE, idp_token}
     ]}]),
     {ok, _} = cowboy:start_clear(?MODULE, [{port, ?PORT}],
                                  #{env => #{dispatch => Dispatch}}),
@@ -155,13 +167,60 @@ init(Req0, token) ->
             #{<<"access_token">> => <<"cc-access">>,
               <<"token_type">> => <<"Bearer">>,
               <<"expires_in">> => 3600};
+        <<"urn:ietf:params:oauth:grant-type:jwt-bearer">> ->
+            %% AS-side step of the EMA chain. The body must
+            %% carry the ID-JAG under `assertion'. With
+            %% client_secret, http_post_form strips client_id
+            %% and authenticates via HTTP Basic.
+            AuthHdr = cowboy_req:header(<<"authorization">>, Req0),
+            true = is_binary(AuthHdr),
+            <<"Basic ", _/binary>> = AuthHdr,
+            <<"id-jag.signed.jwt">> = maps:get(<<"assertion">>, Form),
+            #{<<"access_token">> => <<"ema-access">>,
+              <<"token_type">> => <<"Bearer">>,
+              <<"expires_in">> => 3600};
         _ ->
             #{<<"error">> => <<"unsupported_grant_type">>}
     end,
     R = cowboy_req:reply(200,
         #{<<"content-type">> => <<"application/json">>},
         json_encode(Resp), Req),
-    {ok, R, token}.
+    {ok, R, token};
+%% Mock IdP token-exchange endpoint for the EMA chain.
+init(Req0, idp_token) ->
+    {ok, Body, Req} = cowboy_req:read_urlencoded_body(Req0),
+    Form = maps:from_list(Body),
+    <<"urn:ietf:params:oauth:grant-type:token-exchange">> =
+        maps:get(<<"grant_type">>, Form),
+    <<"urn:ietf:params:oauth:token-type:id-jag">> =
+        maps:get(<<"requested_token_type">>, Form),
+    %% subject_token chooses the response shape so tests can
+    %% steer between happy path and `subject_token_expired'.
+    case maps:get(<<"subject_token">>, Form, undefined) of
+        <<"expired-id-token">> ->
+            R = cowboy_req:reply(400,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{<<"error">> => <<"invalid_grant">>}), Req),
+            {ok, R, idp_token};
+        Subj when is_binary(Subj), Subj =/= <<>> ->
+            %% client_secret_basic strips client_id from the body
+            %% and authenticates via the Authorization header.
+            AuthHdr = cowboy_req:header(<<"authorization">>, Req0),
+            true = is_binary(AuthHdr),
+            <<"Basic ", _/binary>> = AuthHdr,
+            ?BASE = maps:get(<<"audience">>, Form),
+            <<"http://127.0.0.1:19494/mcp">> =
+                maps:get(<<"resource">>, Form),
+            <<"urn:ietf:params:oauth:token-type:id_token">> =
+                maps:get(<<"subject_token_type">>, Form),
+            R = cowboy_req:reply(200,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{<<"access_token">> => <<"id-jag.signed.jwt">>,
+                              <<"issued_token_type">> =>
+                                  <<"urn:ietf:params:oauth:token-type:id-jag">>,
+                              <<"token_type">> => <<"Bearer">>}), Req),
+            {ok, R, idp_token}
+    end.
 
 json_encode(M) -> iolist_to_binary(json:encode(M)).
 
@@ -254,3 +313,86 @@ test_client_credentials_refresh() ->
                      Auth, <<"Bearer error=expired">>),
     ?assertEqual({ok, <<"Bearer cc-access">>},
                  barrel_mcp_client_auth:header(Auth1)).
+
+%%====================================================================
+%% Enterprise-Managed Authorization (RFC 8693 + RFC 7523)
+%%====================================================================
+
+test_token_exchange() ->
+    %% Direct exchanger: present the ID Token, get back an
+    %% ID-JAG (`access_token' field of the response).
+    {ok, IdJag} = barrel_mcp_client_auth_oauth:token_exchange(
+        <<?BASE/binary, "/idp/token">>,
+        #{client_id => <<"client-1">>,
+          client_secret => <<"top-secret">>,
+          subject_token => <<"oidc-id-token">>,
+          subject_token_type =>
+              <<"urn:ietf:params:oauth:token-type:id_token">>,
+          audience => ?BASE,
+          resource => <<"http://127.0.0.1:19494/mcp">>}),
+    ?assertEqual(<<"id-jag.signed.jwt">>, IdJag).
+
+test_jwt_bearer() ->
+    %% Direct exchanger: present the ID-JAG to the AS token
+    %% endpoint, get back the MCP access token.
+    {ok, Resp} = barrel_mcp_client_auth_oauth:jwt_bearer(
+        <<?BASE/binary, "/oauth/token">>,
+        #{client_id => <<"client-1">>,
+          client_secret => <<"top-secret">>,
+          assertion => <<"id-jag.signed.jwt">>,
+          resource => <<"http://127.0.0.1:19494/mcp">>}),
+    ?assertEqual(<<"ema-access">>, maps:get(<<"access_token">>, Resp)).
+
+test_enterprise_managed_handle() ->
+    %% End-to-end via the connect-spec entry the user passes to
+    %% barrel_mcp_client. init/1 walks the EMA chain (token-exchange
+    %% then jwt-bearer) and the Authorization header is ready.
+    Auth = barrel_mcp_client_auth:new({oauth_enterprise, #{
+        idp_token_endpoint => <<?BASE/binary, "/idp/token">>,
+        as_token_endpoint => <<?BASE/binary, "/oauth/token">>,
+        client_id => <<"client-1">>,
+        client_secret => <<"top-secret">>,
+        subject_token => <<"oidc-id-token">>,
+        subject_token_type =>
+            <<"urn:ietf:params:oauth:token-type:id_token">>,
+        audience => ?BASE,
+        resource => <<"http://127.0.0.1:19494/mcp">>
+    }}),
+    ?assertNotMatch({error, _}, Auth),
+    ?assertEqual({ok, <<"Bearer ema-access">>},
+                 barrel_mcp_client_auth:header(Auth)).
+
+test_enterprise_managed_refresh() ->
+    %% A 401 in enterprise_managed mode re-walks the chain.
+    Auth = barrel_mcp_client_auth:new({oauth_enterprise, #{
+        idp_token_endpoint => <<?BASE/binary, "/idp/token">>,
+        as_token_endpoint => <<?BASE/binary, "/oauth/token">>,
+        client_id => <<"client-1">>,
+        client_secret => <<"top-secret">>,
+        subject_token => <<"oidc-id-token">>,
+        subject_token_type =>
+            <<"urn:ietf:params:oauth:token-type:id_token">>,
+        audience => ?BASE,
+        resource => <<"http://127.0.0.1:19494/mcp">>
+    }}),
+    {ok, Auth1} = barrel_mcp_client_auth:refresh(
+                     Auth, <<"Bearer error=expired">>),
+    ?assertEqual({ok, <<"Bearer ema-access">>},
+                 barrel_mcp_client_auth:header(Auth1)).
+
+test_enterprise_managed_subject_token_expired() ->
+    %% IdP returns invalid_grant — caller learns the typed
+    %% subject_token_expired result so it can re-acquire the ID
+    %% Token from the IdP.
+    Result = barrel_mcp_client_auth:new({oauth_enterprise, #{
+        idp_token_endpoint => <<?BASE/binary, "/idp/token">>,
+        as_token_endpoint => <<?BASE/binary, "/oauth/token">>,
+        client_id => <<"client-1">>,
+        client_secret => <<"top-secret">>,
+        subject_token => <<"expired-id-token">>,
+        subject_token_type =>
+            <<"urn:ietf:params:oauth:token-type:id_token">>,
+        audience => ?BASE,
+        resource => <<"http://127.0.0.1:19494/mcp">>
+    }}),
+    ?assertEqual({error, subject_token_expired}, Result).

--- a/test/barrel_mcp_oauth_enterprise_SUITE.erl
+++ b/test/barrel_mcp_oauth_enterprise_SUITE.erl
@@ -1,0 +1,225 @@
+%%%-------------------------------------------------------------------
+%%% @doc End-to-end suite for the Enterprise-Managed Authorization
+%%% grant.
+%%%
+%%% Stands up:
+%%%
+%%% - a tiny cowboy mock that plays both the IdP token-exchange
+%%%   endpoint and the AS jwt-bearer endpoint;
+%%% - a real `barrel_mcp_http_stream' MCP server with bearer auth
+%%%   guarded by a custom verifier that only accepts the access
+%%%   token the mock AS hands out.
+%%%
+%%% Then connects a `barrel_mcp_client' with
+%%% `auth => {oauth_enterprise, Config}', exercises `list_tools'
+%%% and `call_tool' against the protected server, and asserts the
+%%% chain (RFC 8693 token-exchange -> RFC 7523 jwt-bearer ->
+%%% Authorization: Bearer ...) actually unlocks the MCP protocol.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_oauth_enterprise_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([ema_chain_unlocks_protected_server/1,
+         expired_subject_token_blocks_init/1]).
+
+%% Cowboy callback for the IdP/AS mock.
+-export([init/2]).
+
+%% MCP server tool fixture.
+-export([echo_tool/1]).
+
+-define(AS_PORT, 22701).
+-define(MCP_PORT, 22702).
+-define(AS_LISTENER, ?MODULE).
+-define(ACCESS_TOKEN, <<"ema-access-token-issued-by-mock-as">>).
+
+all() ->
+    [ema_chain_unlocks_protected_server,
+     expired_subject_token_blocks_init].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    {ok, _} = application:ensure_all_started(hackney),
+    ok = barrel_mcp_registry:wait_for_ready(),
+
+    %% Cowboy mock implementing both IdP and AS token endpoints.
+    Dispatch = cowboy_router:compile([{'_', [
+        {"/idp/token", ?MODULE, idp_token},
+        {"/as/token",  ?MODULE, as_token}
+    ]}]),
+    {ok, _} = cowboy:start_clear(?AS_LISTENER, [{port, ?AS_PORT}],
+                                  #{env => #{dispatch => Dispatch}}),
+
+    %% Register a tool the test will call against the MCP server.
+    ok = barrel_mcp_registry:reg(tool, <<"echo">>, ?MODULE, echo_tool, #{
+        description => <<"Echo">>,
+        input_schema => #{<<"type">> => <<"object">>,
+                           <<"required">> => [<<"text">>]}
+    }),
+
+    %% MCP server with bearer auth gated by a custom verifier
+    %% that only accepts the access token our mock AS issues.
+    Verifier = fun(Token) ->
+        case Token =:= ?ACCESS_TOKEN of
+            true  -> {ok, #{<<"sub">> => <<"interop-user">>}};
+            false -> {error, invalid_token}
+        end
+    end,
+    {ok, _} = barrel_mcp:start_http_stream(#{
+        port => ?MCP_PORT,
+        session_enabled => true,
+        auth => #{provider => barrel_mcp_auth_bearer,
+                   provider_opts => #{verifier => Verifier}}
+    }),
+    Config.
+
+end_per_suite(_Config) ->
+    catch barrel_mcp:stop_http_stream(),
+    catch cowboy:stop_listener(?AS_LISTENER),
+    catch barrel_mcp_registry:unreg(tool, <<"echo">>),
+    application:stop(barrel_mcp),
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+ema_chain_unlocks_protected_server(_Config) ->
+    %% Build the connect spec. `subject_token' is the IdP-issued ID
+    %% Token the host obtained out of band; here we hand it to the
+    %% library as opaque bytes.
+    AsBase = list_to_binary(io_lib:format("http://127.0.0.1:~B",
+                                           [?AS_PORT])),
+    McpUrl = list_to_binary(io_lib:format("http://127.0.0.1:~B/mcp",
+                                           [?MCP_PORT])),
+    Spec = #{
+        transport => {http, McpUrl},
+        auth => {oauth_enterprise, #{
+            idp_token_endpoint => <<AsBase/binary, "/idp/token">>,
+            as_token_endpoint  => <<AsBase/binary, "/as/token">>,
+            client_id          => <<"client-1">>,
+            client_secret      => <<"top-secret">>,
+            subject_token      => <<"oidc-id-token">>,
+            subject_token_type =>
+                <<"urn:ietf:params:oauth:token-type:id_token">>,
+            audience           => AsBase,
+            resource           => McpUrl
+        }}
+    },
+    {ok, Pid} = barrel_mcp_client:start(Spec),
+    ok = wait_ready(Pid, 50),
+
+    {ok, Tools} = barrel_mcp_client:list_tools(Pid),
+    Names = [maps:get(<<"name">>, T) || T <- Tools],
+    ?assert(lists:member(<<"echo">>, Names)),
+
+    {ok, R} = barrel_mcp_client:call_tool(Pid, <<"echo">>,
+                                          #{<<"text">> => <<"hi">>}),
+    [#{<<"text">> := <<"hi">>} | _] = maps:get(<<"content">>, R),
+
+    barrel_mcp_client:close(Pid),
+    ok.
+
+expired_subject_token_blocks_init(_Config) ->
+    %% A subject_token the mock IdP refuses (returns invalid_grant)
+    %% must surface as `subject_token_expired' from `init/1' so the
+    %% host knows to re-acquire from the IdP.
+    AsBase = list_to_binary(io_lib:format("http://127.0.0.1:~B",
+                                           [?AS_PORT])),
+    McpUrl = list_to_binary(io_lib:format("http://127.0.0.1:~B/mcp",
+                                           [?MCP_PORT])),
+    Spec = #{
+        transport => {http, McpUrl},
+        auth => {oauth_enterprise, #{
+            idp_token_endpoint => <<AsBase/binary, "/idp/token">>,
+            as_token_endpoint  => <<AsBase/binary, "/as/token">>,
+            client_id          => <<"client-1">>,
+            client_secret      => <<"top-secret">>,
+            subject_token      => <<"expired-id-token">>,
+            subject_token_type =>
+                <<"urn:ietf:params:oauth:token-type:id_token">>,
+            audience           => AsBase,
+            resource           => McpUrl
+        }}
+    },
+    %% `start/1' returns asynchronously — the gen_statem accepts
+    %% the spec, then fails during the connecting state when the
+    %% auth handle init walks the EMA chain. Monitor the pid and
+    %% wait for the EXIT.
+    {ok, Pid} = barrel_mcp_client:start(Spec),
+    Ref = erlang:monitor(process, Pid),
+    receive
+        {'DOWN', Ref, process, Pid, Reason} ->
+            ?assertEqual(subject_token_expired,
+                         normalise_reason(Reason))
+    after 5000 ->
+        ct:fail("client did not stop on subject_token_expired")
+    end,
+    ok.
+
+%%====================================================================
+%% Tool fixture
+%%====================================================================
+
+echo_tool(#{<<"text">> := T}) -> T.
+
+%%====================================================================
+%% Cowboy IdP + AS mock
+%%====================================================================
+
+init(Req0, idp_token) ->
+    {ok, Body, Req} = cowboy_req:read_urlencoded_body(Req0),
+    Form = maps:from_list(Body),
+    case maps:get(<<"subject_token">>, Form, undefined) of
+        <<"expired-id-token">> ->
+            R = cowboy_req:reply(400,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{<<"error">> => <<"invalid_grant">>}), Req),
+            {ok, R, idp_token};
+        _ ->
+            R = cowboy_req:reply(200,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{<<"access_token">> => <<"id-jag.signed.jwt">>,
+                              <<"issued_token_type">> =>
+                                  <<"urn:ietf:params:oauth:token-type:id-jag">>,
+                              <<"token_type">> => <<"Bearer">>}), Req),
+            {ok, R, idp_token}
+    end;
+init(Req0, as_token) ->
+    {ok, Body, Req} = cowboy_req:read_urlencoded_body(Req0),
+    Form = maps:from_list(Body),
+    <<"urn:ietf:params:oauth:grant-type:jwt-bearer">> =
+        maps:get(<<"grant_type">>, Form),
+    <<"id-jag.signed.jwt">> = maps:get(<<"assertion">>, Form),
+    R = cowboy_req:reply(200,
+        #{<<"content-type">> => <<"application/json">>},
+        json_encode(#{<<"access_token">> => ?ACCESS_TOKEN,
+                      <<"token_type">> => <<"Bearer">>,
+                      <<"expires_in">> => 3600}), Req),
+    {ok, R, as_token}.
+
+json_encode(M) -> iolist_to_binary(json:encode(M)).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+wait_ready(_Pid, 0) -> {error, not_ready};
+wait_ready(Pid, N) ->
+    case catch barrel_mcp_client:server_capabilities(Pid) of
+        {ok, _} -> ok;
+        _ ->
+            timer:sleep(100),
+            wait_ready(Pid, N - 1)
+    end.
+
+%% `barrel_mcp_client:start/1' wraps init failures; pull out the
+%% inner reason for assertion clarity.
+normalise_reason({shutdown, R}) -> normalise_reason(R);
+normalise_reason({error, R}) -> normalise_reason(R);
+normalise_reason({transport_failed, R}) -> normalise_reason(R);
+normalise_reason(R) -> R.


### PR DESCRIPTION
Adds the enterprise-managed OAuth flow from `modelcontextprotocol/ext-auth`: the host supplies a subject token from its IdP, the library chains RFC 8693 token-exchange (IdP) into RFC 7523 jwt-bearer (AS) to obtain an access token.

## Wire / API

- New connect-spec entry: `{oauth_enterprise, Config}` on `barrel_mcp_client:start/1`.
- `Config` keys: `idp_token_endpoint`, `as_token_endpoint`, `client_id`, `subject_token`, `subject_token_type`, `audience`, `resource`, optional `client_secret` / `client_assertion`, `scopes`.
- Two new public exchangers in `barrel_mcp_client_auth_oauth`:
  - `token_exchange/2` (RFC 8693, returns ID-JAG)
  - `jwt_bearer/2` (RFC 7523, returns access token)
- 401 from the resource server re-runs the chain.
- IdP `invalid_grant` surfaces as `{error, subject_token_expired}` so the host can re-acquire the subject token.

## Tests

5 new eunit cases in `barrel_mcp_client_auth_oauth_tests` and a 2-case CT suite `barrel_mcp_oauth_enterprise_SUITE` driving the full chain against a real bearer-protected MCP server.