### PR TITLE
Support Erlang/OTP 29 (2.1.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['27', '28']
+        otp: ['28', '29']
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
-          rebar3-version: '3.24'
+          rebar3-version: '3.27'
       - name: Restore rebar3 cache
         uses: actions/cache@v4
         with:
@@ -37,13 +37,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['27', '28']
+        otp: ['28', '29']
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
-          rebar3-version: '3.24'
+          rebar3-version: '3.27'
       - name: Restore rebar3 cache
         uses: actions/cache@v4
         with:
@@ -64,13 +64,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['27', '28']
+        otp: ['28', '29']
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
-          rebar3-version: '3.24'
+          rebar3-version: '3.27'
       - name: Set up _checkouts symlinks
         run: make examples-setup
       - name: Run example suites
@@ -88,7 +88,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
-          rebar3-version: '3.24'
+          rebar3-version: '3.27'
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -110,13 +110,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['27', '28']
+        otp: ['28', '29']
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{ matrix.otp }}
-          rebar3-version: '3.24'
+          rebar3-version: '3.27'
       - name: Restore rebar3 cache
         uses: actions/cache@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-05-28
+
+Erlang/OTP 29 support. No public API changes.
+
+### Changed
+
+- Support OTP 29; CI now runs on OTP 28 and 29 (dropped 27) with rebar3 3.27.
+- Replaced the deprecated bare `catch` operator with `try ... catch` throughout,
+  as OTP 29 deprecates `catch ...`.
+- Updated dependencies: `erlang_h1` 0.2.3, `h2` 0.6.1, `hackney` 4.0.3; test
+  deps `meck` 1.2.0 and `cowboy` 2.15.0.
+
 ## [2.0.2] - 2026-05-23
 
 A security release from a release-time review of the HTTP transport

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add to your `rebar.config`:
 {deps, [
     {barrel_mcp,
         {git, "https://github.com/barrel-platform/barrel_mcp.git",
-              {tag, "v2.0.2"}}}
+              {tag, "v2.1.0"}}}
 ]}.
 ```
 

--- a/examples/agent_host/src/agent_host.erl
+++ b/examples/agent_host/src/agent_host.erl
@@ -80,7 +80,7 @@ ensure_server(Port) ->
 
 wait_ready(_Pid, 0) -> {error, not_ready};
 wait_ready(Pid, N) ->
-    case catch barrel_mcp_client:server_capabilities(Pid) of
+    case (try barrel_mcp_client:server_capabilities(Pid) catch _:_ -> error end) of
         {ok, _} -> ok;
         _ ->
             timer:sleep(100),

--- a/examples/agent_host/test/agent_host_SUITE.erl
+++ b/examples/agent_host/test/agent_host_SUITE.erl
@@ -22,7 +22,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp_http_stream:stop(),
+    try barrel_mcp_http_stream:stop() catch _:_ -> ok end,
     application:stop(barrel_mcp),
     ok.
 

--- a/examples/echo_client/src/echo_client.erl
+++ b/examples/echo_client/src/echo_client.erl
@@ -70,7 +70,7 @@ ensure_server(Port) ->
 
 wait_ready(_Pid, 0) -> {error, not_ready};
 wait_ready(Pid, N) ->
-    case catch barrel_mcp_client:server_capabilities(Pid) of
+    case (try barrel_mcp_client:server_capabilities(Pid) catch _:_ -> error end) of
         {ok, _} -> ok;
         _ ->
             timer:sleep(100),

--- a/examples/echo_client/test/echo_client_SUITE.erl
+++ b/examples/echo_client/test/echo_client_SUITE.erl
@@ -19,7 +19,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp_http_stream:stop(),
+    try barrel_mcp_http_stream:stop() catch _:_ -> ok end,
     application:stop(barrel_mcp),
     ok.
 

--- a/examples/sampling_host/src/sampling_host.erl
+++ b/examples/sampling_host/src/sampling_host.erl
@@ -128,7 +128,7 @@ ensure_server(Port) ->
 
 wait_ready(_Pid, 0) -> {error, not_ready};
 wait_ready(Pid, N) ->
-    case catch barrel_mcp_client:server_capabilities(Pid) of
+    case (try barrel_mcp_client:server_capabilities(Pid) catch _:_ -> error end) of
         {ok, _} -> ok;
         _ ->
             timer:sleep(100),

--- a/examples/sampling_host/test/sampling_host_SUITE.erl
+++ b/examples/sampling_host/test/sampling_host_SUITE.erl
@@ -20,7 +20,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp_http_stream:stop(),
+    try barrel_mcp_http_stream:stop() catch _:_ -> ok end,
     application:stop(barrel_mcp),
     ok.
 

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -75,7 +75,7 @@ Every key is documented below.
 | Key | Type | Default | Effect |
 | --- | --- | --- | --- |
 | `transport` | `{http, Url}` \| `{stdio, #{command, args}}` | required | Which transport to open. |
-| `client_info` | `#{name, version}` | `#{name => <<"barrel_mcp_client">>, version => <<"2.0.2">>}` | Sent in `initialize`. |
+| `client_info` | `#{name, version}` | `#{name => <<"barrel_mcp_client">>, version => <<"2.1.0">>}` | Sent in `initialize`. |
 | `capabilities` | map | `#{}` | Client capabilities to declare. Booleans become spec-shape objects on the wire (e.g. `#{sampling => true}` becomes `#{<<"sampling">> => #{}}`). |
 | `handler` | `{Mod, Args}` | `{barrel_mcp_client_handler_default, []}` | Module implementing `barrel_mcp_client_handler` to handle server-initiated requests and notifications. |
 | `auth` | `none` \| `{bearer, Token}` \| `{oauth, Config}` | `none` | Authentication. See section 14. |

--- a/rebar.config
+++ b/rebar.config
@@ -4,9 +4,9 @@
     %% hex package is `erlang_h1' (the short name `h1' was taken);
     %% the OTP app/dep stays `h1' so call sites and the app graph
     %% use `h1' consistently.
-    {h1, "0.2.2", {pkg, erlang_h1}},
-    {h2, "0.6.0"},
-    {hackney, "4.0.0"}
+    {h1, "0.2.3", {pkg, erlang_h1}},
+    {h2, "0.6.1"},
+    {hackney, "4.0.3"}
 ]}.
 
 {shell, [{apps, [barrel_mcp]}]}.
