### PR TITLE
Thread authenticated principal into tool handler Ctx

### DIFF
--- a/src/barrel_mcp_http_engine.erl
+++ b/src/barrel_mcp_http_engine.erl
@@ -166,7 +166,8 @@ simple_post_authenticated(Headers, Body, Responder, Config, AuthInfo) ->
                 no_response ->
                     reply(Responder, 204, cors_headers(Headers, Config, #{}), <<>>);
                 {async, Plan} ->
-                    Result = barrel_mcp_protocol:drive_async_plan(Plan, 60000),
+                    Result = barrel_mcp_protocol:drive_async_plan(Plan, 60000,
+                                                                  AuthInfo),
                     reply_json(Headers, Responder, Config, 200, Result);
                 Result ->
                     reply_json(Headers, Responder, Config, 200, Result)
@@ -282,7 +283,7 @@ handle_dispatch(Headers, Responder, Config, SessionId, Request, AuthInfo) ->
                     reply(Responder, 202, Hdrs, <<>>);
                 {async, AsyncPlan} ->
                     handle_async_tool_call(Headers, Responder, Config, SessionId,
-                                           Request, AsyncPlan);
+                                           Request, AsyncPlan, AuthInfo);
                 Result ->
                     _ = maybe_capture_initialize_version(SessionId, Method, Result),
                     case wants_sse_response(Headers) of
@@ -305,7 +306,8 @@ handle_dispatch(Headers, Responder, Config, SessionId, Request, AuthInfo) ->
 %% Async tool calls
 %%====================================================================
 
-handle_async_tool_call(Headers, Responder, Config, SessionId, Request, AsyncPlan) ->
+handle_async_tool_call(Headers, Responder, Config, SessionId, Request, AsyncPlan,
+                       AuthInfo) ->
     RequestId = maps:get(request_id, AsyncPlan),
     Spawn = maps:get(spawn, AsyncPlan),
     Timeout = maps:get(timeout, AsyncPlan, 60000),
@@ -318,7 +320,8 @@ handle_async_tool_call(Headers, Responder, Config, SessionId, Request, AsyncPlan
     case LongRunning of
         true ->
             handle_long_running_call(Headers, Responder, Config, SessionId,
-                                     RequestId, ToolName, ProgressToken, Meta, Spawn);
+                                     RequestId, ToolName, ProgressToken, Meta,
+                                     Spawn, AuthInfo);
         false ->
             Ctx = #{
                 session_id => SessionId,
@@ -326,7 +329,8 @@ handle_async_tool_call(Headers, Responder, Config, SessionId, Request, AsyncPlan
                 progress_token => ProgressToken,
                 meta => Meta,
                 emit_progress => emit_progress_fun(SessionId, ProgressToken),
-                reply_to => Self
+                reply_to => Self,
+                auth_info => AuthInfo
             },
             WorkerPid = Spawn(Ctx),
             case SessionId of
@@ -350,7 +354,7 @@ is_long_running_tool(Name) ->
     end.
 
 handle_long_running_call(Headers, Responder, Config, SessionId, RequestId,
-                         ToolName, ProgressToken, Meta, Spawn) ->
+                         ToolName, ProgressToken, Meta, Spawn, AuthInfo) ->
     {ok, TaskId} = barrel_mcp_tasks:create(SessionId, ToolName, #{}),
     Collector = spawn_task_collector(SessionId, TaskId),
     Ctx = #{
@@ -359,7 +363,8 @@ handle_long_running_call(Headers, Responder, Config, SessionId, RequestId,
         progress_token => ProgressToken,
         meta => Meta,
         emit_progress => emit_progress_fun(SessionId, ProgressToken),
-        reply_to => Collector
+        reply_to => Collector,
+        auth_info => AuthInfo
     },
     Worker = Spawn(Ctx),
     _ = barrel_mcp_tasks:set_worker(SessionId, TaskId,

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -29,7 +29,8 @@
     encode_error/3,
     decode_envelope/1,
     format_tool_result_external/1,
-    drive_async_plan/2
+    drive_async_plan/2,
+    drive_async_plan/3
 ]).
 
 %%====================================================================
