### PR TITLE
Dynamic Client Registration (RFC 7591)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New public exchangers `barrel_mcp_client_auth_oauth:token_exchange/2` and `jwt_bearer/2` for hosts that want to drive each step directly.
 - The handle re-walks the chain on every 401 (no `refresh_token` involved). When the IdP returns `invalid_grant` the library surfaces the typed `{error, subject_token_expired}` so the host can re-acquire from its IdP without parsing JSON.
 
+### Dynamic Client Registration (RFC 7591)
+
+- New public `barrel_mcp_client_auth_oauth:register_client/2`. Posts the supplied client metadata to the AS's `registration_endpoint` and returns the response unchanged: `client_id`, optional `client_secret`, `client_id_issued_at`, `client_secret_expires_at`, plus any echoed metadata. Hosts feed the returned credentials into a subsequent `{oauth, ...}` / `{oauth_client_credentials, ...}` connect spec.
+- Stays a standalone exchanger: auto-wiring would need persistent storage of issued credentials, which is host policy. Documented in the OAuth section of the auth guide.
+
 ### `_meta` end-to-end propagation
 
 - The MCP spec defines `_meta` as the extensibility hook on every JSON-RPC envelope. Previously only `_meta.progressToken` was read on `tools/call`; everything else dropped on the floor. Now:

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -394,8 +394,8 @@ Authentication failures return proper HTTP status codes and WWW-Authenticate hea
 
 ## OAuth grant flows
 
-`barrel_mcp_client` ships three grants; pick by **who is in the
-loop and when**:
+`barrel_mcp_client` ships three grants plus a registration
+pre-step. Pick by **who is in the loop and when**:
 
 ### Authorization Code + PKCE — interactive
 
@@ -518,24 +518,53 @@ The library treats `subject_token` as opaque — both OIDC and
 SAML modes hit the same code path. The browser flow at the IdP
 stays a host concern.
 
+### Dynamic Client Registration — pre-step
+
+Not a grant. Used **before** any of the others when the host
+doesn't have a `client_id` yet (fresh deployment, distributed
+host, dev sandbox). RFC 7591.
+
+```
+Host                                    AS
+ │  POST /register                       │
+ │  { client_name, redirect_uris,        │
+ │    grant_types, ... }                 │
+ │──────────────────────────────────────►│
+ │  { client_id, client_secret?,         │
+ │    client_id_issued_at, ... }         │
+ │◄──────────────────────────────────────│
+```
+
+```erlang
+{ok, Info} = barrel_mcp_client_auth_oauth:register_client(
+    <<"https://idp/oauth/register">>,
+    #{<<"client_name">> => <<"my-host">>, ...}),
+ClientId     = maps:get(<<"client_id">>, Info),
+ClientSecret = maps:get(<<"client_secret">>, Info, undefined).
+```
+
+Feed the returned credentials into one of the grants above. The
+library does not persist them; that's a host concern.
+
 ### Where they overlap on the wire
 