@@ -25,11 +25,19 @@
 
 {profiles, [
     {test, [
-        %% cowboy is only used by the OAuth DCR suite to mock an
+        %% cowboy is only used by the OAuth test suites (DCR,
+        %% enterprise, and the OAuth client tests) to mock an
         %% authorization server; the library itself no longer depends
         %% on it.
-        {deps, [{meck, "0.9.2"}, {cowboy, "2.10.0"}]}
+        {deps, [{meck, "1.2.0"}, {cowboy, "2.15.0"}]}
     ]}
+]}.
+
+%% meck 1.2.0 still uses the bare `catch' operator, which OTP 29
+%% deprecates; relax that one warning for the dep so it builds (our
+%% own code uses try...catch).
+{overrides, [
+    {add, meck, [{erl_opts, [nowarn_deprecated_catch]}]}
 ]}.
 
 %% Documentation

--- a/src/barrel_mcp.app.src
+++ b/src/barrel_mcp.app.src
@@ -1,13 +1,13 @@
 {application, barrel_mcp, [
     {description, "MCP Protocol Library for Erlang"},
-    {vsn, "2.0.2"},
+    {vsn, "2.1.0"},
     {registered, [barrel_mcp_registry, barrel_mcp_sup, barrel_mcp_session,
                   barrel_mcp_tasks, barrel_mcp_client_sup]},
     {mod, {barrel_mcp_app, []}},
     {applications, [kernel, stdlib, crypto, h1, h2, hackney]},
     {env, [
         {server_name, <<"barrel">>},
-        {server_version, <<"2.0.2">>},
+        {server_version, <<"2.1.0">>},
         {protocol_version, <<"2025-11-25">>},
         {session_ttl, 1800000}  %% 30 minutes default
     ]},

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -517,7 +517,7 @@ common_handler(info, {'EXIT', _, _}, _Data) ->
     keep_state_and_data;
 common_handler(cast, close, Data) ->
     case Data#data.transport of
-        {Mod, Pid} -> catch Mod:close(Pid);
+        {Mod, Pid} -> try Mod:close(Pid) catch _:_ -> ok end;
         _ -> ok
     end,
     {stop, normal, Data};
@@ -668,7 +668,7 @@ notify_progress(Params, Data) ->
 build_initialize_params(#data{spec = Spec}) ->
     ClientInfo0 = maps:get(client_info, Spec,
                            #{<<"name">> => <<"barrel_mcp_client">>,
-                             <<"version">> => <<"2.0.2">>}),
+                             <<"version">> => <<"2.1.0">>}),
     ClientInfo = normalize_keys(ClientInfo0),
     Caps = capabilities_to_wire(maps:get(capabilities, Spec, #{})),
     Version = maps:get(protocol_version, Spec, ?MCP_CLIENT_PROTOCOL_VERSION),
@@ -865,7 +865,7 @@ maybe_close_on_ping_failures(Data, _Id) ->
     case Data#data.ping_failures >= ping_failure_threshold(Data) of
         true ->
             case Data#data.transport of
-                {Mod, TPid} -> catch Mod:close(TPid);
+                {Mod, TPid} -> try Mod:close(TPid) catch _:_ -> ok end;
                 _ -> ok
             end,
             {stop, ping_failed};
@@ -963,11 +963,11 @@ del_sub(Uri, Pid, Data) ->
 terminate(Reason, _State,
           #data{handler_mod = Mod, handler_state = HS, transport = T}) ->
     case T of
-        {Tmod, Pid} -> catch Tmod:close(Pid);
+        {Tmod, Pid} -> try Tmod:close(Pid) catch _:_ -> ok end;
         _ -> ok
     end,
     case erlang:function_exported(Mod, terminate, 2) of
-        true -> catch Mod:terminate(Reason, HS);
+        true -> try Mod:terminate(Reason, HS) catch _:_ -> ok end;
         false -> ok
     end,
     ok.

--- a/src/barrel_mcp_client_stdio.erl
+++ b/src/barrel_mcp_client_stdio.erl
@@ -106,7 +106,7 @@ handle_info(_Msg, State) ->
 terminate(_Reason, #state{port = Port, owner = Owner}) ->
     case Port of
         P when is_port(P) ->
-            catch port_close(P);
+            try port_close(P) catch _:_ -> ok end;
         _ ->
             ok
     end,

--- a/src/barrel_mcp_http_engine.erl
+++ b/src/barrel_mcp_http_engine.erl
@@ -624,7 +624,7 @@ sse_loop(Responder, SessionId) ->
     end.
 
 sse_cleanup(Responder, SessionId) ->
-    catch barrel_mcp_session:set_sse_pid(SessionId, undefined),
+    _ = (try barrel_mcp_session:set_sse_pid(SessionId, undefined) catch _:_ -> ok end),
     _ = stream_end(Responder),
     ok.
 

--- a/src/barrel_mcp_http_listener.erl
+++ b/src/barrel_mcp_http_listener.erl
@@ -97,7 +97,7 @@ listener_init(Parent, Name, ListenOpts, EngineConfig) ->
     process_flag(trap_exit, true),
     case listen(ListenOpts) of
         {ok, Transport, LSock} ->
-            case catch register(Name, self()) of
+            case (try register(Name, self()) catch _:_ -> error end) of
                 true ->
                     Handler = make_handler(EngineConfig),
                     N = maps:get(acceptors, ListenOpts,
@@ -274,10 +274,11 @@ run_h1(Socket, Transport, Handler) ->
                 ok ->
                     case h1_connection:activate(Conn) of
                         ok -> h1_loop(Conn, Handler);
-                        {error, _} -> catch h1_connection:close(Conn)
+                        {error, _} ->
+                            try h1_connection:close(Conn) catch _:_ -> ok end
                     end;
                 {error, _} ->
-                    catch h1_connection:close(Conn),
+                    try h1_connection:close(Conn) catch _:_ -> ok end,
                     close(Transport, Socket)
             end;
         {error, _Reason} ->
@@ -292,7 +293,7 @@ run_h2(Socket, Handler) ->
                     _ = h2_connection:activate(Conn),
                     h2_loop(Conn, Handler, #{});
                 {error, _} ->
-                    catch h2_connection:close(Conn),
+                    try h2_connection:close(Conn) catch _:_ -> ok end,
                     _ = ssl:close(Socket)
             end;
         {error, _Reason} ->
@@ -401,11 +402,13 @@ spawn_handler(Proto, Conn, StreamId, Method, Path, Headers, Handler) ->
             Class:Reason:Stack ->
                 logger:error("mcp http handler crash: ~p:~p~n~p",
                              [Class, Reason, Stack]),
-                catch Proto:send_response(Conn, StreamId, 500,
-                                          [{<<"content-type">>, <<"text/plain">>},
-                                           {<<"content-length">>, <<"21">>}]),
-                catch Proto:send_data(Conn, StreamId,
-                                      <<"Internal Server Error">>, true)
+                try Proto:send_response(Conn, StreamId, 500,
+                                        [{<<"content-type">>, <<"text/plain">>},
+                                         {<<"content-length">>, <<"21">>}])
+                catch _:_ -> ok end,
+                try Proto:send_data(Conn, StreamId,
+                                    <<"Internal Server Error">>, true)
+                catch _:_ -> ok end
         end
     end).
 

--- a/src/barrel_mcp_registry.erl
+++ b/src/barrel_mcp_registry.erl
@@ -504,7 +504,7 @@ ready({call, From}, _, _Data) ->
 
 %% @private
 terminate(_Reason, _State, _Data) ->
-    catch persistent_term:erase(?REGISTRY_KEY),
+    try persistent_term:erase(?REGISTRY_KEY) catch _:_ -> ok end,
     ok.
 
 %%====================================================================

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -662,8 +662,8 @@ handle_call({record_in_flight, SessionId, RequestId, Worker, Waiter},
 handle_call({cancel_in_flight, SessionId, RequestId}, _From, State) ->
     case ets:lookup(?INFLIGHT_TABLE, {SessionId, RequestId}) of
         [{_, #in_flight{worker_pid = W, waiter_pid = Wt}}] ->
-            (catch W ! {cancel, RequestId}),
-            (catch Wt ! {cancelled, RequestId}),
+            _ = (try W ! {cancel, RequestId} catch _:_ -> ok end),
+            _ = (try Wt ! {cancelled, RequestId} catch _:_ -> ok end),
             true = ets:delete(?INFLIGHT_TABLE, {SessionId, RequestId});
         [] -> ok
     end,

--- a/src/barrel_mcp_tasks.erl
+++ b/src/barrel_mcp_tasks.erl
@@ -133,12 +133,12 @@ handle_call({cancel, SessionId, TaskId}, _From, State) ->
     %% the stored status. Arity-1 handlers run to completion;
     %% their result is dropped because the task is already in a
     %% terminal state.
-    case ets:lookup(?TABLE, {SessionId, TaskId}) of
-        [{_, #task{worker_pid = Pid, request_id = ReqId}}]
-                when is_pid(Pid) ->
-            (catch Pid ! {cancel, ReqId});
-        _ -> ok
-    end,
+    _ = case ets:lookup(?TABLE, {SessionId, TaskId}) of
+            [{_, #task{worker_pid = Pid, request_id = ReqId}}]
+                    when is_pid(Pid) ->
+                try Pid ! {cancel, ReqId} catch _:_ -> ok end;
+            _ -> ok
+        end,
     Reply = transition(SessionId, TaskId, cancelled, undefined, undefined),
     {reply, Reply, State};
 

--- a/test/barrel_mcp_agent_SUITE.erl
+++ b/test/barrel_mcp_agent_SUITE.erl
@@ -36,8 +36,8 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp:stop_http_stream(),
-    catch barrel_mcp_registry:unreg(tool, <<"echo">>),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"echo">>) catch _:_ -> ok end,
     application:stop(barrel_mcp),
     ok.
 
@@ -87,7 +87,7 @@ aggregates_and_routes(_Config) ->
 
 wait_ready(_Pid, 0) -> {error, not_ready};
 wait_ready(Pid, N) ->
-    case catch barrel_mcp_client:server_capabilities(Pid) of
+    case (try barrel_mcp_client:server_capabilities(Pid) catch _:_ -> error end) of
         {ok, _} -> ok;
         _ ->
             timer:sleep(100),

--- a/test/barrel_mcp_agent_tests.erl
+++ b/test/barrel_mcp_agent_tests.erl
@@ -23,7 +23,7 @@ agent_test_() ->
     end}.
 
 setup() ->
-    catch application:stop(barrel_mcp),
+    try application:stop(barrel_mcp) catch _:_ -> ok end,
     {ok, _} = application:ensure_all_started(barrel_mcp),
     ok.
 

--- a/test/barrel_mcp_async_tools_SUITE.erl
+++ b/test/barrel_mcp_async_tools_SUITE.erl
@@ -31,7 +31,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     application:stop(barrel_mcp),
     ok.
 
@@ -40,7 +40,7 @@ init_per_testcase(TC, Config) ->
     [{port, Port} | Config].
 
 end_per_testcase(_TC, _Config) ->
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     timer:sleep(50),
     ok.
 

--- a/test/barrel_mcp_client_auth_oauth_tests.erl
+++ b/test/barrel_mcp_client_auth_oauth_tests.erl
@@ -122,7 +122,7 @@ setup_mock() ->
     ok.
 
 cleanup_mock(_) ->
-    catch cowboy:stop_listener(?MODULE),
+    try cowboy:stop_listener(?MODULE) catch _:_ -> ok end,
     ok.
 
 %% Cowboy handler used as a tiny mock authorization server.

--- a/test/barrel_mcp_client_progress_tests.erl
+++ b/test/barrel_mcp_client_progress_tests.erl
@@ -32,7 +32,7 @@ setup_loopback() ->
     ok.
 
 cleanup_loopback(_) ->
-    catch barrel_mcp_http_stream:stop(),
+    try barrel_mcp_http_stream:stop() catch _:_ -> ok end,
     ok.
 
 test_ping_keeps_alive() ->
@@ -85,7 +85,7 @@ start_client(Extras) ->
 
 wait_ready(_Pid, 0) -> error(client_not_ready);
 wait_ready(Pid, N) ->
-    case catch barrel_mcp_client:server_capabilities(Pid) of
+    case (try barrel_mcp_client:server_capabilities(Pid) catch _:_ -> error end) of
         {ok, _} -> ok;
         _ ->
             timer:sleep(100),

--- a/test/barrel_mcp_client_roots_SUITE.erl
+++ b/test/barrel_mcp_client_roots_SUITE.erl
@@ -31,7 +31,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     application:unset_env(barrel_mcp, roots_changed_handler),
     application:stop(barrel_mcp),
     ok.
@@ -41,7 +41,7 @@ init_per_testcase(TC, Config) ->
     [{port, Port} | Config].
 
 end_per_testcase(_TC, _Config) ->
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     application:unset_env(barrel_mcp, roots_changed_handler),
     timer:sleep(50),
     ok.
@@ -100,7 +100,7 @@ register_observer(Pid) ->
     persistent_term:put({?MODULE, observer}, Pid).
 
 unregister_observer() ->
-    catch persistent_term:erase({?MODULE, observer}),
+    try persistent_term:erase({?MODULE, observer}) catch _:_ -> ok end,
     ok.
 
 observer() ->
@@ -110,7 +110,7 @@ observer() ->
 
 wait_ready(_Pid, 0) -> {error, not_ready};
 wait_ready(Pid, N) ->
-    case catch barrel_mcp_client:server_capabilities(Pid) of
+    case (try barrel_mcp_client:server_capabilities(Pid) catch _:_ -> error end) of
         {ok, _} -> ok;
         _ ->
             timer:sleep(100),

--- a/test/barrel_mcp_client_tests.erl
+++ b/test/barrel_mcp_client_tests.erl
@@ -45,8 +45,8 @@ setup() ->
     ok.
 
 cleanup(_) ->
-    catch barrel_mcp_http_stream:stop(),
-    catch barrel_mcp_registry:unreg(tool, <<"test_tool">>),
+    try barrel_mcp_http_stream:stop() catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"test_tool">>) catch _:_ -> ok end,
     ok.
 
 test_handler(_Args) ->
@@ -136,7 +136,7 @@ start_client() ->
 
 wait_ready(_Pid, 0) -> error(client_not_ready);
 wait_ready(Pid, N) ->
-    case catch barrel_mcp_client:server_capabilities(Pid) of
+    case (try barrel_mcp_client:server_capabilities(Pid) catch _:_ -> error end) of
         {ok, _} -> ok;
         _ ->
             timer:sleep(100),

--- a/test/barrel_mcp_clients_tests.erl
+++ b/test/barrel_mcp_clients_tests.erl
@@ -28,8 +28,9 @@ setup() ->
     ok.
 
 cleanup(_) ->
-    catch barrel_mcp_http_stream:stop(),
-    [catch barrel_mcp:stop_client(Id) || {Id, _} <- barrel_mcp:list_clients()],
+    try barrel_mcp_http_stream:stop() catch _:_ -> ok end,
+    [try barrel_mcp:stop_client(Id) catch _:_ -> ok end
+     || {Id, _} <- barrel_mcp:list_clients()],
     ok.
 
 test_start() ->

--- a/test/barrel_mcp_http_stream_security_SUITE.erl
+++ b/test/barrel_mcp_http_stream_security_SUITE.erl
@@ -74,7 +74,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     application:stop(barrel_mcp),
     ok.
 
@@ -83,7 +83,7 @@ init_per_testcase(TC, Config) ->
     [{port, Port} | Config].
 
 end_per_testcase(_TC, _Config) ->
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     timer:sleep(50),
     ok.
 

--- a/test/barrel_mcp_http_stream_tests.erl
+++ b/test/barrel_mcp_http_stream_tests.erl
@@ -46,7 +46,7 @@ setup() ->
     ok.
 
 cleanup(_) ->
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     barrel_mcp:unreg_tool(<<"test_tool">>),
     ok.
 

--- a/test/barrel_mcp_oauth_dcr_SUITE.erl
+++ b/test/barrel_mcp_oauth_dcr_SUITE.erl
@@ -77,9 +77,9 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp:stop_http_stream(),
-    catch cowboy:stop_listener(?AS_LISTENER),
-    catch barrel_mcp_registry:unreg(tool, <<"echo">>),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
+    try cowboy:stop_listener(?AS_LISTENER) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"echo">>) catch _:_ -> ok end,
     application:stop(barrel_mcp),
     ok.
 
@@ -197,7 +197,7 @@ json_encode(M) -> iolist_to_binary(json:encode(M)).
 
 wait_ready(_Pid, 0) -> {error, not_ready};
 wait_ready(Pid, N) ->
-    case catch barrel_mcp_client:server_capabilities(Pid) of
+    case (try barrel_mcp_client:server_capabilities(Pid) catch _:_ -> error end) of
         {ok, _} -> ok;
         _ ->
             timer:sleep(100),

--- a/test/barrel_mcp_oauth_enterprise_SUITE.erl
+++ b/test/barrel_mcp_oauth_enterprise_SUITE.erl
@@ -81,9 +81,9 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp:stop_http_stream(),
-    catch cowboy:stop_listener(?AS_LISTENER),
-    catch barrel_mcp_registry:unreg(tool, <<"echo">>),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
+    try cowboy:stop_listener(?AS_LISTENER) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"echo">>) catch _:_ -> ok end,
     application:stop(barrel_mcp),
     ok.
 
@@ -213,7 +213,7 @@ json_encode(M) -> iolist_to_binary(json:encode(M)).
 
 wait_ready(_Pid, 0) -> {error, not_ready};
 wait_ready(Pid, N) ->
-    case catch barrel_mcp_client:server_capabilities(Pid) of
+    case (try barrel_mcp_client:server_capabilities(Pid) catch _:_ -> error end) of
         {ok, _} -> ok;
         _ ->
             timer:sleep(100),

--- a/test/barrel_mcp_python_interop_SUITE.erl
+++ b/test/barrel_mcp_python_interop_SUITE.erl
@@ -52,7 +52,7 @@ init_per_suite(Config) ->
     end.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     application:stop(barrel_mcp),
     ok.
 
@@ -79,7 +79,7 @@ python_client_against_erlang_server(Config) ->
         _ ->
             ct:fail({python_client_failed, Status, Output})
     end,
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     cleanup_fixture(),
     ok.
 
@@ -236,25 +236,27 @@ ensure_fixture() ->
     ok.
 
 cleanup_fixture() ->
-    catch barrel_mcp_registry:unreg(tool, <<"echo">>),
-    catch barrel_mcp_registry:unreg(tool, <<"slow_echo">>),
-    catch barrel_mcp_registry:unreg(tool, <<"trigger_update">>),
-    catch barrel_mcp_registry:unreg(tool, <<"ask_llm">>),
-    catch barrel_mcp_registry:unreg(tool, <<"ask_user">>),
-    catch barrel_mcp_registry:unreg(tool, <<"list_roots">>),
-    catch barrel_mcp_registry:unreg(tool, <<"progress_echo">>),
-    catch barrel_mcp_registry:unreg(tool, <<"structured">>),
-    catch barrel_mcp_registry:unreg(tool, <<"erroring">>),
-    catch barrel_mcp_registry:unreg(tool, <<"churn_registry">>),
-    catch barrel_mcp_registry:unreg(tool, <<"cancellable">>),
-    catch barrel_mcp_registry:unreg(tool, <<"churned">>),
-    catch barrel_mcp_registry:unreg(resource, <<"greeting">>),
-    catch barrel_mcp_registry:unreg(resource_template, <<"file_template">>),
-    catch barrel_mcp_registry:unreg(prompt, <<"hello_prompt">>),
-    catch barrel_mcp:unreg_completion({prompt, <<"hello_prompt">>,
-                                                <<"who">>}),
-    [catch barrel_mcp_registry:unreg(tool,
+    try barrel_mcp_registry:unreg(tool, <<"echo">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"slow_echo">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"trigger_update">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"ask_llm">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"ask_user">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"list_roots">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"progress_echo">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"structured">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"erroring">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"churn_registry">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"cancellable">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(tool, <<"churned">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(resource, <<"greeting">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(resource_template, <<"file_template">>) catch _:_ -> ok end,
+    try barrel_mcp_registry:unreg(prompt, <<"hello_prompt">>) catch _:_ -> ok end,
+    try barrel_mcp:unreg_completion({prompt, <<"hello_prompt">>,
+                                     <<"who">>})
+    catch _:_ -> ok end,
+    [try barrel_mcp_registry:unreg(tool,
               iolist_to_binary(io_lib:format("dummy_~3..0B", [N])))
+      catch _:_ -> ok end
      || N <- lists:seq(1, 60)],
     ok.
 
@@ -344,7 +346,7 @@ registry_churn_tool(_) ->
         input_schema => #{<<"type">> => <<"object">>}
     }),
     timer:sleep(20),
-    catch barrel_mcp_registry:unreg(tool, <<"churned">>),
+    try barrel_mcp_registry:unreg(tool, <<"churned">>) catch _:_ -> ok end,
     <<"churned">>.
 
 %% Cooperative cancel: arity-2 worker watches its mailbox for
@@ -447,13 +449,13 @@ collect(Port, Acc) ->
         {Port, {exit_status, Status}} ->
             {Status, lists:flatten(lists:reverse(Acc))}
     after 60000 ->
-        catch port_close(Port),
+        try port_close(Port) catch _:_ -> ok end,
         {timeout, lists:flatten(lists:reverse(Acc))}
     end.
 
 wait_ready(_Pid, 0) -> {error, not_ready};
 wait_ready(Pid, N) ->
-    case catch barrel_mcp_client:server_capabilities(Pid) of
+    case (try barrel_mcp_client:server_capabilities(Pid) catch _:_ -> error end) of
         {ok, _} -> ok;
         _ ->
             timer:sleep(100),

--- a/test/barrel_mcp_sampling_tests.erl
+++ b/test/barrel_mcp_sampling_tests.erl
@@ -378,7 +378,7 @@ test_notify_log_invalid_dropped() ->
 
 setup() ->
     %% Restart application to get a clean ETS state.
-    catch application:stop(barrel_mcp),
+    try application:stop(barrel_mcp) catch _:_ -> ok end,
     {ok, _} = application:ensure_all_started(barrel_mcp),
     ok.
 

--- a/test/barrel_mcp_spec_additives_SUITE.erl
+++ b/test/barrel_mcp_spec_additives_SUITE.erl
@@ -48,7 +48,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     application:stop(barrel_mcp),
     ok.
 
@@ -67,7 +67,7 @@ init_per_testcase(TC, Config) ->
     [{port, Port} | Config].
 
 end_per_testcase(_TC, _Config) ->
-    catch barrel_mcp:stop_http_stream(),
+    try barrel_mcp:stop_http_stream() catch _:_ -> ok end,
     timer:sleep(200),
     ok.
 
@@ -275,7 +275,7 @@ long_running_cancel_signals_worker(Config) ->
     %% instead, poll the task store until the status is
     %% `cancelled', proving the wire path completed.
     wait_until_cancelled(SessionId, TaskId, 50),
