### PR TITLE
DCR: support protected registration_endpoint (initial access token)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New public `barrel_mcp_client_auth_oauth:register_client/2`. Posts the supplied client metadata to the AS's `registration_endpoint` and returns the response unchanged: `client_id`, optional `client_secret`, `client_id_issued_at`, `client_secret_expires_at`, plus any echoed metadata. Hosts feed the returned credentials into a subsequent `{oauth, ...}` / `{oauth_client_credentials, ...}` connect spec.
 - Stays a standalone exchanger: auto-wiring would need persistent storage of issued credentials, which is host policy. Documented in the OAuth section of the auth guide.
+- New `register_client/3` accepts an `Opts` map. `initial_access_token` (RFC 7591 section 3) attaches `Authorization: Bearer ...` so protected registration endpoints work.
 
 ### `_meta` end-to-end propagation
 

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -543,6 +543,16 @@ ClientId     = maps:get(<<"client_id">>, Info),
 ClientSecret = maps:get(<<"client_secret">>, Info, undefined).
 ```
 
+For protected registration endpoints (RFC 7591 section 3) pass
+the AS-issued initial access token via `register_client/3`:
+
+```erlang
+{ok, Info} = barrel_mcp_client_auth_oauth:register_client(
+    <<"https://idp/oauth/register">>,
+    #{<<"client_name">> => <<"my-host">>, ...},
+    #{initial_access_token => <<"...">>}).
+```
+
 Feed the returned credentials into one of the grants above. The
 library does not persist them; that's a host concern.
 

--- a/src/barrel_mcp_client_auth_oauth.erl
+++ b/src/barrel_mcp_client_auth_oauth.erl
@@ -73,7 +73,8 @@
     client_credentials/2,
     token_exchange/2,
     jwt_bearer/2,
-    register_client/2
+    register_client/2,
+    register_client/3
 ]).
 
 -export_type([config/0, handle/0]).
@@ -511,9 +512,29 @@ jwt_bearer(TokenEndpoint, Params) ->
 -spec register_client(RegistrationEndpoint :: binary(),
                        Metadata :: map()) ->
     {ok, ClientInfo :: map()} | {error, term()}.
-register_client(RegistrationEndpoint, Metadata) when is_map(Metadata) ->
-    Headers = [{<<"content-type">>, <<"application/json">>},
-               {<<"accept">>, <<"application/json">>}],
+register_client(RegistrationEndpoint, Metadata) ->
+    register_client(RegistrationEndpoint, Metadata, #{}).
+
+%% @doc Variant of {@link register_client/2} that accepts an
+%% options map. Currently the only option is
+%% `initial_access_token' (RFC 7591 section 3): an opaque bearer
+%% token issued out of band by the AS to gate registration. When
+%% present, the call adds `Authorization: Bearer <token>'.
+-spec register_client(RegistrationEndpoint :: binary(),
+                       Metadata :: map(),
+                       Opts :: #{initial_access_token => binary(),
+                                 _ => _}) ->
+    {ok, ClientInfo :: map()} | {error, term()}.
+register_client(RegistrationEndpoint, Metadata, Opts)
+  when is_map(Metadata), is_map(Opts) ->
+    Base = [{<<"content-type">>, <<"application/json">>},
+            {<<"accept">>, <<"application/json">>}],
+    Headers = case maps:get(initial_access_token, Opts, undefined) of
+                  undefined -> Base;
+                  Token when is_binary(Token) ->
+                      [{<<"authorization">>, <<"Bearer ", Token/binary>>}
+                       | Base]
+              end,
     Body = iolist_to_binary(json:encode(Metadata)),
     case hackney:request(post, RegistrationEndpoint, Headers, Body,
                           [with_body]) of

--- a/test/barrel_mcp_client_auth_oauth_tests.erl
+++ b/test/barrel_mcp_client_auth_oauth_tests.erl
@@ -98,7 +98,11 @@ refresh_round_trip_test_() ->
          {"register_client returns client_id + client_secret",
           fun test_register_client_confidential/0},
          {"register_client surfaces 4xx errors",
-          fun test_register_client_error/0}
+          fun test_register_client_error/0},
+         {"register_client/3 sends initial access token",
+          fun test_register_client_protected/0},
+         {"register_client/2 rejected without initial access token",
+          fun test_register_client_protected_unauth/0}
      ]}}.
 
 setup_mock() ->
@@ -233,9 +237,25 @@ init(Req0, register) ->
     {ok, Body, Req} = cowboy_req:read_body(Req0),
     Metadata = json:decode(Body),
     Name = maps:get(<<"client_name">>, Metadata, <<"unnamed">>),
-    %% Test marker: client_name="confidential" provokes a
-    %% client_secret in the response; "bad" provokes a 400.
+    %% Test marker: client_name="protected" requires the RFC 7591
+    %% initial access token; reject without it.
+    AuthHdr = cowboy_req:header(<<"authorization">>, Req0),
     case Name of
+        <<"protected">> when AuthHdr =/= <<"Bearer init-tok">> ->
+            R = cowboy_req:reply(401,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{<<"error">> => <<"invalid_token">>}),
+                Req),
+            {ok, R, register};
+        <<"protected">> ->
+            R = cowboy_req:reply(201,
+                #{<<"content-type">> => <<"application/json">>},
+                json_encode(#{
+                    <<"client_id">> => <<"protected-client-id">>,
+                    <<"client_id_issued_at">> => 1700000000,
+                    <<"client_name">> => Name
+                }), Req),
+            {ok, R, register};
         <<"bad">> ->
             R = cowboy_req:reply(400,
                 #{<<"content-type">> => <<"application/json">>},
@@ -473,3 +493,22 @@ test_register_client_error() ->
         <<?BASE/binary, "/oauth/register">>,
         #{<<"client_name">> => <<"bad">>}),
     ?assertMatch({error, {http_error, 400, _}}, Result).
+
+test_register_client_protected() ->
+    %% Protected registration endpoint: caller passes the
+    %% RFC 7591 initial access token via the Opts map, library
+    %% sets `Authorization: Bearer ...'.
+    {ok, Resp} = barrel_mcp_client_auth_oauth:register_client(
+        <<?BASE/binary, "/oauth/register">>,
+        #{<<"client_name">> => <<"protected">>},
+        #{initial_access_token => <<"init-tok">>}),
+    ?assertEqual(<<"protected-client-id">>,
+                 maps:get(<<"client_id">>, Resp)).
+
+test_register_client_protected_unauth() ->
+    %% Same endpoint but no initial access token: AS rejects
+    %% with 401, surfaced as {error, {http_error, 401, _}}.
+    Result = barrel_mcp_client_auth_oauth:register_client(
+        <<?BASE/binary, "/oauth/register">>,
+        #{<<"client_name">> => <<"protected">>}),
+    ?assertMatch({error, {http_error, 401, _}}, Result).


### PR DESCRIPTION
RFC 7591 section 3 lets the AS protect its `registration_endpoint` behind an initial access token. The previous `register_client/2` sent only Content-Type / Accept headers and could not satisfy that requirement, so MCP discovery against a compliant protected endpoint was unusable.

## API

- New `register_client/3` takes an `Opts` map. When `initial_access_token` is present, the call adds `Authorization: Bearer <token>`.
- `register_client/2` stays as a thin wrapper for the unprotected case.

## Tests

2 new eunit cases: protected endpoint accepts the token; same endpoint rejects with 401 without it. Existing 23 cases unchanged.