-All three grants hit the same OAuth-server token endpoint with
+All grants hit the same OAuth-server token endpoint with
 `application/x-www-form-urlencoded` bodies. Confidential clients
 authenticate with HTTP Basic; `private_key_jwt` clients pass a
 `client_assertion` instead. RFC 8707 `resource` is attached on
 every grant. The MCP `2025-11-25` auth sub-spec layers
 [RFC 9728 PRM](#oauth-protected-resource-metadata-rfc-9728) on
-top so any of the three can be auto-discovered from a `401`
+top so any of the grants can be auto-discovered from a `401`
 response.
 
 ### When to pick which
 
-| Situation | Grant |
+| Situation | Use |
 |---|---|
 | Real user, browser available, host wants their identity | `auth_code` (`{oauth, ...}`) |
 | Background agent / cron / unattended host | `client_credentials` (`{oauth_client_credentials, ...}`) |
 | Enterprise SSO; user identity must flow to MCP | `enterprise_managed` (`{oauth_enterprise, ...}`) |
+| No `client_id` yet | `register_client/2` first, then one of the above |
 
 ## OAuth Protected Resource Metadata (RFC 9728)
 
@@ -585,6 +614,36 @@ The client side is implemented by
 `discover_protected_resource/1` — together with the server side
 above, the MCP authorization sub-spec discovery flow works
 end-to-end.
+
+## Dynamic Client Registration (RFC 7591)
+
+Hosts that don't have a pre-issued `client_id` for the target
+authorization server can register one programmatically. The AS
+metadata document advertises the endpoint via
+`registration_endpoint`.
+
+```erlang
+{ok, Info} = barrel_mcp_client_auth_oauth:register_client(
+    <<"https://idp.example.com/oauth/register">>,
+    #{<<"client_name">>   => <<"my-mcp-host">>,
+      <<"redirect_uris">> => [<<"http://localhost:5173/callback">>],
+      <<"grant_types">>   => [<<"authorization_code">>,
+                              <<"refresh_token">>],
+      <<"response_types">> => [<<"code">>],
+      <<"token_endpoint_auth_method">> => <<"none">>}).
+
+%% Info now contains:
+%%   #{<<"client_id">>           => <<"...">>,
+%%     <<"client_secret">>       => <<"...">>,   % if confidential
+%%     <<"client_id_issued_at">> => 1700000000,  % UNIX epoch
+%%     ...}
+```
+
+Feed the returned credentials into a subsequent
+`{oauth, ...}` / `{oauth_client_credentials, ...}` connect spec.
+This stays a standalone exchanger — the library doesn't persist
+the issued credentials. That's a host concern (file, DB, secret
+manager).
 
 ## Security Best Practices
 

--- a/guides/features.md
+++ b/guides/features.md
@@ -207,6 +207,11 @@ by the spec.
     `client_credentials/2`, `token_exchange/2`, `jwt_bearer/2`.
     All attach the RFC 8707 `resource` parameter; confidential
     clients use HTTP Basic.
+  - Dynamic Client Registration (RFC 7591):
+    `register_client/2` posts client metadata to the AS's
+    `registration_endpoint` and returns the AS's response
+    (`client_id`, optional `client_secret`, ...). Hosts then feed
+    the credentials into one of the connect-spec auth entries.
   - Client Credentials grant (MCP `ext-auth` extension) for
     unattended agent hosts: pass
     `auth => {oauth_client_credentials, Config}` on the connect

--- a/src/barrel_mcp_client_auth_oauth.erl
+++ b/src/barrel_mcp_client_auth_oauth.erl
@@ -72,7 +72,8 @@
     refresh_token/2,
     client_credentials/2,
     token_exchange/2,
-    jwt_bearer/2
+    jwt_bearer/2,
+    register_client/2
 ]).
 
 -export_type([config/0, handle/0]).
@@ -492,6 +493,38 @@ jwt_bearer(TokenEndpoint, Params) ->
              end,
     http_post_form(TokenEndpoint, Body2, Secret,
                    maps:get(client_id, Params, undefined)).