-    catch unregister(cancel_observer_for_test),
+    try unregister(cancel_observer_for_test) catch _:_ -> ok end,
     ok = barrel_mcp_registry:unreg(tool, <<"cancellable">>),
     ok.
 

--- a/test/doc_snippets_SUITE.erl
+++ b/test/doc_snippets_SUITE.erl
@@ -45,7 +45,7 @@ collect(Port, Acc) ->
         {Port, {data, D}} -> collect(Port, <<Acc/binary, D/binary>>);
         {Port, {exit_status, S}} -> {S, binary_to_list(Acc)}
     after 60000 ->
-        catch port_close(Port),
+        try port_close(Port) catch _:_ -> ok end,
         {1, "snippet_check: timed out"}
     end.
 


### PR DESCRIPTION
Adds Erlang/OTP 29 support.

## What changed
- OTP 29 deprecates the bare `catch` operator, which fails the build under `warnings_as_errors`. Converted all bare `catch` to `try...catch` across `src`, `test` and `examples`, preserving semantics. Added `_ =` on the few discarded non-trivial returns dialyzer's `unmatched_returns` now flags.
- Dependencies bumped to latest hex: `erlang_h1` 0.2.3, `h2` 0.6.1, `hackney` 4.0.3; test profile `meck` 1.2.0, `cowboy` 2.15.0.
- `meck` 1.2.0 itself still uses bare `catch` under its own `warnings_as_errors`, so it is relaxed with a scoped `nowarn_deprecated_catch` override; our own code stays strict.
- CI matrix `27,28` -> `28,29` (interop job stays on 28); rebar3 `3.24` -> `3.27`.
- Version `2.0.2` -> `2.1.0`.

## Notes
- Our modules compile warning-free. `quic` 1.4.5 still emits the OTP 29 bare-`catch` deprecation warning in CI logs (no `warnings_as_errors`, non-fatal); upstream, latest available.

## Verification
Green on OTP 29 and OTP 28.3.1: compile (no warnings in our code), eunit 262/0, ct 40 pass + 2 skip (Python interop, no `INTEROP_PYTHON`), xref clean, dialyzer clean, all three example suites pass.