### PR TITLE
Release 2.0.2: security fixes for the HTTP transport and auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ test/interop/__pycache__/
 
 # Rebar3
 rebar.lock
+rebar3.crashdump
 
 # IDE/Editor
 .idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2] - 2026-05-23
+
+A security release from a release-time review of the HTTP transport
+and the auth providers. No public API changes.
+
+### Security
+
+- **Authentication is enforced on every Streamable HTTP verb.**
+  Previously only POST ran the configured auth provider; GET (open
+  SSE stream) and DELETE (terminate session) were gated by the
+  `Mcp-Session-Id` alone. A caller holding a leaked session id could
+  read a session's server-to-client SSE traffic (including replayed
+  buffered events) or terminate sessions without presenting a
+  credential. Both verbs now run the same auth gate as POST, before
+  any session lookup. With `barrel_mcp_auth_none` (the default)
+  behaviour is unchanged.
+- **Resource, prompt and completion handler crashes no longer leak
+  exception terms to the client.** The 2.0.1 change that returns a
+  generic `Internal tool error` covered only `tools/call`. The
+  synchronous `resources/read`, `prompts/get` and
+  `completion/complete` paths still serialised the caught
+  `Class:Reason` (which can carry internal paths, argument values or
+  secret-bearing terms) into the JSON-RPC error. They now log the
+  class, reason, stack, request id and handler name via
+  `logger:error` and return a generic message.
+- **The built-in listener caps concurrent connections.** Because
+  `idle_timeout` is `infinity` (so long-lived SSE GETs are never
+  reaped), a connection lived until the peer closed it, so a flood of
+  connections or slow/idle keep-alive clients could exhaust file
+  descriptors and memory. Each listener now bounds established
+  connections (default 16384, override with the `max_connections`
+  start option) and drops connections past the cap. h1's default 60s
+  `request_timeout` already bounds slow request headers.
+- **Basic-auth unknown-user timing matches the configured mode.**
+  When `hash_passwords` was `false` the unknown-user path still ran
+  the slow PBKDF2 stand-in while the configured-user path ran a fast
+  SHA-256 compare, so response timing could reveal whether a username
+  existed. The stand-in now does the same work as the active
+  comparison mode.
+
+### Fixed
+
+- **Client reports its real version.** The default `client_info` sent
+  in `initialize` was pinned at `2.0.0`; it now matches the library
+  version. The README dependency example also pinned the stale
+  `v1.3.0` tag.
+
 ## [2.0.1] - 2026-05-21
 
 Follow-up hardening from a review of the 2.0.0 transport.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add to your `rebar.config`:
 {deps, [
     {barrel_mcp,
         {git, "https://github.com/barrel-platform/barrel_mcp.git",
-              {tag, "v1.3.0"}}}
+              {tag, "v2.0.2"}}}
 ]}.
 ```
 

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -75,7 +75,7 @@ Every key is documented below.
 | Key | Type | Default | Effect |
 | --- | --- | --- | --- |
 | `transport` | `{http, Url}` \| `{stdio, #{command, args}}` | required | Which transport to open. |
-| `client_info` | `#{name, version}` | `#{name => <<"barrel_mcp_client">>, version => <<"2.0.0">>}` | Sent in `initialize`. |
+| `client_info` | `#{name, version}` | `#{name => <<"barrel_mcp_client">>, version => <<"2.0.2">>}` | Sent in `initialize`. |
 | `capabilities` | map | `#{}` | Client capabilities to declare. Booleans become spec-shape objects on the wire (e.g. `#{sampling => true}` becomes `#{<<"sampling">> => #{}}`). |
 | `handler` | `{Mod, Args}` | `{barrel_mcp_client_handler_default, []}` | Module implementing `barrel_mcp_client_handler` to handle server-initiated requests and notifications. |
 | `auth` | `none` \| `{bearer, Token}` \| `{oauth, Config}` | `none` | Authentication. See section 14. |

--- a/guides/features.md
+++ b/guides/features.md
@@ -112,7 +112,7 @@ Erlang MCP library. See `CHANGELOG.md` for release-by-release detail.
 - **OAuth 2.0 Protected Resource Metadata** (RFC 9728): pass
   `resource_metadata => #{resource, authorization_servers}` to
   `start_http_stream/1` / `start_http/1` to expose
-  `/.well-known/oauth-protected-resource' and have the bearer
+  `/.well-known/oauth-protected-resource` and have the bearer
   challenge emit `WWW-Authenticate: Bearer ...
   resource_metadata="<URL>"` so MCP clients auto-discover the
   authorization server.

--- a/src/barrel_mcp.app.src
+++ b/src/barrel_mcp.app.src
@@ -1,13 +1,13 @@
 {application, barrel_mcp, [
     {description, "MCP Protocol Library for Erlang"},
-    {vsn, "2.0.1"},
+    {vsn, "2.0.2"},
     {registered, [barrel_mcp_registry, barrel_mcp_sup, barrel_mcp_session,
                   barrel_mcp_tasks, barrel_mcp_client_sup]},
     {mod, {barrel_mcp_app, []}},
     {applications, [kernel, stdlib, crypto, h1, h2, hackney]},
     {env, [
         {server_name, <<"barrel">>},
-        {server_version, <<"2.0.1">>},
+        {server_version, <<"2.0.2">>},
         {protocol_version, <<"2025-11-25">>},
         {session_ttl, 1800000}  %% 30 minutes default
     ]},

--- a/src/barrel_mcp_auth_basic.erl
+++ b/src/barrel_mcp_auth_basic.erl
@@ -114,7 +114,7 @@ verify_credentials(Username, Password, #{credentials := Creds, hash_passwords :=
     %% timing doesn't leak username existence.
     case maps:get(Username, Creds, undefined) of
         undefined ->
-            _ = verify_password(Password, dummy_hash()),
+            _ = dummy_verify(Password, HashPwd),
             {error, invalid_credentials};
         ExpectedPassword when is_binary(ExpectedPassword) ->
             verify_password(Username, Password, ExpectedPassword, HashPwd);
@@ -246,6 +246,19 @@ legacy_sha256_hex(Password) ->
 %% unknown-user path so the verify_password/2 work cost matches
 %% the configured-user path. Cached in `persistent_term' so we pay
 %% the (~tens of ms) construction cost at most once per node.
+%% Constant-work stand-in for the unknown-user path. Does the same
+%% comparison work as verify_password/4 for the active `hash_passwords'
+%% mode so request timing does not reveal whether a username exists.
+%% Previously this always ran PBKDF2, making unknown users markedly
+%% slower than known users when hash_passwords = false (still a
+%% username-existence oracle, just inverted).
+dummy_verify(Password, true) ->
+    verify_password(Password, dummy_hash());
+dummy_verify(Password, false) ->
+    HashedInput = legacy_sha256_hex(Password),
+    HashedExpected = legacy_sha256_hex(<<"unused-timing-stand-in">>),
+    crypto:hash_equals(HashedInput, HashedExpected).
+
 -define(DUMMY_HASH_KEY, {?MODULE, dummy_hash}).
 dummy_hash() ->
     case persistent_term:get(?DUMMY_HASH_KEY, undefined) of

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -668,7 +668,7 @@ notify_progress(Params, Data) ->
 build_initialize_params(#data{spec = Spec}) ->
     ClientInfo0 = maps:get(client_info, Spec,
                            #{<<"name">> => <<"barrel_mcp_client">>,
-                             <<"version">> => <<"2.0.0">>}),
+                             <<"version">> => <<"2.0.2">>}),
     ClientInfo = normalize_keys(ClientInfo0),
     Caps = capabilities_to_wire(maps:get(capabilities, Spec, #{})),
     Version = maps:get(protocol_version, Spec, ?MCP_CLIENT_PROTOCOL_VERSION),

--- a/src/barrel_mcp_http.erl
+++ b/src/barrel_mcp_http.erl
@@ -53,7 +53,9 @@ start(Opts) ->
                 allow_missing_origin => AllowMissing,
                 resource_metadata => ResourceMetadata
             },
-            ListenOpts = #{port => Port, ip => Ip, ssl => normalize_ssl(Opts)},
+            ListenOpts = maps:merge(
+                           #{port => Port, ip => Ip, ssl => normalize_ssl(Opts)},
+                           maps:with([max_connections, acceptors], Opts)),
             barrel_mcp_http_listener:start(?HTTP_LISTENER, ListenOpts, EngineConfig)
     end.
 

--- a/src/barrel_mcp_http_engine.erl
+++ b/src/barrel_mcp_http_engine.erl
@@ -20,7 +20,7 @@
 %%%       Lookups are case-insensitive.</li>
 %%%   <li>`Body' — the full request body (`<<>>' when none).</li>
 %%%   <li>`Responder' — a map of I/O closures (see below).</li>
-%%%   <li>`Config' — the engine configuration (see {@link config/0}).</li>
+%%%   <li>`Config' — the engine configuration (see the `config()' type).</li>
 %%% </ul>
 %%%
 %%% The `Responder' abstracts response delivery so the engine never
@@ -555,6 +555,10 @@ maybe_capture_initialize_version(_, _, _) -> ok.
 %%====================================================================
 
 stream_get_sse(Headers, Responder, Config) ->
+    with_authenticated(Headers, Responder, Config,
+                       fun() -> stream_get_sse_authed(Headers, Responder, Config) end).
+
+stream_get_sse_authed(Headers, Responder, Config) ->
     case maps:get(session_enabled, Config, true) of
         false ->
             reply(Responder, 400, cors_headers(Headers, Config, #{}),
@@ -625,6 +629,10 @@ sse_cleanup(Responder, SessionId) ->
     ok.
 
 stream_delete(Headers, Responder, Config) ->
+    with_authenticated(Headers, Responder, Config,
+                       fun() -> stream_delete_authed(Headers, Responder, Config) end).
+
+stream_delete_authed(Headers, Responder, Config) ->
     case session_header(Headers) of
         undefined ->
             reply(Responder, 400, cors_headers(Headers, Config, #{}),
@@ -740,6 +748,21 @@ authenticate(#{provider := barrel_mcp_auth_none}, _Request) ->
     barrel_mcp_auth_none:authenticate(#{}, undefined);
 authenticate(AuthConfig, Request) ->
     barrel_mcp_auth:authenticate(AuthConfig, Request, AuthConfig).
+
+%% Run `Fun' only if the request passes the configured auth provider.
+%% Used by the GET (SSE) and DELETE verbs so they enforce the same
+%% credential as POST instead of trusting the session id alone. With
+%% `barrel_mcp_auth_none' this admits every request unchanged.
+with_authenticated(Headers, Responder, Config, Fun) ->
+    AuthConfig = maps:get(auth_config, Config,
+                          #{provider => barrel_mcp_auth_none}),
+    AuthRequest = #{headers => extract_headers(Headers, AuthConfig)},
+    case authenticate(AuthConfig, AuthRequest) of
+        {ok, _AuthInfo} ->
+            Fun();
+        {error, Reason} ->
+            auth_error(Headers, Responder, AuthConfig, Reason)
+    end.
 
 auth_error(Headers, Responder, AuthConfig, Reason) ->
     {StatusCode, AuthHeaders, Body} =

--- a/src/barrel_mcp_http_listener.erl
+++ b/src/barrel_mcp_http_listener.erl
@@ -35,6 +35,13 @@
 %% system error (e.g. file-descriptor exhaustion, `emfile') throttles
 %% the accept loop instead of spinning the CPU.
 -define(ACCEPT_ERROR_BACKOFF, 50).
