### PR TITLE
Security follow-ups from review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security follow-ups
+
+- **Scope checks now fail closed.** When `required_scopes` is configured but a custom auth provider returns an `AuthInfo` map without a `scopes` key (or with a non-list value), the request is rejected with `{error, insufficient_scope}`. Previously these requests were admitted because the catch-all `check_scopes/2` clause returned `{ok, AuthInfo}`. Behaviour is unchanged for `barrel_mcp_auth_bearer` (which always emits a list).
+- **Tool crash details no longer leak to clients.** When a tool handler raises, `barrel_mcp_registry` logs the class, reason, stack, request id, module and function via `logger:error`. The wire-level error is now a generic `<<"Internal tool error">>` from both `barrel_mcp_protocol` and `barrel_mcp_http_stream`; the previous `io_lib:format("~p", [Reason])` could disclose module/file/function names and exception terms.
+- **Streamable-HTTP client buffers are capped.** `barrel_mcp_client_http` now bounds in-flight response buffers (16 MiB) and SSE event buffers (4 MiB). On overrun the client emits `{mcp_closed, Pid, {response_too_large, Bytes}}` and drops the request from tracking; a malicious or compromised MCP server can no longer drive unbounded memory growth in the host.
+- **OAuth discovery no longer follows redirects.** `barrel_mcp_client_auth_oauth:discover_protected_resource/1` and `discover_authorization_server/1` previously passed `{follow_redirect, true}`, which let an untrusted MCP server redirect discovery into an SSRF-style probe. The flag is now `false`; non-2xx surfaces as `{error, {http_error, Status}}`.
+
 ### Enterprise-Managed Authorization grant
 
 - New connect-spec entry `auth => {oauth_enterprise, Config}` chains an IdP-issued ID Token (or SAML assertion) through RFC 8693 token-exchange (at the IdP) and RFC 7523 jwt-bearer (at the AS) into a short-lived MCP access token. Required Config keys: `idp_token_endpoint`, `as_token_endpoint`, `client_id`, `subject_token`, `subject_token_type`, `audience`, `resource`. Optional `client_secret` / `client_assertion`, `scopes`. Implements the second half of `modelcontextprotocol/ext-auth` for SSO-driven MCP hosts.

--- a/src/barrel_mcp_auth.erl
+++ b/src/barrel_mcp_auth.erl
@@ -365,11 +365,14 @@ decode_basic_auth(Encoded) ->
             {error, no_credentials}
     end.
 
-check_scopes(RequiredScopes, #{scopes := TokenScopes} = AuthInfo) ->
+check_scopes(RequiredScopes, #{scopes := TokenScopes} = AuthInfo)
+  when is_list(TokenScopes) ->
     case lists:all(fun(S) -> lists:member(S, TokenScopes) end, RequiredScopes) of
         true -> {ok, AuthInfo};
         false -> {error, insufficient_scope}
     end;
-check_scopes(_, AuthInfo) ->
-    %% No scopes in token, check if any required
-    {ok, AuthInfo}.
+check_scopes(_RequiredScopes, _AuthInfo) ->
+    %% required_scopes is configured but the provider did not surface a
+    %% scopes list (or surfaced a non-list). Fail closed: a missing
+    %% claim is not implicit consent.
+    {error, insufficient_scope}.

--- a/src/barrel_mcp_client_auth_oauth.erl
+++ b/src/barrel_mcp_client_auth_oauth.erl
@@ -645,8 +645,12 @@ apply_token_response(H, _) -> H.
 %%====================================================================
 
 http_get_json(Url) ->
+    %% Discovery endpoints (RFC 9728 / RFC 8414) are typically served
+    %% directly under the same origin as the resource. Following
+    %% arbitrary cross-origin redirects from an untrusted server
+    %% turns these helpers into an SSRF primitive, so we don't.
     case hackney:request(get, Url, [{<<"accept">>, <<"application/json">>}],
-                         <<>>, [with_body, {follow_redirect, true}]) of
+                         <<>>, [with_body, {follow_redirect, false}]) of
         {ok, 200, _Hdrs, Body} ->
             try {ok, json:decode(Body)}
             catch _:_ -> {error, {invalid_json, Body}} end;

--- a/src/barrel_mcp_client_http.erl
+++ b/src/barrel_mcp_client_http.erl
@@ -48,6 +48,14 @@
     retried = false :: boolean()
 }).
 