@@ -551,6 +552,15 @@ format_tool_result_external(Result) ->
 %% in-flight entries for cancellation routing.
 -spec drive_async_plan(map(), timeout()) -> map().
 drive_async_plan(Plan, Timeout) ->
+    drive_async_plan(Plan, Timeout, undefined).
+
+%% @doc As {@link drive_async_plan/2}, but threads the authenticated
+%% principal (`AuthInfo', the auth provider's `authenticate/2' map) into
+%% the tool `Ctx' under `auth_info'. Transports that authenticate before
+%% driving the plan (the simple HTTP transport) pass it here; callers
+%% with no auth provider use the `/2' form and `auth_info' is `undefined'.
+-spec drive_async_plan(map(), timeout(), term()) -> map().
+drive_async_plan(Plan, Timeout, AuthInfo) ->
     Self = self(),
     RequestId = maps:get(request_id, Plan),
     Spawn = maps:get(spawn, Plan),
@@ -560,7 +570,8 @@ drive_async_plan(Plan, Timeout) ->
             progress_token => undefined,
             meta => Meta,
             emit_progress => fun(_, _, _) -> ok end,
-            reply_to => Self},
+            reply_to => Self,
+            auth_info => AuthInfo},
     _Pid = Spawn(Ctx),
     receive
         {tool_result, RequestId, Result} ->

--- a/test/barrel_mcp_async_tools_SUITE.erl
+++ b/test/barrel_mcp_async_tools_SUITE.erl
@@ -12,17 +12,19 @@
          init_per_testcase/2, end_per_testcase/2]).
 -export([cancel_returns_empty_body/1,
          progress_emits_events/1,
-         tool_error_returns_isError/1]).
+         tool_error_returns_isError/1,
+         auth_info_passed_to_tool/1]).
 
 %% Tool handlers used by the suite.
--export([slow_tool/2, progress_tool/2, error_tool/1]).
+-export([slow_tool/2, progress_tool/2, error_tool/1, whoami_tool/2]).
 
 -define(BASE_PORT, 22200).
 
 all() -> [
     cancel_returns_empty_body,
     progress_emits_events,
-    tool_error_returns_isError
+    tool_error_returns_isError,
+    auth_info_passed_to_tool
 ].
 
 init_per_suite(Config) ->
@@ -167,6 +169,40 @@ tool_error_returns_isError(Config) ->
     ok.
 
 %%====================================================================
+%% auth_info threading
+%%====================================================================
+
+%% A configured auth provider's authenticate/2 map must reach the
+%% arity-2 tool's Ctx under auth_info, end to end through the engine
+%% async path.
+auth_info_passed_to_tool(Config) ->
+    Port = ?config(port, Config),
+    {ok, _} = barrel_mcp:start_http_stream(#{
+        port => Port,
+        session_enabled => true,
+        auth => #{provider => barrel_mcp_auth_apikey,
+                  provider_opts => #{keys => #{<<"key-123">> =>
+                      #{subject => <<"user1">>, scopes => [<<"read">>]}}}}}),
+    ok = barrel_mcp_registry:reg(tool, <<"whoami">>, ?MODULE, whoami_tool, #{}),
+
+    {200, IH, _} = post_init_auth(Port, <<"key-123">>),
+    SessionId = proplists:get_value(<<"mcp-session-id">>, IH),
+
+    Body = tool_call_body(<<"whoami">>, 31),
+    {ok, 200, _, RB} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
+         {<<"mcp-session-id">>, SessionId},
+         {<<"x-api-key">>, <<"key-123">>}],
+        Body, [with_body]),
+    Resp = json:decode(RB),
+    Result = maps:get(<<"result">>, Resp),
+    [Block | _] = maps:get(<<"content">>, Result),
+    ?assertEqual(<<"user1">>, maps:get(<<"text">>, Block)),
+    ok = barrel_mcp_registry:unreg(tool, <<"whoami">>),
+    ok.
+
+%%====================================================================
 %% Tool implementations
 %%====================================================================
 