+%% Default cap on concurrently-established connections per listener.
+%% `idle_timeout' is `infinity' (so long-lived SSE GETs are never
+%% reaped), which means a connection lives until the peer closes it.
+%% Without a cap a flood of connections — or slow/idle keep-alive
+%% clients — could exhaust file descriptors and memory. Override with
+%% the `max_connections' listen option.
+-define(DEFAULT_MAX_CONNECTIONS, 16384).
 
 %%====================================================================
 %% API
@@ -42,8 +49,9 @@
 
 %% @doc Start a listener registered as `Name'.
 %%
-%% `ListenOpts': `#{port, ip, ssl, acceptors}'. `ssl' is `undefined'
-%% (cleartext) or `#{certfile, keyfile, cacertfile => _}'.
+%% `ListenOpts': `#{port, ip, ssl, acceptors, max_connections}'.
+%% `ssl' is `undefined' (cleartext) or
+%% `#{certfile, keyfile, cacertfile => _}'.
 %% `EngineConfig' is passed verbatim to {@link barrel_mcp_http_engine:handle/6}.
 -spec start(atom(), map(), barrel_mcp_http_engine:config()) ->
     {ok, pid()} | {error, term()}.
@@ -94,13 +102,17 @@ listener_init(Parent, Name, ListenOpts, EngineConfig) ->
                     Handler = make_handler(EngineConfig),
                     N = maps:get(acceptors, ListenOpts,
                                  max(2, erlang:system_info(schedulers))),