+
+%% @doc Dynamic Client Registration ([RFC 7591][rfc7591]). Posts
+%% the supplied client metadata to the AS's `registration_endpoint'
+%% and returns the AS's response unchanged: typically including
+%% `client_id', optionally `client_secret',
+%% `client_id_issued_at', `client_secret_expires_at', plus any
+%% client-metadata echo the AS chose to include.
+%%
+%% Hosts that receive a fresh `client_id' (and `client_secret', if
+%% issued) feed it into a subsequent `{oauth, ...}',
+%% `{oauth_client_credentials, ...}', or `{oauth_enterprise, ...}'
+%% connect spec. This stays a standalone exchanger; auto-wiring
+%% would require persisting credentials, which is host policy.
+%%
+%% [rfc7591]: https://datatracker.ietf.org/doc/html/rfc7591
+-spec register_client(RegistrationEndpoint :: binary(),
+                       Metadata :: map()) ->
+    {ok, ClientInfo :: map()} | {error, term()}.
+register_client(RegistrationEndpoint, Metadata) when is_map(Metadata) ->
+    Headers = [{<<"content-type">>, <<"application/json">>},
+               {<<"accept">>, <<"application/json">>}],
+    Body = iolist_to_binary(json:encode(Metadata)),
+    case hackney:request(post, RegistrationEndpoint, Headers, Body,
+                          [with_body]) of
+        {ok, Status, _Hdrs, Resp}
+          when Status >= 200, Status < 300 ->
+            try {ok, json:decode(Resp)}
+            catch _:_ -> {error, {invalid_json, Resp}} end;
+        {ok, Status, _Hdrs, Resp} ->
+            {error, {http_error, Status, Resp}};
+        {error, _} = Err -> Err
+    end.
 
 %%====================================================================
 %% Internal — refresh wired through the behaviour

--- a/test/barrel_mcp_client_auth_oauth_tests.erl
+++ b/test/barrel_mcp_client_auth_oauth_tests.erl
@@ -92,7 +92,13 @@ refresh_round_trip_test_() ->
          {"enterprise-managed re-acquires on 401",
           fun test_enterprise_managed_refresh/0},
          {"expired subject_token surfaces typed error",
-          fun test_enterprise_managed_subject_token_expired/0}
+          fun test_enterprise_managed_subject_token_expired/0},
+         {"register_client returns just the client_id",
+          fun test_register_client_public/0},
+         {"register_client returns client_id + client_secret",
+          fun test_register_client_confidential/0},
+         {"register_client surfaces 4xx errors",
+          fun test_register_client_error/0}
      ]}}.
 
 setup_mock() ->
@@ -103,7 +109,8 @@ setup_mock() ->
         {"/.well-known/oauth-authorization-server", ?MODULE, as},
         {"/oauth/token", ?MODULE, token},
         %% IdP token endpoint for the EMA token-exchange step.
-        {"/idp/token", ?MODULE, idp_token}
+        {"/idp/token", ?MODULE, idp_token},
+        {"/oauth/register", ?MODULE, register}
     ]}]),
     {ok, _} = cowboy:start_clear(?MODULE, [{port, ?PORT}],
                                  #{env => #{dispatch => Dispatch}}),
@@ -220,6 +227,41 @@ init(Req0, idp_token) ->
                                   <<"urn:ietf:params:oauth:token-type:id-jag">>,
                               <<"token_type">> => <<"Bearer">>}), Req),
             {ok, R, idp_token}
+    end;
+%% Mock dynamic client registration endpoint (RFC 7591).
+init(Req0, register) ->
+    {ok, Body, Req} = cowboy_req:read_body(Req0),
+    Metadata = json:decode(Body),
+    Name = maps:get(<<"client_name">>, Metadata, <<"unnamed">>),
+    %% Test marker: client_name="confidential" provokes a
+    %% client_secret in the response; "bad" provokes a 400.
+    case Name of
+        <<"bad">> ->
+            R = cowboy_req:reply(400,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{<<"error">> => <<"invalid_redirect_uri">>}),
+                Req),
+            {ok, R, register};
+        <<"confidential">> ->
+            R = cowboy_req:reply(201,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{
+                    <<"client_id">> => <<"new-client-id">>,
+                    <<"client_secret">> => <<"new-secret">>,
+                    <<"client_id_issued_at">> => 1700000000,
+                    <<"client_secret_expires_at">> => 0,
+                    <<"client_name">> => Name
+                }), Req),
+            {ok, R, register};
+        _ ->
+            R = cowboy_req:reply(201,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{
+                    <<"client_id">> => <<"new-client-id">>,
+                    <<"client_id_issued_at">> => 1700000000,
+                    <<"client_name">> => Name
+                }), Req),
+            {ok, R, register}
     end.
 
 json_encode(M) -> iolist_to_binary(json:encode(M)).
