### PR TITLE
Expose tool_name to tool handlers; honor arity-2 in run/3

### DIFF
--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -100,7 +100,13 @@
         request_timeout => pos_integer(),
         init_timeout => pos_integer(),
         ping_interval => pos_integer() | infinity,
-        ping_failure_threshold => pos_integer()
+        ping_failure_threshold => pos_integer(),
+        %% Extra headers on every HTTP request. Servers configured with
+        %% `allow_missing_origin => false' reject requests that carry no
+        %% `Origin', so pass one here:
+        %%   `http_headers => [{<<"origin">>, <<"https://app.example">>}]'
+        %% Ignored by the stdio transport.
+        http_headers => [{binary() | string(), binary() | string()}]
     }.
 
 -export_type([connect_spec/0]).

--- a/src/barrel_mcp_registry.erl
+++ b/src/barrel_mcp_registry.erl
@@ -237,7 +237,13 @@ run(Type, Name, Args) ->
     case find(Type, Name) of
         {ok, #{module := M, function := F}} ->
             try
-                Result = M:F(Args),
+                %% Mirror invoke_tool_handler/5: prefer the arity-2 form so
+                %% a local invoke reaches the same handlers the wire does.
+                Result =
+                    case erlang:function_exported(M, F, 2) of
+                        true -> M:F(Args, #{tool_name => Name});
+                        false -> M:F(Args)
+                    end,
                 {ok, Result}
             catch
                 Class:Reason:Stack ->
@@ -266,7 +272,9 @@ run_completion(Key, Value, Ctx) ->
 
 %% @doc Execute a tool handler asynchronously. Spawns a worker that
 %% calls `Mod:Fun(Args, Ctx)' (when arity 2 is exported) or
-%% `Mod:Fun(Args)' otherwise. The worker reports back to
+%% `Mod:Fun(Args)' otherwise. `Ctx' carries `tool_name' — the name the
+%% tool was invoked under — so one handler can serve many registered
+%% tools (as an MCP gateway does). The worker reports back to
 %% `maps:get(reply_to, Ctx)' as either:
 %% <ul>
 %%   <li>`{tool_result, RequestId, Result}' on a normal return</li>
@@ -293,7 +301,10 @@ run_tool(Name, Args, Ctx) ->
             {error, {not_found, tool, Name}}
     end.
 
-run_tool_worker(_Name, Args, Ctx, Handler, ReplyTo, RequestId) ->
+run_tool_worker(Name, Args, Ctx0, Handler, ReplyTo, RequestId) ->
+    %% Gateways register many tools against one handler; without the name
+    %% an arity-2 handler cannot tell which tool it is serving.
+    Ctx = Ctx0#{tool_name => Name},
     %% Optional input validation against the registered input_schema.
     case validate_tool_input(Args, Handler) of
         ok ->

--- a/test/barrel_mcp_registry_tests.erl
+++ b/test/barrel_mcp_registry_tests.erl
@@ -7,7 +7,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %% Test handlers (exported for MCP registry)
--export([sample_handler/1]).
+-export([sample_handler/1, ctx_handler/2]).
 
 %%====================================================================
 %% Test Fixtures
@@ -20,6 +20,8 @@ registry_test_() ->
         {"Register and find prompt", fun test_register_prompt/0},
         {"Unregister handler", fun test_unregister/0},
         {"Run tool handler", fun test_run_tool/0},
+        {"Ctx carries tool_name", fun test_run_tool_ctx_tool_name/0},
+        {"One handler serves many tools", fun test_gateway_dispatch_by_tool_name/0},
         {"Run handler not found", fun test_run_not_found/0},
         {"List all handlers", fun test_all/0},
         {"List handlers by type", fun test_all_type/0},
@@ -62,6 +64,12 @@ cleanup(_) ->
 %% Sample handler function for testing
 sample_handler(Args) ->
     #{result => Args}.
+
+%% An arity-2 handler: echoes back the tool it was invoked as. This is the
+%% shape an MCP gateway uses to route one handler across many registered
+%% tool names.
+ctx_handler(Args, Ctx) ->
+    #{invoked_as => maps:get(tool_name, Ctx, undefined), args => Args}.
 
 %%====================================================================
 %% Tests
@@ -121,6 +129,51 @@ test_run_tool() ->
     {ok, Result} = barrel_mcp_registry:run(tool, Name, Args),
     ?assertEqual(#{result => Args}, Result),
     barrel_mcp_registry:unreg(tool, Name).
+
+%% Drive the real wire path: run_tool/3 spawns a worker that replies to
+%% `reply_to'. This is what barrel_mcp_http_engine does.
+run_tool_sync(Name, Args) ->
+    RequestId = erlang:unique_integer([positive]),
+    Ctx = #{reply_to => self(), request_id => RequestId},
+    {ok, _Pid} = barrel_mcp_registry:run_tool(Name, Args, Ctx),
+    receive
+        {tool_result, RequestId, Result} -> {ok, Result};
+        {tool_failed, RequestId, Reason} -> {error, Reason}
+    after 5000 -> {error, timeout}
+    end.
+
+test_run_tool_ctx_tool_name() ->
+    Name = <<"ctx_test">>,
+    ok = barrel_mcp_registry:reg(tool, Name, ?MODULE, ctx_handler, #{}),
+    Args = #{<<"key">> => <<"value">>},
+    %% wire path
+    {ok, Result} = run_tool_sync(Name, Args),
+    ?assertEqual(Name, maps:get(invoked_as, Result)),
+    ?assertEqual(Args, maps:get(args, Result)),
+    %% local-invoke path (barrel_mcp:call_tool/2) must agree
+    {ok, Local} = barrel_mcp_registry:run(tool, Name, Args),
+    ?assertEqual(Name, maps:get(invoked_as, Local)),
+    barrel_mcp_registry:unreg(tool, Name).
+
+%% The gateway contract: many tool names, one Module:Function. Each call
+%% must report the name it was invoked under, or a gateway cannot route
+%% upstream.
+test_gateway_dispatch_by_tool_name() ->
+    Names = [<<"srv_a:do_thing">>, <<"srv_b:other_thing">>],
+    [ok = barrel_mcp_registry:reg(tool, N, ?MODULE, ctx_handler, #{}) || N <- Names],
+    Seen = [
+        begin
+            {ok, R} = run_tool_sync(N, #{}),
+            maps:get(invoked_as, R)
+        end
+     || N <- Names
+    ],
+    ?assertEqual(Names, Seen),
+    %% arity-1 handlers keep working alongside arity-2 ones
+    ok = barrel_mcp_registry:reg(tool, <<"plain">>, ?MODULE, sample_handler, #{}),
+    ?assertEqual({ok, #{result => #{}}}, run_tool_sync(<<"plain">>, #{})),
+    [barrel_mcp_registry:unreg(tool, N) || N <- [<<"plain">> | Names]],
+    ok.
 
 test_run_not_found() ->
     {error, {not_found, tool, <<"nonexistent">>}} =


### PR DESCRIPTION
run_tool_worker/6 received the tool name and discarded it, so a single Module:Function handler could not tell which of many registered tools it was serving, the shape an MCP gateway needs. Bind it into the handler Ctx as tool_name.

registry:run/3 also only ever called M:F(Args), silently ignoring the arity-2 handlers reg_tool/4 accepts. Make it mirror the wire path.

Both additive; tests cover the wire and local-invoke paths and that arity-1 handlers still work.

Note: the branch was rebuilt on main; its two other commits (hackney ~> 4.7 constraint, already_present reconnect recovery) already landed via #60 and f377806.