+                    Max = maps:get(max_connections, ListenOpts,
+                                   ?DEFAULT_MAX_CONNECTIONS),
+                    Counter = atomics:new(1, [{signed, false}]),
                     Listener = self(),
                     _ = [spawn_link(fun() ->
-                                        acceptor_loop(LSock, Transport, Handler, Listener)
+                                        acceptor_loop(LSock, Transport, Handler,
+                                                      Listener, Counter, Max)
                                     end)
                          || _ <- lists:seq(1, N)],
                     Parent ! {self(), {ok, self()}},
-                    listener_loop(LSock, Transport);
+                    listener_loop(LSock, Transport, Counter);
                 _ ->
                     close_listen(Transport, LSock),
                     Parent ! {self(), {error, {already_started, Name}}}
@@ -109,7 +121,7 @@ listener_init(Parent, Name, ListenOpts, EngineConfig) ->
             Parent ! {self(), {error, Reason}}
     end.
 
-listener_loop(LSock, Transport) ->
+listener_loop(LSock, Transport, Counter) ->
     receive
         {stop, From, Ref} ->
             %% Close the listen socket (unblocks acceptors) and exit
@@ -118,11 +130,23 @@ listener_loop(LSock, Transport) ->
             close_listen(Transport, LSock),
             From ! {Ref, ok},
             exit(shutdown);