@@ -188,6 +224,12 @@ progress_tool(_Args, Ctx) ->
 
 error_tool(_Args) ->
     {tool_error, [#{<<"type">> => <<"text">>, <<"text">> => <<"boom">>}]}.
+
+%% Returns the authenticated subject from the Ctx auth_info so the
+%% test can assert the principal was threaded in.
+whoami_tool(_Args, Ctx) ->
+    AuthInfo = barrel_mcp_auth:get_auth_info(Ctx),
+    maps:get(subject, AuthInfo, <<"none">>).
 
 %%====================================================================
 %% Helpers
@@ -211,6 +253,27 @@ post_init(Port) ->
     {ok, S, H, B} = hackney:request(post, url(Port),
         [{<<"content-type">>, <<"application/json">>},
          {<<"accept">>, <<"application/json, text/event-stream">>}],
+        Body, [with_body]),
+    {S, H, B}.
+
+%% Like post_init/1 but presents an API key, for suites that configure
+%% an auth provider (initialize is authenticated like any other POST).
+post_init_auth(Port, ApiKey) ->
+    Body = json:encode(#{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => 1,
+        <<"method">> => <<"initialize">>,
+        <<"params">> => #{
+            <<"protocolVersion">> => <<"2025-11-25">>,
+            <<"capabilities">> => #{},
+            <<"clientInfo">> => #{<<"name">> => <<"async-suite">>,
+                                  <<"version">> => <<"1.0">>}
+        }
+    }),
+    {ok, S, H, B} = hackney:request(post, url(Port),
+        [{<<"content-type">>, <<"application/json">>},
+         {<<"accept">>, <<"application/json, text/event-stream">>},
+         {<<"x-api-key">>, ApiKey}],
         Body, [with_body]),
     {S, H, B}.
 

--- a/test/barrel_mcp_tools_tests.erl
+++ b/test/barrel_mcp_tools_tests.erl
@@ -13,7 +13,8 @@
     error_tool/1,
     map_result_tool/1,
     list_result_tool/1,
-    result_meta_tool/2
+    result_meta_tool/2,
+    auth_capture_tool/2
 ]).
 
 %%====================================================================
@@ -36,7 +37,11 @@ tools_test_() ->
         {"Tool annotations are surfaced in tools/list",
          fun test_tool_annotations/0},
         {"Tool returning {result_meta, _, _} surfaces _meta on the wire",
-         fun test_tool_result_meta/0}
+         fun test_tool_result_meta/0},
+        {"Arity-2 tool receives auth_info in Ctx",
+         fun test_tool_receives_auth_info/0},
+        {"Arity-1 tool is unaffected by auth_info in Ctx",
+         fun test_arity1_tool_ignores_auth_info/0}
      ]
     }.
 
