### PR TITLE
2.0.1: transport review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-05-21
+
+Follow-up hardening from a review of the 2.0.0 transport.
+
+### Fixed
+
+- **`_auth` no longer leaks into inbound responses.** The Streamable HTTP transport tagged the authenticated principal (`_auth`) on every decoded message before splitting requests from responses, so a client-posted JSON-RPC response (answering a server `sampling`/`elicitation` request) carried `_auth` into the delivered map. It is now attached only on the request dispatch path, matching 1.x behaviour. Server-internal only; no data was sent to clients.
+- **Accept loop no longer spins on persistent errors.** `barrel_mcp_http_listener` now backs off briefly on a non-`closed` accept error, so a system error such as file-descriptor exhaustion (`emfile`) throttles the acceptor instead of burning CPU.
+
 ## [2.0.0] - 2026-05-21
 
 A dependency-restructuring release. The HTTP server transport is rebuilt on the `h1` and `h2` libraries and Cowboy is removed from the library, so `barrel_mcp` can be embedded next to web frameworks (such as Livery) that bring their own HTTP stack without dragging Cowboy into the runtime. The protocol core and the public start/stop API are unchanged.

--- a/src/barrel_mcp.app.src
+++ b/src/barrel_mcp.app.src
@@ -1,13 +1,13 @@
 {application, barrel_mcp, [
     {description, "MCP Protocol Library for Erlang"},
-    {vsn, "2.0.0"},
+    {vsn, "2.0.1"},
     {registered, [barrel_mcp_registry, barrel_mcp_sup, barrel_mcp_session,
                   barrel_mcp_tasks, barrel_mcp_client_sup]},
     {mod, {barrel_mcp_app, []}},
     {applications, [kernel, stdlib, crypto, h1, h2, hackney]},
     {env, [
         {server_name, <<"barrel">>},
-        {server_version, <<"2.0.0">>},
+        {server_version, <<"2.0.1">>},
         {protocol_version, <<"2025-11-25">>},
         {session_ttl, 1800000}  %% 30 minutes default
     ]},

--- a/src/barrel_mcp_http_engine.erl
+++ b/src/barrel_mcp_http_engine.erl
@@ -213,8 +213,11 @@ stream_post_authed(Headers, Body, Responder, Config, AuthInfo) ->
                                 ?JSONRPC_INVALID_REQUEST,
                                 <<"Batch requests are not supported">>);
         {ok, Request} when is_map(Request) ->
+            %% Pass the raw request through the response-vs-request
+            %% split; `_auth' is attached only on the request path
+            %% (handle_dispatch), never on inbound responses.
             stream_post_request(Headers, Responder, Config, SessionEnabled,
-                                with_auth(Request, AuthInfo), AuthInfo);
+                                Request, AuthInfo);
         {error, parse_error} ->
             reply_jsonrpc_error(Headers, Responder, Config, undefined, 400, null,
                                 ?JSONRPC_PARSE_ERROR, <<"Parse error">>)
@@ -271,7 +274,8 @@ handle_dispatch(Headers, Responder, Config, SessionId, Request, AuthInfo) ->
                                  _ -> #{session_id => SessionId}
                              end,
             ProtocolState = ProtocolState0#{auth_info => AuthInfo},
-            case barrel_mcp_protocol:handle(Request, ProtocolState) of
+            case barrel_mcp_protocol:handle(with_auth(Request, AuthInfo),
+                                            ProtocolState) of
                 no_response ->
                     Hdrs = add_session_header(
                              cors_headers(Headers, Config, #{}), SessionId),

--- a/src/barrel_mcp_http_listener.erl
+++ b/src/barrel_mcp_http_listener.erl
@@ -31,6 +31,10 @@
 -define(MAX_BODY_BYTES, 16 * 1024 * 1024).
 -define(BODY_TIMEOUT, 60000).
 -define(HANDSHAKE_TIMEOUT, 30000).
+%% Brief backoff after a non-`closed' accept error so a persistent
+%% system error (e.g. file-descriptor exhaustion, `emfile') throttles
+%% the accept loop instead of spinning the CPU.
+-define(ACCEPT_ERROR_BACKOFF, 50).
 
 %%====================================================================
 %% API
@@ -162,6 +166,7 @@ acceptor_loop(LSock, Transport, Handler, Listener) ->
         {error, closed} ->
             ok;
         {error, _Reason} ->
+            timer:sleep(?ACCEPT_ERROR_BACKOFF),
             acceptor_loop(LSock, Transport, Handler, Listener)
     end.
 


### PR DESCRIPTION
Hardening from the 2.0.0 transport review.

- Attach `_auth` only on the request dispatch path; a client-posted JSON-RPC response no longer carries it into the delivered map (server-internal, matches 1.x).
- `barrel_mcp_http_listener` backs off on non-`closed` accept errors so fd exhaustion (`emfile`) throttles instead of spinning the CPU.

No API changes. Version 2.0.1.