+        {track, Pid} ->
+            %% Monitor each accepted connection so its slot is released
+            %% on termination, however the process dies. The connection
+            %% owner does not trap exits (a linked `h1_connection'
+            %% stopping with `{shutdown, _}' would kill it), so it
+            %% cannot reliably release the slot itself.
+            _ = monitor(process, Pid),
+            listener_loop(LSock, Transport, Counter);
+        {'DOWN', _Ref, process, _Pid, _Reason} ->
+            atomics:sub(Counter, 1, 1),
+            listener_loop(LSock, Transport, Counter);
         {'EXIT', _Pid, _Reason} ->
-            %% A connection or acceptor process exited; ignore.
-            listener_loop(LSock, Transport);
+            %% A connection or acceptor process exited; ignore (the
+            %% slot is released by the matching `DOWN' above).
+            listener_loop(LSock, Transport, Counter);
         _Other ->
-            listener_loop(LSock, Transport)
+            listener_loop(LSock, Transport, Counter)
     end.
 
 listen(ListenOpts) ->
@@ -158,16 +182,29 @@ close_listen(ssl, LSock) -> _ = ssl:close(LSock), ok.
 %% Acceptor
 %%====================================================================
 
-acceptor_loop(LSock, Transport, Handler, Listener) ->
+acceptor_loop(LSock, Transport, Handler, Listener, Counter, Max) ->
     case do_accept(Transport, LSock) of
         {ok, Socket} ->
-            start_connection(Socket, Transport, Handler, Listener),
-            acceptor_loop(LSock, Transport, Handler, Listener);
+            _ = case atomics:add_get(Counter, 1, 1) > Max of
+                false ->
+                    Pid = start_connection(Socket, Transport, Handler, Listener),
+                    %% Hand the pid to the listener to monitor; it
+                    %% releases the slot on the connection's `DOWN'.
+                    Listener ! {track, Pid};
+                true ->
+                    %% At capacity: undo the reservation and drop the
+                    %% connection so a flood cannot exhaust resources.
+                    %% The brief backoff bounds the accept/close churn.
+                    atomics:sub(Counter, 1, 1),
+                    close(Transport, Socket),
+                    timer:sleep(?ACCEPT_ERROR_BACKOFF)
+            end,
+            acceptor_loop(LSock, Transport, Handler, Listener, Counter, Max);
         {error, closed} ->
             ok;
         {error, _Reason} ->
             timer:sleep(?ACCEPT_ERROR_BACKOFF),
-            acceptor_loop(LSock, Transport, Handler, Listener)
+            acceptor_loop(LSock, Transport, Handler, Listener, Counter, Max)
     end.
 
 do_accept(gen_tcp, LSock) -> gen_tcp:accept(LSock, infinity);
@@ -186,7 +223,7 @@ start_connection(Socket, Transport, Handler, Listener) ->
             Pid ! {socket_failed, Reason},
             close(Transport, Socket)
     end,
-    ok.
+    Pid.
 
 transfer(gen_tcp, Socket, Pid) -> gen_tcp:controlling_process(Socket, Pid);
 transfer(ssl, Socket, Pid) -> ssl:controlling_process(Socket, Pid).
@@ -202,6 +239,8 @@ connection_init(Transport, Handler, Listener) ->
     %% Link to the listener so a `stop' (listener exits `shutdown')
     %% terminates this connection too. The listener traps exits, so
     %% our own crash is absorbed there rather than killing the pool.
+    %% The listener also monitors us and releases our connection slot
+    %% on `DOWN' (see {@link listener_loop/3}).
     link(Listener),
     receive
         {socket_ready, Socket} ->

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -62,7 +62,8 @@
         session_enabled => boolean(),
         ssl => map(),
         allowed_origins => [binary()] | any,
-        allow_missing_origin => boolean()
+        allow_missing_origin => boolean(),
+        max_connections => pos_integer()
     }.
 start(Opts) ->
     Port = maps:get(port, Opts, 9090),
@@ -94,7 +95,9 @@ start(Opts) ->
                 sse_buffer_size => maps:get(sse_buffer_size, Opts, 256),
                 resource_metadata => ResourceMetadata
             },
-            ListenOpts = #{port => Port, ip => Ip, ssl => normalize_ssl(Opts)},
+            ListenOpts = maps:merge(
+                           #{port => Port, ip => Ip, ssl => normalize_ssl(Opts)},
+                           maps:with([max_connections, acceptors], Opts)),
             barrel_mcp_http_listener:start(?STREAM_LISTENER, ListenOpts, EngineConfig)
     end.
 

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -348,8 +348,9 @@ handle_request(<<"prompts/get">>, Params, Id, _State) ->
             });
         {error, {not_found, _, _}} ->
             error_response(Id, ?JSONRPC_METHOD_NOT_FOUND, <<"Prompt not found">>);
-        {error, Reason} ->
-            error_response(Id, ?MCP_PROMPT_ERROR, format_error(Reason))
+        {error, Crash} ->
+            log_handler_crash(prompt, Name, Id, Crash),
+            error_response(Id, ?MCP_PROMPT_ERROR, <<"Internal prompt error">>)
     end;
 
 %% Tasks
@@ -424,9 +425,10 @@ handle_request(<<"completion/complete">>, Params, Id, _State) ->
                                             completion_payload(Values, HasMore)});
                 {error, {not_found, _, _}} ->
                     success_response(Id, #{<<"completion">> => empty_completion()});
-                {error, Reason} ->
+                {error, Crash} ->
+                    log_handler_crash(completion, Key, Id, Crash),
                     error_response(Id, ?JSONRPC_INTERNAL_ERROR,
-                                   format_error(Reason))
+                                   <<"Internal completion error">>)
             end
     end;
 
@@ -624,8 +626,9 @@ run_resource_read(Type, Name, Args, Uri, Id) ->
         {ok, Result} ->
             Content = format_resource_result(Uri, Result),
             success_response(Id, #{<<"contents">> => Content});
-        {error, Reason} ->
-            error_response(Id, ?MCP_RESOURCE_ERROR, format_error(Reason))
+        {error, Crash} ->
+            log_handler_crash(resource, Name, Id, Crash),
+            error_response(Id, ?MCP_RESOURCE_ERROR, <<"Internal resource error">>)
     end.
 
 %% Walk the registered resource_template entries and return the
@@ -682,8 +685,14 @@ add_resource_uri(Uri, Block) when is_map(Block) ->
         false -> Block#{<<"uri">> => Uri}
     end.
 
-format_error({Class, Reason, _Stack}) ->
-    iolist_to_binary(io_lib:format("~p:~p", [Class, Reason])).
+%% Log a crashed resource/prompt/completion handler server-side and
+%% never surface the exception term to the client: a caught `Reason'
+%% can carry internal paths, argument values or secret-bearing terms.
+%% The wire layer returns a generic message; operators cross-reference
+%% via the request id. Mirrors the tool path in barrel_mcp_registry.
+log_handler_crash(Kind, Name, Id, Crash) ->
+    logger:error("~p handler crashed: ~p (request_id=~p, name=~p)",
+                 [Kind, Crash, Id, Name]).
 
 maybe_advertise_completions(Caps) ->
     case barrel_mcp_registry:all(completion) of

--- a/test/barrel_mcp_http_stream_security_SUITE.erl
+++ b/test/barrel_mcp_http_stream_security_SUITE.erl
@@ -35,7 +35,9 @@
     accept_wildcard_ok/1,
     initialize_with_unknown_session_returns_404/1,
     prm_endpoint_serves_metadata/1,
-    bearer_challenge_includes_resource_metadata/1
+    bearer_challenge_includes_resource_metadata/1,
+    get_sse_requires_auth/1,
+    delete_requires_auth/1
 ]).
 
 -define(BASE_PORT, 21100).
