### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-10
+
+A feature release that completes the OAuth surface vs MCP `2025-11-25` and `modelcontextprotocol/ext-auth`: Enterprise-Managed Authorization (EMA) for SSO-driven hosts, Dynamic Client Registration (RFC 7591) including the section-3 protected variant, plus four security follow-ups from review (scope fail-closed, no exception leakage, capped client buffers, no redirect-following on discovery).
+
 ### Security follow-ups
 
 - **Scope checks now fail closed.** When `required_scopes` is configured but a custom auth provider returns an `AuthInfo` map without a `scopes` key (or with a non-list value), the request is rejected with `{error, insufficient_scope}`. Previously these requests were admitted because the catch-all `check_scopes/2` clause returned `{ok, AuthInfo}`. Behaviour is unchanged for `barrel_mcp_auth_bearer` (which always emits a list).
@@ -405,4 +409,6 @@ Initial release of barrel_mcp, an Erlang implementation of the Model Context Pro
 - MCP 2024-11-05 specification
 - Methods: initialize, ping, tools/list, tools/call, resources/list, resources/read, prompts/list, prompts/get
 
+[1.3.0]: https://github.com/barrel-platform/barrel_mcp/releases/tag/v1.3.0
+[1.2.0]: https://github.com/barrel-platform/barrel_mcp/releases/tag/v1.2.0
 [1.0.0]: https://github.com/barrel-db/barrel_mcp/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Add to your `rebar.config`:
 {deps, [
     {barrel_mcp,
         {git, "https://github.com/barrel-platform/barrel_mcp.git",
-              {tag, "v1.2.0"}}}
+              {tag, "v1.3.0"}}}
 ]}.
 ```
 

--- a/src/barrel_mcp.app.src
+++ b/src/barrel_mcp.app.src
@@ -1,13 +1,13 @@
 {application, barrel_mcp, [
     {description, "MCP Protocol Library for Erlang"},
-    {vsn, "1.2.0"},
+    {vsn, "1.3.0"},
     {registered, [barrel_mcp_registry, barrel_mcp_sup, barrel_mcp_session,
                   barrel_mcp_tasks, barrel_mcp_client_sup]},
     {mod, {barrel_mcp_app, []}},
     {applications, [kernel, stdlib, crypto, cowboy, hackney]},
     {env, [
         {server_name, <<"barrel">>},
-        {server_version, <<"1.2.0">>},
+        {server_version, <<"1.3.0">>},
         {protocol_version, <<"2025-11-25">>},
         {session_ttl, 1800000}  %% 30 minutes default
     ]},


### PR DESCRIPTION
Bumps `vsn`, `server_version`, README install snippet, and CHANGELOG header.

## Highlights

- Enterprise-Managed Authorization grant (RFC 8693 + RFC 7523).
- Dynamic Client Registration (RFC 7591) including the section-3 protected variant.
- Security follow-ups: scope checks fail closed, no exception leakage on tool crash, capped HTTP client buffers, no redirect-following on OAuth discovery.

See `CHANGELOG.md` `[1.3.0]` for the full list.