@@ -396,3 +438,38 @@ test_enterprise_managed_subject_token_expired() ->
         resource => <<"http://127.0.0.1:19494/mcp">>
     }}),
     ?assertEqual({error, subject_token_expired}, Result).
+
+%%====================================================================
+%% Dynamic Client Registration (RFC 7591)
+%%====================================================================
+
+test_register_client_public() ->
+    %% Public client (token_endpoint_auth_method=none): AS issues
+    %% just a client_id, no secret.
+    {ok, Resp} = barrel_mcp_client_auth_oauth:register_client(
+        <<?BASE/binary, "/oauth/register">>,
+        #{<<"client_name">> => <<"my-mcp-host">>,
+          <<"redirect_uris">> => [<<"http://localhost:5173/cb">>],
+          <<"grant_types">> => [<<"authorization_code">>],
+          <<"response_types">> => [<<"code">>],
+          <<"token_endpoint_auth_method">> => <<"none">>}),
+    ?assertEqual(<<"new-client-id">>, maps:get(<<"client_id">>, Resp)),
+    ?assertNot(maps:is_key(<<"client_secret">>, Resp)).
+
+test_register_client_confidential() ->
+    %% Confidential client: AS issues both client_id and
+    %% client_secret. Both flow back to the caller verbatim.
+    {ok, Resp} = barrel_mcp_client_auth_oauth:register_client(
+        <<?BASE/binary, "/oauth/register">>,
+        #{<<"client_name">> => <<"confidential">>,
+          <<"grant_types">> => [<<"client_credentials">>]}),
+    ?assertEqual(<<"new-client-id">>, maps:get(<<"client_id">>, Resp)),
+    ?assertEqual(<<"new-secret">>, maps:get(<<"client_secret">>, Resp)).
+
+test_register_client_error() ->
+    %% AS rejects the request with a 4xx; caller learns the
+    %% status + body so it can react.
+    Result = barrel_mcp_client_auth_oauth:register_client(
+        <<?BASE/binary, "/oauth/register">>,
+        #{<<"client_name">> => <<"bad">>}),
+    ?assertMatch({error, {http_error, 400, _}}, Result).

--- a/test/barrel_mcp_oauth_dcr_SUITE.erl
+++ b/test/barrel_mcp_oauth_dcr_SUITE.erl
@@ -1,0 +1,202 @@
+%%%-------------------------------------------------------------------
+%%% @doc End-to-end suite for Dynamic Client Registration.
+%%%
+%%% Stands up:
+%%%
+%%% - a tiny cowboy mock that plays both an RFC 7591 registration
+%%%   endpoint and an OAuth 2.0 token endpoint;
+%%% - a real `barrel_mcp_http_stream' MCP server with bearer auth
+%%%   guarded by a custom verifier that only accepts the token
+%%%   the mock AS issues to a freshly registered client.
+%%%
+%%% Then drives the full flow:
+%%%
+%%%   1. `register_client/2' to obtain a `client_id' /
+%%%      `client_secret';
+%%%   2. `barrel_mcp_client:start/1' with
+%%%      `auth => {oauth_client_credentials, ...}' using the
+%%%      registered credentials;
+%%%   3. `list_tools' / `call_tool' against the protected MCP
+%%%      server.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(barrel_mcp_oauth_dcr_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([dcr_then_client_credentials_unlocks_server/1,
+         registration_error_surfaces/1]).
+
+-export([init/2]).
+-export([echo_tool/1]).
+
+-define(AS_PORT, 22751).
+-define(MCP_PORT, 22752).
+-define(AS_LISTENER, ?MODULE).
+-define(ACCESS_TOKEN, <<"dcr-cc-access-token">>).
+
+all() ->
+    [dcr_then_client_credentials_unlocks_server,
+     registration_error_surfaces].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(barrel_mcp),
+    {ok, _} = application:ensure_all_started(hackney),
+    ok = barrel_mcp_registry:wait_for_ready(),
+
+    Dispatch = cowboy_router:compile([{'_', [
+        {"/oauth/register", ?MODULE, register},
+        {"/oauth/token",    ?MODULE, token}
+    ]}]),
+    {ok, _} = cowboy:start_clear(?AS_LISTENER, [{port, ?AS_PORT}],
+                                  #{env => #{dispatch => Dispatch}}),
+
+    ok = barrel_mcp_registry:reg(tool, <<"echo">>, ?MODULE, echo_tool, #{
+        description => <<"Echo">>,
+        input_schema => #{<<"type">> => <<"object">>,
+                           <<"required">> => [<<"text">>]}
+    }),
+
+    Verifier = fun(Token) ->
+        case Token =:= ?ACCESS_TOKEN of
+            true  -> {ok, #{<<"sub">> => <<"dcr-client">>}};
+            false -> {error, invalid_token}
+        end
+    end,
+    {ok, _} = barrel_mcp:start_http_stream(#{
+        port => ?MCP_PORT,
+        session_enabled => true,
+        auth => #{provider => barrel_mcp_auth_bearer,
+                   provider_opts => #{verifier => Verifier}}
+    }),
+    Config.
+
+end_per_suite(_Config) ->
+    catch barrel_mcp:stop_http_stream(),
+    catch cowboy:stop_listener(?AS_LISTENER),
+    catch barrel_mcp_registry:unreg(tool, <<"echo">>),
+    application:stop(barrel_mcp),
+    ok.
+
+%%====================================================================
+%% Cases
+%%====================================================================
+
+dcr_then_client_credentials_unlocks_server(_Config) ->
+    AsBase = list_to_binary(io_lib:format("http://127.0.0.1:~B",
+                                           [?AS_PORT])),
+    McpUrl = list_to_binary(io_lib:format("http://127.0.0.1:~B/mcp",
+                                           [?MCP_PORT])),
+
+    %% Step 1: register a client.
+    {ok, Info} = barrel_mcp_client_auth_oauth:register_client(
+        <<AsBase/binary, "/oauth/register">>,
+        #{<<"client_name">>   => <<"e2e-host">>,
+          <<"grant_types">>   => [<<"client_credentials">>],
+          <<"token_endpoint_auth_method">> => <<"client_secret_basic">>}),
+    ClientId = maps:get(<<"client_id">>, Info),
+    ClientSecret = maps:get(<<"client_secret">>, Info),
+    ?assert(is_binary(ClientId)),
+    ?assert(is_binary(ClientSecret)),
+
+    %% Step 2: connect to the protected MCP server using the
+    %% registered credentials via the client_credentials grant.
+    Spec = #{
+        transport => {http, McpUrl},
+        auth => {oauth_client_credentials, #{
+            token_endpoint => <<AsBase/binary, "/oauth/token">>,
+            client_id      => ClientId,
+            client_secret  => ClientSecret,
+            resource       => McpUrl
+        }}
+    },
+    {ok, Pid} = barrel_mcp_client:start(Spec),
+    ok = wait_ready(Pid, 50),
+
+    %% Step 3: exercise MCP through the bearer-protected channel.
+    {ok, Tools} = barrel_mcp_client:list_tools(Pid),
+    Names = [maps:get(<<"name">>, T) || T <- Tools],
+    ?assert(lists:member(<<"echo">>, Names)),
+
+    {ok, R} = barrel_mcp_client:call_tool(Pid, <<"echo">>,
+                                          #{<<"text">> => <<"hi">>}),
+    [#{<<"text">> := <<"hi">>} | _] = maps:get(<<"content">>, R),
+
+    barrel_mcp_client:close(Pid),
+    ok.
+
+registration_error_surfaces(_Config) ->
+    %% A 4xx from the registration endpoint must propagate the
+    %% status + body so the host can react.
+    AsBase = list_to_binary(io_lib:format("http://127.0.0.1:~B",
+                                           [?AS_PORT])),
+    Result = barrel_mcp_client_auth_oauth:register_client(
+        <<AsBase/binary, "/oauth/register">>,
+        #{<<"client_name">> => <<"reject-me">>}),
+    ?assertMatch({error, {http_error, 400, _}}, Result),
+    ok.
+
+%%====================================================================
+%% Tool fixture
+%%====================================================================
+
+echo_tool(#{<<"text">> := T}) -> T.
+
+%%====================================================================
+%% Cowboy mock: registration + token endpoints
+%%====================================================================
+
+init(Req0, register) ->
+    {ok, Body, Req} = cowboy_req:read_body(Req0),
+    Metadata = json:decode(Body),
+    case maps:get(<<"client_name">>, Metadata, <<>>) of
+        <<"reject-me">> ->
+            R = cowboy_req:reply(400,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{<<"error">> => <<"invalid_redirect_uri">>}),
+                Req),
+            {ok, R, register};
+        _ ->
+            R = cowboy_req:reply(201,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{
+                    <<"client_id">> => <<"registered-client-id">>,
+                    <<"client_secret">> => <<"registered-secret">>,
+                    <<"client_id_issued_at">> => 1700000000,
+                    <<"client_secret_expires_at">> => 0
+                }), Req),
+            {ok, R, register}
+    end;
+init(Req0, token) ->
+    {ok, Body, Req} = cowboy_req:read_urlencoded_body(Req0),
+    Form = maps:from_list(Body),
+    <<"client_credentials">> = maps:get(<<"grant_type">>, Form),
+    %% The client authenticates via HTTP Basic with the
+    %% registered credentials; barrel_mcp_client_auth_oauth strips
+    %% client_id from the body in that mode.
+    AuthHdr = cowboy_req:header(<<"authorization">>, Req0),
+    true = is_binary(AuthHdr),
+    <<"Basic ", _/binary>> = AuthHdr,
+    R = cowboy_req:reply(200,
+        #{<<"content-type">> => <<"application/json">>},
+        json_encode(#{<<"access_token">> => ?ACCESS_TOKEN,
+                      <<"token_type">> => <<"Bearer">>,
+                      <<"expires_in">> => 3600}), Req),
+    {ok, R, token}.
+
+json_encode(M) -> iolist_to_binary(json:encode(M)).
+
+%%====================================================================
+%% Helpers
+%%====================================================================
+
+wait_ready(_Pid, 0) -> {error, not_ready};
+wait_ready(Pid, N) ->
+    case catch barrel_mcp_client:server_capabilities(Pid) of
+        {ok, _} -> ok;
+        _ ->
+            timer:sleep(100),
+            wait_ready(Pid, N - 1)
+    end.


### PR DESCRIPTION
Adds a client-side helper for RFC 7591 dynamic client registration so hosts without pre-issued credentials can register against the AS's `registration_endpoint` and feed the returned `client_id` (and optional `client_secret`) into a subsequent `{oauth, ...}` / `{oauth_client_credentials, ...}` / `{oauth_enterprise, ...}` connect spec.

## API

- New `barrel_mcp_client_auth_oauth:register_client/2`. POSTs the metadata map as JSON; returns the AS response verbatim.
- Standalone exchanger, not auto-wired into `init/1`. Persisting issued credentials is host policy.

## Tests

3 new eunit cases (public client, confidential client, 4xx error path) plus a 2-case CT suite `barrel_mcp_oauth_dcr_SUITE` that registers, runs the client_credentials grant with the issued credentials, and calls a tool against a real MCP server.