@@ -61,7 +63,9 @@ all() -> [
     accept_wildcard_ok,
     initialize_with_unknown_session_returns_404,
     prm_endpoint_serves_metadata,
-    bearer_challenge_includes_resource_metadata
+    bearer_challenge_includes_resource_metadata,
+    get_sse_requires_auth,
+    delete_requires_auth
 ].
 
 init_per_suite(Config) ->
@@ -431,6 +435,40 @@ bearer_challenge_includes_resource_metadata(Config) ->
     ?assertNotEqual(nomatch, binary:match(Challenge, ExpectedSubstr)),
     %% Make sure the legacy non-conformant `resource="..."' is gone.
     ?assertEqual(nomatch, binary:match(Challenge, <<" resource=\"">>)),
+    ok.
+
+%%====================================================================
+%% Auth is enforced on every verb, not just POST
+%%====================================================================
+
+%% A GET (open SSE) with no credentials must be rejected by the auth
+%% provider before any session is touched — the session id is not a
+%% credential. Regression for the GET/DELETE auth-bypass.
+get_sse_requires_auth(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{
+        port => Port,
+        session_enabled => true,
+        auth => #{provider => barrel_mcp_auth_bearer,
+                  provider_opts => #{secret => <<"top-secret">>}}}),
+    {ok, 401, _, _} = hackney:request(get, url(Port),
+        [{<<"accept">>, <<"text/event-stream">>},
+         {<<"mcp-session-id">>, <<"mcp_does_not_matter">>}],
+        <<>>, [with_body]),
+    ok.
+
+%% A DELETE (terminate session) with no credentials must likewise be
+%% rejected before the session lookup.
+delete_requires_auth(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{
+        port => Port,
+        session_enabled => true,
+        auth => #{provider => barrel_mcp_auth_bearer,
+                  provider_opts => #{secret => <<"top-secret">>}}}),
+    {ok, 401, _, _} = hackney:request(delete, url(Port),
+        [{<<"mcp-session-id">>, <<"mcp_does_not_matter">>}],
+        <<>>, [with_body]),
     ok.
 
 post_init(Port, ExtraHeaders) ->


### PR DESCRIPTION
A security release from a release-time review of the 2.0.x HTTP transport and the auth providers. No public API changes.

## Security

- **Auth enforced on every Streamable HTTP verb.** GET (open SSE) and DELETE (terminate session) previously ran no auth provider; the `Mcp-Session-Id` alone gated them, so a leaked session id let a caller read a session's SSE traffic or kill sessions without a credential. Both verbs now run the same gate as POST, before any session lookup. No-op under `barrel_mcp_auth_none`.
- **No exception-term leak on resource/prompt/completion crashes.** `resources/read`, `prompts/get` and `completion/complete` serialised the caught `Class:Reason` into the JSON-RPC error (the `tools/call` path was fixed in 2.0.1). They now log server-side and return a generic message.
- **Connection cap on the built-in listener.** `idle_timeout` is `infinity` so long-lived SSE GETs are never reaped, which left connections unbounded. Each listener now caps established connections (default 16384, `max_connections` option) and the listener monitors connections to release slots on exit. h1's 60s `request_timeout` already bounds slow request headers.
- **Basic-auth unknown-user timing matches the configured mode.** With `hash_passwords = false` the unknown-user path ran PBKDF2 while the configured path ran a fast SHA-256 compare, revealing username existence by timing. The stand-in now matches the active mode.

## Other

- Version bumped to 2.0.2 everywhere. Caught two strays: the client reported `2.0.0` in `client_info`, and the README dependency example pinned `v1.3.0`.
- Fixed a broken `{@link config/0}` edoc reference in `barrel_mcp_http_engine`.

Tests: 262 eunit, 40 CT (2 interop skipped), xref and dialyzer clean. New CT regression tests assert GET/DELETE return 401 when auth is configured.