+%% Cap incoming response and SSE buffers so a malicious or
+%% misbehaving MCP server cannot drive unbounded memory growth on
+%% the host. A request that overflows is closed with a
+%% `{response_too_large, ...}' reason; the long-lived SSE stream is
+%% torn down and rescheduled.
+-define(MAX_RESP_BYTES, 16 * 1024 * 1024).
+-define(MAX_SSE_BUFFER_BYTES, 4 * 1024 * 1024).
+
 -record(state, {
     owner :: pid(),
     url :: binary(),
@@ -179,17 +187,37 @@ handle_info({hackney_response, Ref, {error, Reason}},
             {noreply, State}
     end;
 handle_info({hackney_response, Ref, Chunk},
-            #state{requests = Reqs, sse_ref = SseRef} = State)
+            #state{requests = Reqs, sse_ref = SseRef, owner = Owner} = State)
   when is_binary(Chunk) ->
     case maps:find(Ref, Reqs) of
         {ok, #req{format = sse, buffer = Buf} = R} ->
-            {Events, NewBuf} = parse_sse(<<Buf/binary, Chunk/binary>>),
-            State1 = forward_sse_events(Events, State),
-            R1 = R#req{buffer = NewBuf},
-            {noreply, State1#state{requests = Reqs#{Ref => R1}}};
+            Combined = <<Buf/binary, Chunk/binary>>,
+            case byte_size(Combined) > ?MAX_SSE_BUFFER_BYTES of
+                true ->
+                    %% Drop the request from tracking; further chunks
+                    %% for this Ref fall through the unknown-ref clause.
+                    Owner ! {mcp_closed, self(),
+                             {response_too_large, byte_size(Combined)}},
+                    {noreply, State#state{requests = maps:remove(Ref, Reqs)}};
+                false ->
+                    {Events, NewBuf} = parse_sse(Combined),
+                    State1 = forward_sse_events(Events, State),
+                    R1 = R#req{buffer = NewBuf},
+                    {noreply, State1#state{requests = Reqs#{Ref => R1}}}
+            end;
         {ok, #req{buffer = Buf} = R} ->
-            R1 = R#req{buffer = <<Buf/binary, Chunk/binary>>},
-            {noreply, State#state{requests = Reqs#{Ref => R1}}};
+            Combined = <<Buf/binary, Chunk/binary>>,
+            case byte_size(Combined) > ?MAX_RESP_BYTES of
+                true ->
+                    %% Drop the request from tracking; further chunks
+                    %% for this Ref fall through the unknown-ref clause.
+                    Owner ! {mcp_closed, self(),
+                             {response_too_large, byte_size(Combined)}},
+                    {noreply, State#state{requests = maps:remove(Ref, Reqs)}};
+                false ->
+                    R1 = R#req{buffer = Combined},
+                    {noreply, State#state{requests = Reqs#{Ref => R1}}}
+            end;
         error when Ref =:= SseRef ->
             handle_sse_chunk(Chunk, State);
         error ->
@@ -286,10 +314,23 @@ handle_sse_status(_Ref, _Status, State) ->
 handle_sse_headers(_Ref, _Headers, State) ->
     {noreply, State}.
 
-handle_sse_chunk(Chunk, #state{sse_buffer = Buf} = State) ->
-    {Events, NewBuf} = parse_sse(<<Buf/binary, Chunk/binary>>),
-    State1 = forward_sse_events(Events, State),
-    {noreply, State1#state{sse_buffer = NewBuf}}.
+handle_sse_chunk(Chunk, #state{sse_buffer = Buf, owner = Owner} = State) ->
+    Combined = <<Buf/binary, Chunk/binary>>,
+    case byte_size(Combined) > ?MAX_SSE_BUFFER_BYTES of
+        true ->
+            %% Drop the long-lived SSE channel; reopen on the next
+            %% timer tick so a transient overrun doesn't permanently
+            %% disable server-to-client traffic.
+            Owner ! {mcp_closed, self(),
+                     {response_too_large, byte_size(Combined)}},
+            erlang:send_after(1000, self(), reopen_sse),
+            {noreply, State#state{sse_ref = undefined,
+                                  sse_buffer = <<>>}};
+        false ->
+            {Events, NewBuf} = parse_sse(Combined),
+            State1 = forward_sse_events(Events, State),
+            {noreply, State1#state{sse_buffer = NewBuf}}
+    end.
 
 handle_sse_done(State) ->
     %% Server closed the long-lived stream; reopen in a moment.

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -543,10 +543,12 @@ deliver_tool_outcome(Req0, State, SessionId, RequestId,
                        #{<<"content">> =>
                             [#{<<"type">> => <<"text">>, <<"text">> => Msg}],
                          <<"isError">> => true});
-deliver_tool_outcome(Req0, State, SessionId, RequestId, {failed, Reason}) ->
+deliver_tool_outcome(Req0, State, SessionId, RequestId, {failed, _Reason}) ->
+    %% Crash details are logged server-side by the registry. Wire emits
+    %% only a generic message.
     send_jsonrpc_error_envelope(Req0, State, SessionId, RequestId,
                                 ?MCP_TOOL_ERROR,
-                                iolist_to_binary(io_lib:format("~p", [Reason])));
+                                <<"Internal tool error">>);
 deliver_tool_outcome(Req0, State, SessionId, RequestId, timeout) ->
     send_jsonrpc_error_envelope(Req0, State, SessionId, RequestId,
                                 ?MCP_TOOL_ERROR, <<"Tool timed out">>).

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -593,9 +593,12 @@ drive_async_plan(Plan, Timeout) ->
                 #{<<"content">> =>
                     [#{<<"type">> => <<"text">>, <<"text">> => Msg}],
                   <<"isError">> => true});
-        {tool_failed, RequestId, Reason} ->
+        {tool_failed, RequestId, _Reason} ->
+            %% Crash details are logged server-side by the registry; do
+            %% not echo `Reason' back to the wire (it can carry module
+            %% paths, file paths, or secret-bearing exception terms).
             error_response(RequestId, ?MCP_TOOL_ERROR,
-                iolist_to_binary(io_lib:format("~p", [Reason])))
+                           <<"Internal tool error">>)
     after Timeout ->
         error_response(RequestId, ?MCP_TOOL_ERROR, <<"Tool timed out">>)
     end.