@@ -79,6 +84,12 @@ result_meta_tool(_Args, Ctx) ->
     Inbound = maps:get(meta, Ctx, #{}),
     {result_meta, <<"ok">>,
      Inbound#{<<"echoedBy">> => <<"barrel_mcp">>}}.
+
+%% Arity-2 handler that records the `auth_info' it received in Ctx so
+%% the test can assert the authenticated principal was threaded through.
+auth_capture_tool(_Args, Ctx) ->
+    true = ets:insert(mcp_auth_capture, {auth, maps:get(auth_info, Ctx)}),
+    <<"ok">>.
 
 %%====================================================================
 %% Tests
@@ -274,3 +285,54 @@ test_tool_result_meta() ->
     ?assertEqual(<<"abc-123">>, maps:get(<<"requestId">>, Meta)),
     ?assertEqual(<<"barrel_mcp">>, maps:get(<<"echoedBy">>, Meta)),
     barrel_mcp_registry:unreg(tool, <<"meta_echo">>).
+
+test_tool_receives_auth_info() ->
+    %% An arity-2 tool must receive a Ctx whose `auth_info' equals the
+    %% map returned by the auth provider's authenticate/2. The capture
+    %% tool records it in ETS; drive_async_plan/3 threads it through.
+    ensure_capture_table(),
+    ok = barrel_mcp_registry:reg(tool, <<"auth_capture">>, ?MODULE,
+                                  auth_capture_tool, #{}),
+    Expected = #{subject => <<"user:123">>, scopes => [<<"read">>]},
+    Request = #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => 1,
+        <<"method">> => <<"tools/call">>,
+        <<"params">> => #{<<"name">> => <<"auth_capture">>,
+                          <<"arguments">> => #{}}
+    },
+    {async, Plan} = barrel_mcp_protocol:handle(Request),
+    _Resp = barrel_mcp_protocol:drive_async_plan(Plan, 2000, Expected),
+    ?assertEqual(Expected, captured_auth_info()),
+    barrel_mcp_registry:unreg(tool, <<"auth_capture">>).
+
+test_arity1_tool_ignores_auth_info() ->
+    %% Adding auth_info to Ctx must not affect arity-1 handlers, which
+    %% are dispatched as Mod:Fun(Args) and never see Ctx.
+    ok = barrel_mcp_registry:reg(tool, <<"echo1">>, ?MODULE, echo_tool, #{}),
+    Request = #{
+        <<"jsonrpc">> => <<"2.0">>,
+        <<"id">> => 1,
+        <<"method">> => <<"tools/call">>,
+        <<"params">> => #{<<"name">> => <<"echo1">>,
+                          <<"arguments">> => #{<<"input">> => <<"hi">>}}
+    },
+    {async, Plan} = barrel_mcp_protocol:handle(Request),
+    Resp = barrel_mcp_protocol:drive_async_plan(Plan, 2000,
+                                                #{subject => <<"user:123">>}),
+    [Block | _] = maps:get(<<"content">>, maps:get(<<"result">>, Resp)),
+    ?assertEqual(<<"Echo: hi">>, maps:get(<<"text">>, Block)),
+    barrel_mcp_registry:unreg(tool, <<"echo1">>).
+
+ensure_capture_table() ->
+    case ets:info(mcp_auth_capture) of
+        undefined -> ets:new(mcp_auth_capture, [named_table, public, set]);
+        _ -> ets:delete_all_objects(mcp_auth_capture)
+    end,
+    ok.
+
+captured_auth_info() ->
+    case ets:lookup(mcp_auth_capture, auth) of
+        [{auth, Info}] -> Info;
+        [] -> undefined
+    end.


### PR DESCRIPTION
An authenticated MCP request resolves an `auth_info` map (the auth provider's `authenticate/2` result, e.g. `#{subject => <<"user:123">>}`), but that identity reached only the protocol state, never the spawned tool worker. Owner-scoped tools couldn't tell who was calling.

## Changes
- `barrel_mcp_http_engine`: `handle_dispatch/6` passes `AuthInfo` through `handle_async_tool_call/7` and `handle_long_running_call/10`; both worker `Ctx` maps now carry `auth_info`.
- `barrel_mcp_protocol`: new `drive_async_plan/3` threads `AuthInfo` into the synchronous-path `Ctx`; `drive_async_plan/2` delegates with `undefined`. The simple HTTP transport uses `/3`; stdio keeps `/2` (no auth provider).
- No registry change: arity-2 handlers get `Mod:Fun(Args, Ctx)`, arity-1 get `Mod:Fun(Args)` and are unaffected.

## Tests
- eunit: arity-2 tool receives a `Ctx` whose `auth_info` equals the provider map (exact match); arity-1 tool unaffected.
- CT: end-to-end engine async path with an apikey provider asserts the authenticated subject reaches the tool.