### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-06-09
+
+Threads the authenticated principal into tool handlers.
+
+### Added
+
+- Arity-2 tool handlers (`Mod:Fun(Args, Ctx)`) now receive the auth
+  provider's `authenticate/2` result in `Ctx` under `auth_info`, so
+  owner-scoped tools can identify the caller. Arity-1 handlers
+  (`Mod:Fun(Args)`) are unchanged. With `barrel_mcp_auth_none` the value
+  is the anonymous principal; on paths with no auth provider (stdio) it
+  is `undefined`.
+- `barrel_mcp_protocol:drive_async_plan/3`, which threads `auth_info`
+  into the synchronous tool-call path. `drive_async_plan/2` is retained
+  and delegates with `auth_info` set to `undefined`.
+
 ## [2.1.0] - 2026-05-28
 
 Erlang/OTP 29 support. No public API changes.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add to your `rebar.config`:
 {deps, [
     {barrel_mcp,
         {git, "https://github.com/barrel-platform/barrel_mcp.git",
-              {tag, "v2.1.0"}}}
+              {tag, "v2.2.0"}}}
 ]}.
 ```
 

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -75,7 +75,7 @@ Every key is documented below.
 | Key | Type | Default | Effect |
 | --- | --- | --- | --- |
 | `transport` | `{http, Url}` \| `{stdio, #{command, args}}` | required | Which transport to open. |
-| `client_info` | `#{name, version}` | `#{name => <<"barrel_mcp_client">>, version => <<"2.1.0">>}` | Sent in `initialize`. |
+| `client_info` | `#{name, version}` | `#{name => <<"barrel_mcp_client">>, version => <<"2.2.0">>}` | Sent in `initialize`. |
 | `capabilities` | map | `#{}` | Client capabilities to declare. Booleans become spec-shape objects on the wire (e.g. `#{sampling => true}` becomes `#{<<"sampling">> => #{}}`). |
 | `handler` | `{Mod, Args}` | `{barrel_mcp_client_handler_default, []}` | Module implementing `barrel_mcp_client_handler` to handle server-initiated requests and notifications. |
 | `auth` | `none` \| `{bearer, Token}` \| `{oauth, Config}` | `none` | Authentication. See section 14. |

--- a/src/barrel_mcp.app.src
+++ b/src/barrel_mcp.app.src
@@ -1,13 +1,13 @@
 {application, barrel_mcp, [
     {description, "MCP Protocol Library for Erlang"},
-    {vsn, "2.1.0"},
+    {vsn, "2.2.0"},
     {registered, [barrel_mcp_registry, barrel_mcp_sup, barrel_mcp_session,
                   barrel_mcp_tasks, barrel_mcp_client_sup]},
     {mod, {barrel_mcp_app, []}},
     {applications, [kernel, stdlib, crypto, h1, h2, hackney]},
     {env, [
         {server_name, <<"barrel">>},
-        {server_version, <<"2.1.0">>},
+        {server_version, <<"2.2.0">>},
         {protocol_version, <<"2025-11-25">>},
         {session_ttl, 1800000}  %% 30 minutes default
     ]},

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -668,7 +668,7 @@ notify_progress(Params, Data) ->
 build_initialize_params(#data{spec = Spec}) ->
     ClientInfo0 = maps:get(client_info, Spec,
                            #{<<"name">> => <<"barrel_mcp_client">>,
-                             <<"version">> => <<"2.1.0">>}),
+                             <<"version">> => <<"2.2.0">>}),
     ClientInfo = normalize_keys(ClientInfo0),
     Caps = capabilities_to_wire(maps:get(capabilities, Spec, #{})),
     Version = maps:get(protocol_version, Spec, ?MCP_CLIENT_PROTOCOL_VERSION),


### PR DESCRIPTION
Version bump `2.1.0` to `2.2.0` and changelog for the auth_info feature merged in #55.

### Changed
- `vsn`/`server_version` in `barrel_mcp.app.src`, client `client_info` default, README dep tag, and the client guide bumped to 2.2.0.
- `CHANGELOG.md`: new `[2.2.0]` entry.