--- a/src/barrel_mcp_registry.erl
+++ b/src/barrel_mcp_registry.erl
@@ -323,7 +323,14 @@ invoke_tool_handler(Args, Ctx, #{module := M, function := F} = Handler,
         deliver_tool_result(Result, Handler, ReplyTo, RequestId)
     catch
         Class:Reason:Stack ->
-            ReplyTo ! {tool_failed, RequestId, {Class, Reason, Stack}}
+            %% Log the full exception (with stack) server-side and
+            %% surface only an opaque request-scoped reference to the
+            %% client. The wire layer renders a generic "Internal tool
+            %% error" text; operators cross-reference using the id.
+            logger:error("Tool handler crashed: ~p:~p ~p (request_id=~p, "
+                         "module=~p, function=~p)",
+                         [Class, Reason, Stack, RequestId, M, F]),
+            ReplyTo ! {tool_failed, RequestId, internal_error}
     end.
 
 deliver_tool_result({tool_error, Content}, _Handler, ReplyTo, RequestId) ->

--- a/test/barrel_mcp_auth_tests.erl
+++ b/test/barrel_mcp_auth_tests.erl
@@ -50,6 +50,8 @@ auth_test_() ->
         %% Scope checking
         {"Scope check passes with required scopes", fun test_scope_check_pass/0},
         {"Scope check fails with missing scopes", fun test_scope_check_fail/0},
+        {"Scope check fails closed when provider omits scopes",
+         fun test_scope_check_fail_closed/0},
 
         %% Custom auth tests
         {"Custom auth init calls module init", fun test_custom_init/0},
@@ -336,6 +338,17 @@ test_scope_check_fail() ->
 
     Request = #{headers => #{<<"authorization">> => <<"Bearer ", Token/binary>>}},
     ?assertEqual({error, insufficient_scope}, barrel_mcp_auth:authenticate(Config, Request, Config)).
+
+test_scope_check_fail_closed() ->
+    %% Custom provider that returns no `scopes' key. With
+    %% required_scopes configured, the request must be rejected; a
+    %% missing claim is not implicit consent.
+    Config = #{provider => test_auth_no_scopes,
+               provider_state => #{},
+               required_scopes => [<<"read">>]},
+    Request = #{headers => #{<<"authorization">> => <<"Bearer anything">>}},
+    ?assertEqual({error, insufficient_scope},
+                 barrel_mcp_auth:authenticate(Config, Request, Config)).
 
 %%====================================================================
 %% Helper Functions

--- a/test/test_auth_no_scopes.erl
+++ b/test/test_auth_no_scopes.erl
@@ -1,0 +1,14 @@
+%%%-------------------------------------------------------------------
+%%% @doc Test auth provider that authenticates any request without
+%%% surfacing a `scopes' key. Used to assert that scope checks fail
+%%% closed when a custom provider omits scope claims.
+%%% @end
+%%%-------------------------------------------------------------------
+-module(test_auth_no_scopes).
+
+-export([init/1, authenticate/2]).
+
+init(_Opts) -> {ok, #{}}.
+
+authenticate(_Request, _State) ->
+    {ok, #{subject => <<"test-user">>}}.


### PR DESCRIPTION
Four findings from the review on `feat/dcr-initial-access-token`.

## Wire / API

- `barrel_mcp_auth:check_scopes/2` fails closed when a custom provider returns an `AuthInfo` without a `scopes` key. `barrel_mcp_auth_bearer` is unaffected (it always emits a list).
- Tool handler crashes now log `Class:Reason:Stack` server-side via `logger:error` (with request id, module, function) and surface a generic `<<"Internal tool error">>` to the client. Replaces the previous `io_lib:format("~p", [Reason])`.
- `barrel_mcp_client_http` caps response buffers at 16 MiB and SSE event buffers at 4 MiB. On overrun the owner gets `{mcp_closed, Pid, {response_too_large, Bytes}}`.
- `barrel_mcp_client_auth_oauth:http_get_json/1` (used by PRM and AS metadata discovery) no longer sets `{follow_redirect, true}`.

## Tests

1 new eunit case (`test_scope_check_fail_closed` with a no-scopes provider). 262 eunit, 38 CT, dialyzer green.