### PR TITLE
Replace the em dashes inherited in docs and comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ _checkouts/
 ebin/
 *.beam
 
-# Examples — _checkouts symlinks created by `make examples-setup'
+# Examples: _checkouts symlinks created by `make examples-setup'
 examples/*/_checkouts/
 
 # Python interop venv created by `make interop-setup'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -511,7 +511,7 @@ A feature release that completes the OAuth surface vs MCP `2025-11-25` and `mode
 
 - The MCP spec defines `_meta` as the extensibility hook on every JSON-RPC envelope. Previously only `_meta.progressToken` was read on `tools/call`; everything else dropped on the floor. Now:
   - **Inbound**: tool handler `Ctx` carries the full inbound `_meta` map under the `meta` key. `progress_token` stays for back-compat. The async plan emitted by `barrel_mcp_protocol:handle/1` for `tools/call` carries `meta` so transports without their own `_meta` extraction (stdio, legacy HTTP) get it via `barrel_mcp_protocol:drive_async_plan/2`.
-  - **Outbound**: new return shapes on tool handlers — `{result_meta, Result, MetaMap}`, `{structured_meta, Data, Content, MetaMap}`, `{tool_error, Content, MetaMap}` — surface `_meta` on the response. The existing tuple shapes are unchanged.
+  - **Outbound**: new return shapes on tool handlers: `{result_meta, Result, MetaMap}`, `{structured_meta, Data, Content, MetaMap}`, `{tool_error, Content, MetaMap}`: surface `_meta` on the response. The existing tuple shapes are unchanged.
   - **Envelope helpers**: new `barrel_mcp_protocol:success_response/3` and `error_response/4` accept an optional `_meta` map. Empty map omits the field. Used by every transport's tool-outcome path so the wire shape is consistent.
 - 8 new eunit cases cover the envelope helpers, `drive_async_plan` for the new result/structured/error meta variants, and an end-to-end `_meta` round-trip through a tool that echoes Ctx-supplied `_meta` back through the response.
 
@@ -551,7 +551,7 @@ endpoint, the OAuth Client Credentials grant from
 apps. The default `protocol_version` env is now `2025-11-25`
 (was `2025-03-26`).
 
-**Breaking wire-level changes since 1.1.0** — hosts that
+**Breaking wire-level changes since 1.1.0**: hosts that
 produced or consumed these envelopes need to update:
 
 - `notifications/tasks/changed` was renamed to `notifications/tasks/status` (the spec method name).
@@ -570,13 +570,13 @@ produced or consumed these envelopes need to update:
 
 ### Cancellation race fix in Streamable HTTP
 
-- `wait_for_tool/2` now does a 50ms lookahead after every tool outcome to absorb a pending `{cancelled, _}` message that races with the worker's response. A cooperative arity-2 handler that returns `{tool_error, ...}` on cancel could deliver its outcome to the waiter's mailbox **before** the session-emitted `{cancelled, _}`, depending on scheduler — which made the HTTP path emit a JSON-RPC `isError: true` envelope instead of the spec-mandated 200 + empty body. With the lookahead the cancel always wins.
+- `wait_for_tool/2` now does a 50ms lookahead after every tool outcome to absorb a pending `{cancelled, _}` message that races with the worker's response. A cooperative arity-2 handler that returns `{tool_error, ...}` on cancel could deliver its outcome to the waiter's mailbox **before** the session-emitted `{cancelled, _}`, depending on scheduler, which made the HTTP path emit a JSON-RPC `isError: true` envelope instead of the spec-mandated 200 + empty body. With the lookahead the cancel always wins.
 
 ### OAuth Client Credentials grant (MCP `ext-auth` extension)
 
 - `barrel_mcp_client_auth_oauth` now supports the OAuth 2.1 `client_credentials` grant for unattended agent hosts. Pass `auth => {oauth_client_credentials, Config}` on the connect spec; required keys are `token_endpoint` and `client_id`, plus either `client_secret` (HTTP Basic per RFC 6749) or `client_assertion` (`private_key_jwt`, RFC 7523). Optional `scopes`, `resource`.
 - New public exchanger `barrel_mcp_client_auth_oauth:client_credentials/2` for direct use outside the auth-handle flow.
-- The library fetches the token eagerly during `init/1` (so a misconfigured client fails fast) and re-acquires via the same grant on every 401 — no refresh_token involved. Reuses the existing PRM + AS metadata discovery code.
+- The library fetches the token eagerly during `init/1` (so a misconfigured client fails fast) and re-acquires via the same grant on every 401, no refresh_token involved. Reuses the existing PRM + AS metadata discovery code.
 - Implements the OAuth Client Credentials extension from `modelcontextprotocol/ext-auth`. The Enterprise-Managed Authorization extension (token-exchange + JWT bearer assertions) is left for follow-up; ask if you need it.
 
 ### Doc cleanup: stale roadmap items + subscription session scope
@@ -584,7 +584,7 @@ produced or consumed these envelopes need to update:
 - `guides/features.md`'s roadmap section called out a "periodic deadline timer" and "client-side `Last-Event-ID` resume" as missing. Both turn out to be either by-design (default request timeout already bounds every call; explicit `infinity` is a deliberate caller choice) or already shipped (the transport's `reopen_sse` loop preserves `sse_last_event_id` across server-initiated SSE closes, and a full client restart re-initializes the session anyway). Replaced the roadmap section with notes explaining each.
 - `guides/tools-resources-prompts.md` now calls out that `resources/subscribe` is scoped to the calling `Mcp-Session-Id`: when a client re-initializes, the new session id has no carry-over subscriptions and must subscribe again. Matches the spec's session-lifecycle model; previously implicit.
 
-### `examples/agent_host` — runnable multi-server federation demo
+### `examples/agent_host`: runnable multi-server federation demo
 
 - New example app showing the `barrel_mcp_agent` aggregator + router end-to-end. `agent_host:run/0` connects two clients to one in-process MCP server under different `ServerId`s, calls `barrel_mcp_agent:list_tools/0` to surface the namespaced catalog, and routes a `<<"beta:echo">>` call through the right client. CT case asserts the namespaced names appear and the routed result round-trips.
 - Closes the docs loop for `barrel_mcp_agent` (the module shipped without a runnable example).
@@ -644,7 +644,7 @@ Together with sampling / elicitation / roots / progress / subscribe / tasks alre
 ### Tasks Task-shape wire alignment
 
 - Renamed the wire field `updatedAt` → `lastUpdatedAt` on every Task envelope (`tasks/get`, `tasks/list`, `notifications/tasks/changed`). The reference Python SDK models the field as `lastUpdatedAt`, and accepts no other name.
-- Added a `ttl` field to every Task envelope (always `null` for now — we don't yet honour client-supplied TTLs). The Python SDK's `Task` model requires the field to be present.
+- Added a `ttl` field to every Task envelope (always `null` for now, we don't yet honour client-supplied TTLs). The Python SDK's `Task` model requires the field to be present.
 - `tasks/cancel` now returns the cancelled Task instead of `{}`. Matches `CancelTaskResult` in the reference SDK; existing barrel_mcp clients that pattern-match `{ok, _}` are unaffected.
 - Extended the Direction A interop test to call `experimental.list_tasks()`, exercising the Task wire shape end-to-end against the reference pydantic models.
 
@@ -659,13 +659,13 @@ Together with sampling / elicitation / roots / progress / subscribe / tasks alre
 - `make interop-setup` creates the venv, `make interop-test` runs the suite. The CT cases skip cleanly when `INTEROP_PYTHON` is unset, so the default `rebar3 ct` loop is unaffected by missing Python tooling.
 - New `interop` CI job runs both directions on Linux with Python 3.12 + OTP 28.
 
-### `barrel_mcp_agent` — multi-server tool aggregator
+### `barrel_mcp_agent`: multi-server tool aggregator
 
 - New module sitting on top of `barrel_mcp_clients`. Aggregates `tools/list` across every connected MCP client, rewrites each tool name to `<<"ServerId<sep>ToolName">>` (default separator `:`), and routes a namespaced `call_tool/2,3` back to the correct client.
 - `to_anthropic/0,1` and `to_openai/0,1` return the aggregated catalog directly in provider format, ready to hand to a model.
 - Closes the orchestration gap for hosts running an agent loop against multiple MCP servers.
 
-### `barrel_mcp_tool_format` — LLM provider tool-shape translator
+### `barrel_mcp_tool_format`: LLM provider tool-shape translator
 
 - New module bridging MCP tool definitions and the tool shapes the LLM provider APIs expect.
 - `to_anthropic/1`, `to_openai/1` translate MCP `tools/list` entries (single map or list) to the Anthropic Messages API and OpenAI Chat Completions tool shapes.
@@ -675,11 +675,11 @@ Together with sampling / elicitation / roots / progress / subscribe / tasks alre
 ### `resources/read` content-block flexibility
 
 - Resource handlers may now return a list of pre-built content blocks; each block is passed through verbatim, with `uri` auto-injected when the handler omits it.
-- The `#{text := _}` and `#{blob := _, mimeType := _}` map shapes accept optional `mimeType` (text only — blob already requires it) and `annotations` keys, matching the spec's per-content metadata. Both flow through to the wire under `mimeType` / `annotations`.
+- The `#{text := _}` and `#{blob := _, mimeType := _}` map shapes accept optional `mimeType` (text only, blob already requires it) and `annotations` keys, matching the spec's per-content metadata. Both flow through to the wire under `mimeType` / `annotations`.
 
 ### Tool, resource, prompt, and resource-template annotations
 
-- `reg_tool/4`, `reg_resource/4`, `reg_prompt/4`, and `reg_resource_template/4` accept a new `annotations` option — a free-form map surfaced verbatim under `annotations` in the matching `*/list` payload. The MCP spec defines `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` for tools, and `audience` / `priority` for resources, prompts, and templates. Registrations without annotations omit the field on the wire.
+- `reg_tool/4`, `reg_resource/4`, `reg_prompt/4`, and `reg_resource_template/4` accept a new `annotations` option, a free-form map surfaced verbatim under `annotations` in the matching `*/list` payload. The MCP spec defines `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint` for tools, and `audience` / `priority` for resources, prompts, and templates. Registrations without annotations omit the field on the wire.
 
 ### `logging/setLevel` actually filters the log stream
 
@@ -727,7 +727,7 @@ Together with sampling / elicitation / roots / progress / subscribe / tasks alre
 ### Spec parity: protocol bump, async tools, list-changed, auth hardening
 
 - **Server protocol bumped to `2025-11-25`.** `initialize` negotiates with the client: when the client requests a version we speak, we echo it; otherwise we reply with our preferred version. Capabilities advertised in `initialize` now include `listChanged: true` on `tools`, `resources`, and `prompts`.
-- **Async tool execution.** `barrel_mcp_protocol:handle/2` returns `{async, AsyncPlan}` for `tools/call`; the transport invokes the spawn closure to start a worker, records the in-flight entry, and waits on its mailbox. Tool handlers may export arity 1 (legacy) or arity 2 (`(Args, Ctx)` — the new shape that receives session/progress context).
+- **Async tool execution.** `barrel_mcp_protocol:handle/2` returns `{async, AsyncPlan}` for `tools/call`; the transport invokes the spawn closure to start a worker, records the in-flight entry, and waits on its mailbox. Tool handlers may export arity 1 (legacy) or arity 2 (`(Args, Ctx)`: the new shape that receives session/progress context).
 - **`notifications/cancelled` wired end-to-end.** Inbound cancel finds the in-flight worker via `barrel_mcp_session:cancel_in_flight/2`, sends `{cancel, RequestId}` to the worker and `{cancelled, RequestId}` to the waiter. Per the MCP spec the cancelled HTTP request closes with 200 + empty body; no JSON-RPC response is emitted.
 - **`notifications/progress` emit + handler context.** New façades `barrel_mcp:notify_progress/3,4`. Arity-2 tool handlers receive `Ctx` with an `emit_progress` function bound to the session's progress token, so they can emit progress without knowing about sessions.
 - **`notifications/roots/list_changed` dispatch hook.** Configurable via `application:set_env(barrel_mcp, roots_changed_handler, {Mod, Fun}).`. No-op when unset.
@@ -741,7 +741,7 @@ Together with sampling / elicitation / roots / progress / subscribe / tasks alre
 
 ### Security and spec conformance (Streamable HTTP + JSON-RPC)
 
-- **Origin validation.** Streamable HTTP and the legacy `barrel_mcp_http` now validate the `Origin` header on POST/GET/DELETE/OPTIONS using `uri_string:parse/1` (structural scheme/host/port match — no binary prefix matching). New options `allowed_origins` and `allow_missing_origin`. The literal `Origin: null` value is treated as a distinct present origin and is rejected unless explicitly allowed.
+- **Origin validation.** Streamable HTTP and the legacy `barrel_mcp_http` now validate the `Origin` header on POST/GET/DELETE/OPTIONS using `uri_string:parse/1` (structural scheme/host/port match, no binary prefix matching). New options `allowed_origins` and `allow_missing_origin`. The literal `Origin: null` value is treated as a distinct present origin and is rejected unless explicitly allowed.
 - **Default bind to loopback.** Both transports default to `{127, 0, 0, 1}`. Public binds require an explicit `allowed_origins`; the start function refuses with `{error, allowed_origins_required}` otherwise.
 - **CORS tightening.** `Access-Control-Allow-Origin` now echoes the validated `Origin` (no wildcard) with `Vary: Origin`, and is omitted entirely when no `Origin` is sent. The `Access-Control-Allow-Headers` allow-list is derived from the configured auth provider via a new optional `auth_headers/1` callback on `barrel_mcp_auth`. Custom API-key header names are honoured both in CORS and in `extract_headers`.
 - **Streamable HTTP response shape.** Notifications and POSTed responses to server-initiated requests now return **202 Accepted** with empty body. Missing `Mcp-Session-Id` on a non-initialize request returns **400 Bad Request**; unknown/invalid id returns **404 Not Found**. `initialize` is the only request that may run without a session.
@@ -787,11 +787,11 @@ Together with sampling / elicitation / roots / progress / subscribe / tasks alre
 
 ### Added (docs)
 
-- `guides/building-a-client.md` — task-oriented walkthrough for hosting MCP clients on `barrel_mcp` (transport choice, connect spec, lifecycle, capability negotiation, tool calls, server-initiated requests via the handler behaviour, OAuth, federation, schema validation, error reference).
-- `guides/internals.md` — architecture and behaviour contracts (module map, supervision tree, state machine, message flow, transport/handler/auth contracts, ETS layout, wire format).
-- `examples/echo_client/` — minimal MCP host that boots a local server, lists tools, calls `echo`. Common-test suite asserts the round-trip.
-- `examples/sampling_host/` — host implementing `barrel_mcp_client_handler` to answer `sampling/createMessage`. Common-test suite covers the full server-to-client round-trip.
-- `test/snippet_check.escript` + `test/doc_snippets_SUITE.erl` — extracts every `` ```erlang `` fenced block from the new guides and example READMEs and verifies it compiles. Wired into `rebar3 ct`.
+- `guides/building-a-client.md`: task-oriented walkthrough for hosting MCP clients on `barrel_mcp` (transport choice, connect spec, lifecycle, capability negotiation, tool calls, server-initiated requests via the handler behaviour, OAuth, federation, schema validation, error reference).
+- `guides/internals.md`: architecture and behaviour contracts (module map, supervision tree, state machine, message flow, transport/handler/auth contracts, ETS layout, wire format).
+- `examples/echo_client/`: minimal MCP host that boots a local server, lists tools, calls `echo`. Common-test suite asserts the round-trip.
+- `examples/sampling_host/`: host implementing `barrel_mcp_client_handler` to answer `sampling/createMessage`. Common-test suite covers the full server-to-client round-trip.
+- `test/snippet_check.escript` + `test/doc_snippets_SUITE.erl`: extracts every `` ```erlang `` fenced block from the new guides and example READMEs and verifies it compiles. Wired into `rebar3 ct`.
 - `Makefile` with `examples-setup` and `examples-test` targets; CI runs example suites on OTP 27 + 28.
 - Per-function `@doc` and `-spec` on the public client surface (`barrel_mcp_client`, `barrel_mcp_clients`, `barrel_mcp_client_handler` example).
 - ex_doc sidebar reorganised: client modules grouped, new "Building a Client" / "Client Internals" pages.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ change. See [Protocol Versions](guides/protocol-versions.md).
   (`barrel_mcp_schema`).
 - **Transports**: Streamable HTTP (Claude Code), legacy HTTP,
   stdio (Claude Desktop). The HTTP server is built on `h1`/`h2`
-  (HTTP/1.1 + HTTP/2 on one port via ALPN) — no Cowboy. Streamable
+  (HTTP/1.1 + HTTP/2 on one port via ALPN), no Cowboy. Streamable
   HTTP defaults to `127.0.0.1`, validates `Origin`, and replays SSE
   events via `Last-Event-ID`.
 - **Authentication**: bearer (JWT/opaque), API keys (peppered
@@ -116,10 +116,10 @@ If `wait_for_proc` is not set, the registry becomes ready immediately after init
 
 barrel_mcp covers the three MCP roles in one library:
 
-- **server** — exposes tools, resources, prompts to MCP clients.
-- **client** — connects to one MCP server, calls tools, reads
+- **server**: exposes tools, resources, prompts to MCP clients.
+- **client**: connects to one MCP server, calls tools, reads
   resources, handles server-initiated requests.
-- **host (agent)** — drives one or more clients on behalf of an
+- **host (agent)**: drives one or more clients on behalf of an
   LLM; collects each server's tool catalog, hands it to the
   model, routes the model's tool call back through the right
   client.
@@ -128,7 +128,7 @@ The three short examples below cover the typical wiring; deeper
 guides live under `guides/` (`getting-started.md`,
 `tools-resources-prompts.md`, `building-a-client.md`).
 
-### Server — expose a tool over Streamable HTTP
+### Server: expose a tool over Streamable HTTP
 
 ```erlang
 -module(my_server).
@@ -153,7 +153,7 @@ That's a complete MCP server. Point any MCP client (Claude Code,
 Claude Desktop via stdio, the `barrel_mcp_client` below, …) at
 `http://127.0.0.1:8080/mcp`.
 
-### Client — connect and call a tool
+### Client: connect and call a tool
 
 ```erlang
 client_demo() ->
@@ -169,9 +169,9 @@ client_demo() ->
 
 The transport tuple selects the wire (`{http, Url}`,
 `{stdio, [Cmd | Args]}`). Auth and OAuth options live on the same
-spec — see `guides/building-a-client.md`.
+spec, see `guides/building-a-client.md`.
 
-### Host (agent) — hand many MCP servers to an LLM
+### Host (agent): hand many MCP servers to an LLM
 
 ```erlang
 agent_loop() ->
@@ -200,7 +200,7 @@ agent_loop() ->
 provider shapes (Anthropic Messages API, OpenAI Chat Completions);
 swap `to_anthropic/0` and `from_anthropic_call/1` for the OpenAI
 counterparts to use a different model. `ask_llm/1` is your own
-LLM HTTP call — barrel_mcp does not bundle an LLM SDK.
+LLM HTTP call, barrel_mcp does not bundle an LLM SDK.
 
 ## Quick Start
 
@@ -538,8 +538,8 @@ handshake to complete, call tools.
 ok = barrel_mcp_client:close(Pid).
 ```
 
-For the full task-oriented walkthrough — transport choice, auth,
-OAuth, server-to-client handlers, federation, schema validation —
+For the full task-oriented walkthrough (transport choice, auth,
+OAuth, server-to-client handlers, federation, schema validation)
 see [Building a client](guides/building-a-client.md). For
 architecture and behaviour contracts, see
 [Internals](guides/internals.md). Three runnable examples live

--- a/examples/agent_host/README.md
+++ b/examples/agent_host/README.md
@@ -34,7 +34,7 @@ For a self-contained example we boot one in-process Streamable
 HTTP server with a single `echo` tool and connect both clients
 to it. The aggregator surfaces `echo` twice (`alpha:echo` and
 `beta:echo`) and routing still dispatches deterministically by
-prefix — so the round-trip exercises the same code paths a real
+prefix, so the round-trip exercises the same code paths a real
 multi-server setup would use.
 
 ## Run it
@@ -54,11 +54,11 @@ rebar3 shell --eval 'agent_host:run().'
 
 ## Companion modules
 
-- `barrel_mcp_agent` — the aggregator and router this example
+- `barrel_mcp_agent`: the aggregator and router this example
   showcases. See `guides/features.md` and the module's edoc.
-- `barrel_mcp_tool_format` — translate the namespaced catalog
+- `barrel_mcp_tool_format`: translate the namespaced catalog
   to the Anthropic Messages API or OpenAI Chat Completions tool
   shape, and translate a model's tool-call back to
   `(Name, Args)`.
-- `barrel_mcp_clients` — the federation registry that backs
+- `barrel_mcp_clients`: the federation registry that backs
   `barrel_mcp:start_client/2`.

--- a/examples/echo_client/README.md
+++ b/examples/echo_client/README.md
@@ -24,5 +24,5 @@ rebar3 ct
 
 ## What to read
 
-- `src/echo_client.erl` — the entire flow in ~50 lines.
-- `test/echo_client_SUITE.erl` — common_test wrapper.
+- `src/echo_client.erl`: the entire flow in ~50 lines.
+- `test/echo_client_SUITE.erl`: common_test wrapper.

--- a/examples/sampling_host/README.md
+++ b/examples/sampling_host/README.md
@@ -27,14 +27,14 @@ rebar3 ct
 
 ## What to read
 
-- `src/sampling_host.erl` — the full flow. The
+- `src/sampling_host.erl`: the full flow. The
   `barrel_mcp_client_handler` callbacks are at the bottom of the
   module; the server-side tool is `ask_sampler/1`.
-- `test/sampling_host_SUITE.erl` — common_test wrapper.
+- `test/sampling_host_SUITE.erl`: common_test wrapper.
 
 ## Why this matters
 
 A real LLM agent host implements `handle_request/3` to call the LLM
-provider's API. The pattern shown here is the same shape — replace
+provider's API. The pattern shown here is the same shape, replace
 `{reply, Result, State}` with an HTTP call to Anthropic, OpenAI, a
 local Hermes model, or anything else.

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -172,7 +172,7 @@ Stored values look like
 `<<"hmac-sha256$<base64-encoded-hash>">>`.
 
 For verification outside the auth pipeline (config tooling,
-tests), use `barrel_mcp_auth_apikey:verify_key/2` — it does a
+tests), use `barrel_mcp_auth_apikey:verify_key/2`, it does a
 constant-time comparison and accepts both the new format and
 legacy unsalted hex SHA-256 digests for one release.
 
@@ -273,9 +273,9 @@ barrel_mcp:start_http(#{
 
 `hash_password/2` accepts an options map:
 
-- `algorithm` — `pbkdf2-sha256` (default) or `sha256-hex` (legacy,
+- `algorithm`: `pbkdf2-sha256` (default) or `sha256-hex` (legacy,
   for migration only).
-- `iterations` — PBKDF2 iteration count (default 100000).
+- `iterations`: PBKDF2 iteration count (default 100000).
 
 The verification path is the public `verify_password/2`. It
 accepts the modern format and legacy hex SHA-256 digests for one
@@ -399,7 +399,7 @@ Authentication failures return proper HTTP status codes and WWW-Authenticate hea
 `barrel_mcp_client` ships three grants plus a registration
 pre-step. Pick by **who is in the loop and when**:
 
-### Authorization Code + PKCE — interactive
+### Authorization Code + PKCE: interactive
 
 For flows where a real user authorises the host. Browser
 redirect, PKCE prevents code interception, refresh on 401.
@@ -515,7 +515,7 @@ Validate error responses too. On a mismatch the `error`,
 `error_description` and `error_uri` are not yours to act on or display,
 since you cannot tell who wrote them.
 
-### Client Credentials — unattended (M2M)
+### Client Credentials: unattended (M2M)
 
 For agent hosts running without a human. The host already has
 its own credentials.
@@ -543,11 +543,11 @@ auth => {oauth_client_credentials, #{
 }}
 ```
 
-Eager fetch on init — a misconfigured client fails up front.
+Eager fetch on init, a misconfigured client fails up front.
 Re-acquires via the same grant on 401. No `refresh_token` is
 involved.
 
-### Enterprise-Managed Authorization — SSO chain
+### Enterprise-Managed Authorization: SSO chain
 
 For SSO-driven hosts. The user already has a session at the org
 IdP; their identity flows into a short-lived MCP access token
@@ -594,11 +594,11 @@ auth => {oauth_enterprise, #{
 }}
 ```
 
-The library treats `subject_token` as opaque — both OIDC and
+The library treats `subject_token` as opaque, both OIDC and
 SAML modes hit the same code path. The browser flow at the IdP
 stays a host concern.
 
-### Dynamic Client Registration — pre-step
+### Dynamic Client Registration: pre-step
 
 Not a grant. One of three ways to get a `client_id` before any of the
 others; see [Client registration](#client-registration) for choosing
@@ -840,7 +840,7 @@ the wire emission of `WWW-Authenticate` changed.
 
 The client side is implemented by
 `barrel_mcp_client_auth_oauth:parse_www_authenticate/1` and
-`discover_protected_resource/1` — together with the server side
+`discover_protected_resource/1`: together with the server side
 above, the MCP authorization sub-spec discovery flow works
 end-to-end.
 
@@ -870,7 +870,7 @@ metadata document advertises the endpoint via
 
 Feed the returned credentials into a subsequent
 `{oauth, ...}` / `{oauth_client_credentials, ...}` connect spec.
-This stays a standalone exchanger — the library doesn't persist
+This stays a standalone exchanger, the library doesn't persist
 the issued credentials. That's a host concern (file, DB, secret
 manager).
 

--- a/guides/building-a-client.md
+++ b/guides/building-a-client.md
@@ -2,7 +2,7 @@
 
 `barrel_mcp` is a pure MCP library. It implements the wire protocol,
 the transports, and the client state machine. It does **not** call
-LLM providers, build prompts, or run an agent loop — those belong to
+LLM providers, build prompts, or run an agent loop, those belong to
 the host application that uses this library.
 
 This guide is task-oriented. Each section answers "I want to do X"
@@ -426,9 +426,9 @@ The server may follow up with `roots/list` against your handler.
 
 Three return shapes from `handle_request/3`:
 
-- `{reply, Result, State}` — synchronous answer.
-- `{error, Code, Message, State}` — JSON-RPC error response.
-- `{async, Tag, State}` — defer; reply later from any process via
+- `{reply, Result, State}`: synchronous answer.
+- `{error, Code, Message, State}`: JSON-RPC error response.
+- `{async, Tag, State}`: defer; reply later from any process via
   `barrel_mcp_client:reply_async(Pid, Tag, Result)`.
 
 Skeleton:
@@ -523,17 +523,17 @@ handle_request(<<"sampling/createMessage">>, Params, State) ->
 The handler's `handle_notification/3` callback receives every inbound
 notification with its raw `params` map. Common methods:
 
-- `notifications/resources/updated` — also dispatched to subscribers
+- `notifications/resources/updated`: also dispatched to subscribers
   of the URI as `{mcp_resource_updated, Uri, Params}` (see section 8).
-- `notifications/progress` — also dispatched to the caller of the
+- `notifications/progress`: also dispatched to the caller of the
   request that owns the progress token (see section 7).
 - `notifications/tools/list_changed`, `.../resources/list_changed`,
-  `.../prompts/list_changed` — catalogue updated; re-fetch or
+  `.../prompts/list_changed`: catalogue updated; re-fetch or
   invalidate caches.
-- `notifications/tasks/status` — a long-running task transitioned
+- `notifications/tasks/status`: a long-running task transitioned
   state. The full task record is in `params`.
-- `notifications/message` — server logging stream.
-- `notifications/replay_truncated` — your `Last-Event-ID` was
+- `notifications/message`: server logging stream.
+- `notifications/replay_truncated`: your `Last-Event-ID` was
   outside the server's replay window; resync rather than trust the
   partial stream.
 
@@ -602,13 +602,13 @@ cancel_request(Pid, Id) ->
 The id is the JSON-RPC request id for the in-flight call.
 `barrel_mcp_client` increments these internally; in tests you can
 read pending ids via `sys:get_state/1`. In production you usually
-don't cancel by id — you set a `timeout` on `call_tool/4` and let
+don't cancel by id, you set a `timeout` on `call_tool/4` and let
 the deadline fire.
 
 Periodic ping is opt-in:
 
 ```erl
-%% Spec snippet — a key on barrel_mcp_client:start_link/1's input map.
+%% Spec snippet, a key on barrel_mcp_client:start_link/1's input map.
 #{ping_interval => 30000, ping_failure_threshold => 3}
 ```
 
@@ -727,7 +727,7 @@ call_validated(Pid, Name, Args, Schema) ->
     end.
 ```
 
-This is opt-in — many hosts trust the LLM output enough to skip it.
+This is opt-in, many hosts trust the LLM output enough to skip it.
 Use it when you want a clear error before the request reaches the
 server.
 
@@ -803,9 +803,9 @@ Why}` when a pinned modern connection could not be established, and
 
 ## See also
 
-- [Internals](internals.md) — architecture and behaviour contracts.
-- [`examples/echo_client/`](https://github.com/barrel-platform/barrel_mcp/tree/main/examples/echo_client) — minimal
+- [Internals](internals.md): architecture and behaviour contracts.
+- [`examples/echo_client/`](https://github.com/barrel-platform/barrel_mcp/tree/main/examples/echo_client): minimal
   end-to-end host.
-- [`examples/sampling_host/`](https://github.com/barrel-platform/barrel_mcp/tree/main/examples/sampling_host) — handler
+- [`examples/sampling_host/`](https://github.com/barrel-platform/barrel_mcp/tree/main/examples/sampling_host): handler
   behaviour worked example.
-- [Features](features.md) — spec coverage matrix.
+- [Features](features.md): spec coverage matrix.

--- a/guides/features.md
+++ b/guides/features.md
@@ -22,7 +22,7 @@ deployment, and connects to both. See the
 
 ### Transports
 
-- HTTP transport (`barrel_mcp_http`) — JSON-RPC over POST. Legacy.
+- HTTP transport (`barrel_mcp_http`): JSON-RPC over POST. Legacy.
 - Streamable HTTP transport (`barrel_mcp_http_stream`): every
   revision from `2026-07-28` down to `2024-11-05`. POST (JSON or
   SSE), GET (SSE, legacy), DELETE (legacy), OPTIONS. Default bind
@@ -86,7 +86,7 @@ deployment, and connects to both. See the
 
 ### Registries
 
-- **Tools** — handlers may be arity 1 or arity 2. Arity-2
+- **Tools**: handlers may be arity 1 or arity 2. Arity-2
   handlers receive a `Ctx` map with `session_id`, `request_id`,
   `progress_token`, the inbound `meta` map (the spec's `_meta`
   extension hook), and an `emit_progress` function.
@@ -94,25 +94,25 @@ deployment, and connects to both. See the
   `{structured_meta, Data, Content, Map}`,
   `{tool_error, Content, Map}`) attach `_meta` to the response
   envelope.
-- **Resources** — text/binary content, MIME types,
+- **Resources**: text/binary content, MIME types,
   `notifications/resources/updated` for live updates. Handlers
   may return a single block (`#{text := _}` /
   `#{blob := _, mimeType := _}`, with optional `mimeType` and
   `annotations`) or a list of pre-built content blocks for
   multi-part responses.
-- **Resource templates** — RFC 6570 URI templates, surfaced via
+- **Resource templates**: RFC 6570 URI templates, surfaced via
   `resources/templates/list`. `resources/read` against a URI
   matching a registered template auto-expands the variables
   (Level 1, simple `{var}` substitutions) and routes to the
   template handler with the substituted values in `Args`.
-- **Prompts** — multi-message conversation templates with
+- **Prompts**: multi-message conversation templates with
   arguments.
-- **Completions** — keyed by `{prompt, Name, Arg}` or
+- **Completions**: keyed by `{prompt, Name, Arg}` or
   `{resource_template, Uri, Arg}`; advertised via the
   `completions` capability when at least one is registered.
 - All registrations accept optional `title` and `icons`.
 - Tool, resource, prompt, and resource-template registrations
-  also accept `annotations` — a free-form map surfaced verbatim
+  also accept `annotations`, a free-form map surfaced verbatim
   under `annotations` in the matching `*/list` payload. Tools use
   `readOnlyHint`, `destructiveHint`, `idempotentHint`,
   `openWorldHint`; resources/prompts/templates use `audience`
@@ -126,7 +126,7 @@ deployment, and connects to both. See the
 - `validate_input` and `validate_output` opt-in schema validation
   via `barrel_mcp_schema`.
 - `long_running => true` returns a `taskId` immediately and runs
-  the worker in the background. Backed by `barrel_mcp_tasks` —
+  the worker in the background. Backed by `barrel_mcp_tasks`, 
   surfaces `tasks/list`, `tasks/get`, `tasks/cancel`, and
   `notifications/tasks/status`.
 - Cancellation: cooperative arity-2 handlers see
@@ -189,7 +189,7 @@ by the spec.
 | Streamable HTTP | `barrel_mcp_client_http` | POST with `application/json, text/event-stream`, SSE on POST and on a long-lived GET, `Mcp-Session-Id` capture, `MCP-Protocol-Version` after init, DELETE on close, 401 retry through `barrel_mcp_client_auth`. |
 | stdio | `barrel_mcp_client_stdio` | Subprocess line-delimited JSON-RPC. |
 
-### Protocol coverage (Phase A — shipped)
+### Protocol coverage (Phase A, shipped)
 
 - Speaks every revision from `2026-07-28` down to `2024-11-05`.
   `protocol_version => auto` (the default) probes with
@@ -291,7 +291,7 @@ by the spec.
     with `client_secret` (HTTP Basic) or `client_assertion`
     (`private_key_jwt`, RFC 7523). Optional `scopes`, `resource`.
     The library fetches the token eagerly during `init/1` and
-    re-acquires via the same grant on 401 — no refresh_token
+    re-acquires via the same grant on 401, no refresh_token
     needed.
   - Enterprise-Managed Authorization (MCP `ext-auth` EMA) for
     SSO-driven hosts: pass `auth => {oauth_enterprise, Config}`.
@@ -317,12 +317,12 @@ registry into a single namespaced tool catalog the host can hand
 to an LLM, plus a router that dispatches a model's tool call back
 to the right MCP server.
 
-- `list_tools/0,1` — aggregated `tools/list` across every
+- `list_tools/0,1`: aggregated `tools/list` across every
   registered client; tool names rewritten to
   `<<"ServerId<sep>ToolName">>` (default separator `:`).
-- `to_anthropic/0,1`, `to_openai/0,1` — the same catalog in the
+- `to_anthropic/0,1`, `to_openai/0,1`: the same catalog in the
   matching provider shape.
-- `call_tool/2,3` — parses the namespaced name, routes to the
+- `call_tool/2,3`: parses the namespaced name, routes to the
   right client. Errors `{error, no_separator | unknown_server}`
   cover the parse / lookup paths.
 
@@ -332,8 +332,8 @@ Translates MCP tool maps to the shapes the major LLM provider
 APIs expect, and translates a model's tool-call back into the
 `(Name, Arguments)` pair `barrel_mcp_client:call_tool/4` consumes.
 
-- `to_anthropic/1`, `to_openai/1` — MCP tool → provider tool.
-- `from_anthropic_call/1`, `from_openai_call/1` — provider call →
+- `to_anthropic/1`, `to_openai/1`: MCP tool → provider tool.
+- `from_anthropic_call/1`, `from_openai_call/1`: provider call →
   `{Name, Args}`. Accepts both parsed maps and JSON-string
   arguments (the OpenAI wire shape).
 

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -41,7 +41,7 @@ Tools are functions that can be called by MCP clients (like Claude):
 -module(my_tools).
 -export([greet/1]).
 
-%% Arity-1 handler — gets only the call arguments. The simplest
+%% Arity-1 handler, gets only the call arguments. The simplest
 %% shape; pick this when you don't need progress, cancellation, or
 %% session context. For arity-2 handlers (with a Ctx parameter),
 %% see the Tools guide.
@@ -75,7 +75,7 @@ barrel_mcp:reg_tool(<<"greet">>, my_tools, greet, #{
 
 The Streamable HTTP server binds to `127.0.0.1` by default and
 validates the `Origin` header on every request. Public binds (any
-non-loopback IP) require an explicit `allowed_origins` — see the
+non-loopback IP) require an explicit `allowed_origins`, see the
 [Streamable HTTP guide](http-stream.md) for the security defaults.
 
 The legacy plain-HTTP transport (`start_http/1`, JSON-RPC only,
@@ -123,10 +123,10 @@ For Claude Desktop integration, use the stdio transport:
 
 ## Next Steps
 
-- [Tools, Resources & Prompts](tools-resources-prompts.md) — handler shapes (arity 1 / arity 2 with `Ctx`), tool errors, structured output, long-running tasks, completions, resource templates, server notifications.
-- [Streamable HTTP transport](http-stream.md) — security defaults, CORS, `Origin` validation, response codes, replay.
-- [Authentication](authentication.md) — bearer / API key / basic, modern hash formats.
-- [Features matrix](features.md) — what's supported on the wire.
-- [Building a client](building-a-client.md) — task-oriented walkthrough for hosting MCP clients.
-- [Client internals](internals.md) — architecture and behaviour contracts.
+- [Tools, Resources & Prompts](tools-resources-prompts.md): handler shapes (arity 1 / arity 2 with `Ctx`), tool errors, structured output, long-running tasks, completions, resource templates, server notifications.
+- [Streamable HTTP transport](http-stream.md): security defaults, CORS, `Origin` validation, response codes, replay.
+- [Authentication](authentication.md): bearer / API key / basic, modern hash formats.
+- [Features matrix](features.md): what's supported on the wire.
+- [Building a client](building-a-client.md): task-oriented walkthrough for hosting MCP clients.
+- [Client internals](internals.md): architecture and behaviour contracts.
 - [MCP Client (reference)](client.md) - Older API reference, kept for cross-linking

--- a/guides/http-stream.md
+++ b/guides/http-stream.md
@@ -92,7 +92,7 @@ otherwise. This avoids accidental exposure to DNS-rebinding and
 CORS-style attacks.
 
 ```erlang
-%% Public bind — must list allowed origins explicitly.
+%% Public bind, must list allowed origins explicitly.
 {ok, _} = barrel_mcp:start_http_stream(#{
     port => 9090,
     ip => {0, 0, 0, 0},

--- a/guides/internals.md
+++ b/guides/internals.md
@@ -86,12 +86,12 @@ temporary under `barrel_mcp_client_sup`, so no other client notices.
 
 State transitions:
 
-- `connecting → initializing` — internal event after `open_transport/1`.
-- `initializing → ready` — successful `initialize` response, version in
+- `connecting → initializing`: internal event after `open_transport/1`.
+- `initializing → ready`: successful `initialize` response, version in
   `?MCP_CLIENT_SUPPORTED_VERSIONS`.
-- `initializing → stop {init_failed, _}` — server returned a JSON-RPC
+- `initializing → stop {init_failed, _}`: server returned a JSON-RPC
   error to `initialize` or omitted `protocolVersion`.
-- `ready → closing` — caller cast `close`, or stop on `mcp_closed`,
+- `ready → closing`: caller cast `close`, or stop on `mcp_closed`,
   or stop with `ping_failed`.
 
 ## 4. Inbound message flow
@@ -112,7 +112,7 @@ barrel_mcp_client gen_statem (info handler)
                                (+ progress routing for notifications/progress)
 ```
 
-The transport process owns the wire — socket, port, SSE buffer — and
+The transport process owns the wire (socket, port, SSE buffer) and
 forwards one JSON-RPC envelope per `{mcp_in, _, _}` message. The
 gen_statem never reads the wire directly. This means transports can
 implement framing however suits them (line-delimited for stdio,
@@ -165,7 +165,7 @@ matching state-timeout.
 
 The transport process MUST emit `{mcp_in, TransportPid, JsonBinary}`
 to `Owner` for every complete inbound JSON-RPC envelope. On
-shutdown — peer disconnect, port exit, fatal error — it MUST emit
+shutdown (peer disconnect, port exit, fatal error) it MUST emit
 `{mcp_closed, TransportPid, Reason}` exactly once.
 
 ### `barrel_mcp_client_handler`

--- a/guides/stdio.md
+++ b/guides/stdio.md
@@ -14,7 +14,7 @@ Unlike HTTP transport, stdio transport:
 
 The same registries (tools, resources, prompts, resource
 templates, completions, tasks) work over stdio. Tool handlers may
-be arity 1 or arity 2 (`(Args, Ctx)`) — the `emit_progress` and
+be arity 1 or arity 2 (`(Args, Ctx)`), the `emit_progress` and
 cancellation hooks in `Ctx` interleave on stdout in stdio just
 like they do on the SSE channel for HTTP. See the
 [Tools guide](tools-resources-prompts.md) for the handler shape.

--- a/guides/tools-resources-prompts.md
+++ b/guides/tools-resources-prompts.md
@@ -161,10 +161,10 @@ Arity-1 handlers continue to work; pick whichever arity you need.
 Tool handlers may attach a `_meta` map to the response envelope
 by returning one of the meta-bearing tuples:
 
-- `{result_meta, Result, MetaMap}` — plain result + `_meta`.
-- `{structured_meta, Data, Content, MetaMap}` —
+- `{result_meta, Result, MetaMap}`: plain result + `_meta`.
+- `{structured_meta, Data, Content, MetaMap}`: 
   `structuredContent` + `_meta`.
-- `{tool_error, Content, MetaMap}` — error result + `_meta`.
+- `{tool_error, Content, MetaMap}`: error result + `_meta`.
 
 Empty maps are omitted from the wire. The plain
 `{tool_error, Content}` and `{structured, Data, Content}`
@@ -573,7 +573,7 @@ barrel_mcp:reg_resource_template(<<"file">>, my_resources, read_file_uri, #{
 ```
 
 `resources/read` against a templated URI is matched and routed
-to the template handler automatically — RFC 6570 Level 1
+to the template handler automatically, RFC 6570 Level 1
 substitutions (simple `{var}` expansion) cover what the spec's
 reference examples use. The substituted variables are merged
 into the handler's `Args` map under their template names:
@@ -605,8 +605,8 @@ barrel_mcp:reg_completion(
 
 Handlers are arity 2: `(PartialValue, Ctx)`. Return one of:
 
-- `{ok, [Suggestion]}` — full list.
-- `{ok, [Suggestion], #{has_more => true}}` — more available; the
+- `{ok, [Suggestion]}`: full list.
+- `{ok, [Suggestion], #{has_more => true}}`: more available; the
   client can issue another `completion/complete` to drill in.
 
 The `completions` capability is advertised in `initialize` as soon

--- a/src/barrel_mcp.erl
+++ b/src/barrel_mcp.erl
@@ -335,11 +335,11 @@ list_resources() ->
 %%
 %% Options:
 %% <ul>
-%%   <li>`name' — display name.</li>
-%%   <li>`uri_template' — RFC 6570 URI template (e.g.
+%%   <li>`name': display name.</li>
+%%   <li>`uri_template': RFC 6570 URI template (e.g.
 %%       `<<"file:///{path}">>').</li>
-%%   <li>`description' — human-readable description.</li>
-%%   <li>`mime_type' — content type (default `<<"text/plain">>').</li>
+%%   <li>`description': human-readable description.</li>
+%%   <li>`mime_type': content type (default `<<"text/plain">>').</li>
 %% </ul>
 -spec reg_resource_template(Name, Module, Function, Opts) -> ok | {error, term()} when
     Name :: binary(),
@@ -902,7 +902,7 @@ notify_log(SessionId, Level, Data) ->
 ) -> ok.
 notify_log(SessionId, Level, Logger, Data) ->
     case barrel_mcp_session:log_level_priority(Level) of
-        %% invalid level — drop
+        %% invalid level, drop
         error ->
             ok;
         EventPrio ->

--- a/src/barrel_mcp_agent.erl
+++ b/src/barrel_mcp_agent.erl
@@ -105,9 +105,9 @@ to_openai(Opts) ->
 %% prefix selects the client and the `ToolName' suffix is forwarded.
 %% Errors:
 %% <ul>
-%%   <li>`{error, no_separator}' — the name does not contain the
+%%   <li>`{error: no_separator}', the name does not contain the
 %%       configured separator.</li>
-%%   <li>`{error, unknown_server}' — no client is registered under
+%%   <li>`{error: unknown_server}', no client is registered under
 %%       the parsed `ServerId'.</li>
 %%   <li>Any error returned by
 %%       {@link barrel_mcp_client:call_tool/4}.</li>

--- a/src/barrel_mcp_auth_apikey.erl
+++ b/src/barrel_mcp_auth_apikey.erl
@@ -169,7 +169,7 @@ hash_key(Key) ->
 %%
 %% `Opts' may include:
 %% <ul>
-%%   <li>`pepper' (binary, required for the new format) — server-side
+%%   <li>`pepper' (binary, required for the new format): server-side
 %%       secret mixed into the HMAC. Stored format becomes
 %%       `hmac-sha256$<base64(hash)>'.</li>
 %% </ul>
@@ -180,7 +180,7 @@ hash_key(Key, _) ->
     legacy_sha256_hex(Key).
 
 %% @doc Constant-time comparison of a presented `Key' against a
-%% `Stored' digest. Accepts only the legacy hex SHA-256 format —
+%% `Stored' digest. Accepts only the legacy hex SHA-256 format,
 %% the modern `hmac-sha256$...' format requires the server-side
 %% pepper, which {@link verify_key/3} takes explicitly. This shim
 %% rejects HMAC-format inputs so callers don't accidentally treat
@@ -202,7 +202,7 @@ verify_key(_Key, _Stored) ->
 %% `hmac-sha256$...' format. The `Pepper' is ignored for legacy
 %% hex SHA-256 digests (they were produced without a pepper). Use
 %% this from any code that owns the pepper (config tooling,
-%% tests) — the auth provider's internal authenticate path goes
+%% tests), the auth provider's internal authenticate path goes
 %% through `verify_against_state/2' which already has the pepper
 %% in state.
 -spec verify_key(

--- a/src/barrel_mcp_auth_basic.erl
+++ b/src/barrel_mcp_auth_basic.erl
@@ -174,9 +174,9 @@ hash_password(Password) ->
 %%
 %% `Opts' may contain:
 %% <ul>
-%%   <li>`algorithm' — `pbkdf2-sha256' (default) or `sha256-hex'
+%%   <li>`algorithm': `pbkdf2-sha256' (default) or `sha256-hex'
 %%       (deprecated; kept for migration only).</li>
-%%   <li>`iterations' — PBKDF2 iteration count (default 100000).</li>
+%%   <li>`iterations': PBKDF2 iteration count (default 100000).</li>
 %% </ul>
 %%
 %% Stored format for the modern hash:

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -7,28 +7,28 @@
 %%%
 %%% States:
 %%% <ul>
-%%%   <li>`connecting'   — transport is opening.</li>
-%%%   <li>`initializing' — `initialize' request in flight.</li>
-%%%   <li>`ready'        — handshake complete; calls accepted.</li>
-%%%   <li>`closing'      — owner asked to close.</li>
+%%%   <li>`connecting': transport is opening.</li>
+%%%   <li>`initializing': `initialize' request in flight.</li>
+%%%   <li>`ready': handshake complete; calls accepted.</li>
+%%%   <li>`closing': owner asked to close.</li>
 %%% </ul>
 %%%
 %%% Inbound JSON-RPC envelopes from the transport are routed by
 %%% `decode_envelope/1':
 %%% <ul>
-%%%   <li>response/error with `id' — match against the pending-request
+%%%   <li>response/error with `id': match against the pending-request
 %%%       table, post the result to the waiting caller.</li>
-%%%   <li>request with `id'        — dispatch to the configured
+%%%   <li>request with `id': dispatch to the configured
 %%%       `barrel_mcp_client_handler' module; reply (sync or async)
 %%%       goes back over the same transport.</li>
-%%%   <li>notification (no `id')   — dispatch to handler; resource
+%%%   <li>notification (no `id'): dispatch to handler; resource
 %%%       update notifications are also routed to subscribers.</li>
 %%% </ul>
 %%%
 %%% Server-side host application code never sees the transport
 %%% layer; it talks to this module via the API below. Whether to bind
 %%% an LLM provider (Anthropic, OpenAI, Hermes-style local model) into
-%%% this loop is the host's job — `barrel_mcp' itself stays a pure
+%%% this loop is the host's job, `barrel_mcp' itself stays a pure
 %%% MCP library.
 %%% @end
 %%%-------------------------------------------------------------------
@@ -231,11 +231,11 @@ list_tools(Pid) ->
 %%
 %% `Opts' may contain:
 %% <ul>
-%%   <li>`{cursor, Cursor}' — start from a previously-returned
+%%   <li>`{cursor: Cursor}', start from a previously-returned
 %%       `nextCursor'.</li>
-%%   <li>`{want_cursor, true}' — return `{ok, Items, NextCursor}' even
+%%   <li>`{want_cursor: true}', return `{ok, Items, NextCursor}' even
 %%       on the last page (with `undefined' for `NextCursor').</li>
-%%   <li>`{timeout, Ms}' — override the per-request timeout.</li>
+%%   <li>`{timeout: Ms}', override the per-request timeout.</li>
 %% </ul>
 -spec list_tools(pid(), map()) ->
     {ok, [map()], NextCursor :: binary() | undefined}
@@ -260,10 +260,10 @@ call_tool(Pid, Name, Args) ->
 %%
 %% `Opts' may contain:
 %% <ul>
-%%   <li>`{progress_token, Token}' — register the calling process to
+%%   <li>`{progress_token: Token}', register the calling process to
 %%       receive `{mcp_progress, Token, Params}' messages until the
 %%       request settles.</li>
-%%   <li>`{timeout, Ms}' — override the per-request timeout
+%%   <li>`{timeout: Ms}', override the per-request timeout
 %%       (`request_timeout' from the connect spec, default 30000).</li>
 %% </ul>
 -spec call_tool(pid(), binary(), map(), map()) -> {ok, map()} | {error, term()}.

--- a/src/barrel_mcp_client_auth.erl
+++ b/src/barrel_mcp_client_auth.erl
@@ -47,15 +47,15 @@
 -optional_callbacks([challenge/2, settled/1, request_headers/3]).
 
 %% Build the auth handle from a config term.
-%%   `none' — no auth header sent.
-%%   `{bearer, Token}' — static bearer token.
-%%   `{oauth, Config}' — OAuth 2.1 + PKCE (authorization_code grant).
-%%   `{oauth_client_credentials, Config}' — OAuth 2.1 client_credentials
+%%   `none': no auth header sent.
+%%   `{bearer: Token}', static bearer token.
+%%   `{oauth: Config}', OAuth 2.1 + PKCE (authorization_code grant).
+%%   `{oauth_client_credentials: Config}', OAuth 2.1 client_credentials
 %%       grant (RFC 6749, plus the MCP `ext-auth' OAuth Client
 %%       Credentials extension). For unattended agent hosts. Config
 %%       requires `token_endpoint' and `client_id'; supply either
 %%       `client_secret' or `client_assertion' (private_key_jwt).
-%%   `{oauth_enterprise, Config}' — Enterprise-Managed Authorization
+%%   `{oauth_enterprise: Config}', Enterprise-Managed Authorization
 %%       (MCP `ext-auth' EMA). Chains an IdP-issued ID Token through
 %%       RFC 8693 token-exchange and RFC 7523 jwt-bearer to mint a
 %%       short-lived MCP access token. For SSO-driven hosts. Config

--- a/src/barrel_mcp_client_auth_oauth.erl
+++ b/src/barrel_mcp_client_auth_oauth.erl
@@ -6,12 +6,12 @@
 %%% the spec</a> and the underlying RFCs:
 %%%
 %%% <ul>
-%%%   <li>RFC 9728 — Protected Resource Metadata (PRM)</li>
-%%%   <li>RFC 8414 — Authorization Server Metadata</li>
-%%%   <li>RFC 7636 — PKCE (S256)</li>
-%%%   <li>RFC 8707 — `resource' indicator on auth + token requests</li>
+%%%   <li>RFC 9728: Protected Resource Metadata (PRM)</li>
+%%%   <li>RFC 8414: Authorization Server Metadata</li>
+%%%   <li>RFC 7636: PKCE (S256)</li>
+%%%   <li>RFC 8707: `resource' indicator on auth + token requests</li>
 %%%   <li>RFC 9207: issuer identification on the authorization response</li>
-%%%   <li>RFC 6749 / OAuth 2.1 — authorization-code + refresh_token grants</li>
+%%%   <li>RFC 6749 / OAuth 2.1: authorization-code + refresh_token grants</li>
 %%%   <li>draft-ietf-oauth-client-id-metadata-document-00: an HTTPS
 %%%       URL as the `client_id'</li>
 %%% </ul>
@@ -156,7 +156,7 @@
     subject_token := binary(),
     %% Spec URN: `id_token' or `saml2'.
     subject_token_type := binary(),
-    %% AS issuer URL — the `aud' the IdP signs into the ID-JAG.
+    %% AS issuer URL: the `aud' the IdP signs into the ID-JAG.
     audience := binary(),
     %% MCP server's RFC 9728 resource identifier.
     resource := binary(),
@@ -806,7 +806,7 @@ refresh_token(TokenEndpoint, Params) ->
     ).
 
 %% @doc Acquire an access token via the OAuth 2.1 client_credentials
-%% grant — for unattended / machine-to-machine flows where there is
+%% grant, for unattended / machine-to-machine flows where there is
 %% no human in the loop. Per the MCP `ext-auth' OAuth Client
 %% Credentials extension, callers may authenticate either with a
 %% `client_secret' (HTTP Basic, per RFC 6749) or a `client_assertion'
@@ -1191,7 +1191,7 @@ cred(Key, Credentials) ->
     end.
 
 %%====================================================================
-%% Internal — refresh wired through the behaviour
+%% Internal: refresh wired through the behaviour
 %%====================================================================
 
 do_refresh(

--- a/src/barrel_mcp_client_handler.erl
+++ b/src/barrel_mcp_client_handler.erl
@@ -7,11 +7,11 @@
 %%%
 %%% Capabilities and the matching callbacks:
 %%% <ul>
-%%%   <li>`sampling' — server may call `sampling/createMessage' to ask
+%%%   <li>`sampling': server may call `sampling/createMessage' to ask
 %%%       the host to run an LLM completion.</li>
-%%%   <li>`roots'    — server may call `roots/list' to enumerate the
+%%%   <li>`roots': server may call `roots/list' to enumerate the
 %%%       filesystem boundaries the host exposes.</li>
-%%%   <li>`elicitation' — server may call `elicitation/create' to
+%%%   <li>`elicitation': server may call `elicitation/create' to
 %%%       prompt the user for a value.</li>
 %%% </ul>
 %%%

--- a/src/barrel_mcp_client_stdio.erl
+++ b/src/barrel_mcp_client_stdio.erl
@@ -91,7 +91,7 @@ handle_cast(close, State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
-%% A complete line — emit it.
+%% A complete line, emit it.
 handle_info(
     {Port, {data, {eol, Line}}},
     #state{port = Port, owner = Owner, buffer = Buf} = State
@@ -99,7 +99,7 @@ handle_info(
     Full = <<Buf/binary, Line/binary>>,
     Owner ! {mcp_in, self(), Full},
     {noreply, State#state{buffer = <<>>}};
-%% A partial line — buffer it until the eol arrives.
+%% A partial line, buffer it until the eol arrives.
 handle_info(
     {Port, {data, {noeol, Chunk}}},
     #state{port = Port, buffer = Buf} = State

--- a/src/barrel_mcp_client_transport.erl
+++ b/src/barrel_mcp_client_transport.erl
@@ -7,9 +7,9 @@
 %%% this behaviour and consumes asynchronous messages of the form:
 %%%
 %%% <ul>
-%%%   <li>`{mcp_in, TransportPid, JsonBinary}' — one decoded JSON-RPC
+%%%   <li>`{mcp_in: TransportPid, JsonBinary}', one decoded JSON-RPC
 %%%       envelope arrived from the peer.</li>
-%%%   <li>`{mcp_closed, TransportPid, Reason}' — the transport ended
+%%%   <li>`{mcp_closed: TransportPid, Reason}', the transport ended
 %%%       (peer hung up, port exited, etc.).</li>
 %%% </ul>
 %%%

--- a/src/barrel_mcp_http_engine.erl
+++ b/src/barrel_mcp_http_engine.erl
@@ -13,14 +13,14 @@
 %%% or an external adapter such as Livery's) reads the request line
 %%% and body, then calls {@link handle/6} with:
 %%% <ul>
-%%%   <li>`Method' — the request method binary (`<<"POST">>' …).</li>
-%%%   <li>`Path' — the request target (query string allowed; it is
+%%%   <li>`Method': the request method binary (`<<"POST">>' …).</li>
+%%%   <li>`Path': the request target (query string allowed; it is
 %%%       stripped here).</li>
-%%%   <li>`Headers' — a `[{binary(), binary()}]' proplist.
+%%%   <li>`Headers': a `[{binary(), binary()}]' proplist.
 %%%       Lookups are case-insensitive.</li>
-%%%   <li>`Body' — the full request body (`<<>>' when none).</li>
-%%%   <li>`Responder' — a map of I/O closures (see below).</li>
-%%%   <li>`Config' — the engine configuration (see the `config()' type).</li>
+%%%   <li>`Body': the full request body (`<<>>' when none).</li>
+%%%   <li>`Responder': a map of I/O closures (see below).</li>
+%%%   <li>`Config': the engine configuration (see the `config()' type).</li>
 %%% </ul>
 %%%
 %%% The `Responder' abstracts response delivery so the engine never
@@ -247,7 +247,7 @@ reply_json(Headers, Responder, Config, Status, Envelope) ->
     ).
 
 %%====================================================================
-%% Streamable transport — POST
+%% Streamable transport: POST
 %%====================================================================
 
 stream_post(Headers, Body, Responder, Config) ->
@@ -1589,7 +1589,7 @@ maybe_capture_initialize_version(_, _, _) ->
     ok.
 
 %%====================================================================
-%% Streamable transport — GET (long-lived SSE) and DELETE
+%% Streamable transport: GET (long-lived SSE) and DELETE
 %%====================================================================
 
 stream_get_sse(Headers, Responder, Config) ->

--- a/src/barrel_mcp_http_listener.erl
+++ b/src/barrel_mcp_http_listener.erl
@@ -6,7 +6,7 @@
 %%% A small acceptor pool on a single port, built on the `h1' and
 %%% `h2' protocol libraries (no cowboy). Cleartext binds speak
 %%% HTTP/1.1; TLS binds advertise ALPN `[h2, http/1.1]' and dispatch
-%%% each connection to the negotiated protocol — so one URL serves
+%%% each connection to the negotiated protocol, so one URL serves
 %%% both, like the cowboy listener it replaces.
 %%%
 %%% Per accepted connection a process owns the socket, performs the
@@ -38,8 +38,8 @@
 %% Default cap on concurrently-established connections per listener.
 %% `idle_timeout' is `infinity' (so long-lived SSE GETs are never
 %% reaped), which means a connection lives until the peer closes it.
-%% Without a cap a flood of connections — or slow/idle keep-alive
-%% clients — could exhaust file descriptors and memory. Override with
+%% Without a cap a flood of connections (or slow/idle keep-alive
+%% clients) could exhaust file descriptors and memory. Override with
 %% the `max_connections' listen option.
 -define(DEFAULT_MAX_CONNECTIONS, 16384).
 

--- a/src/barrel_mcp_http_stream.erl
+++ b/src/barrel_mcp_http_stream.erl
@@ -42,16 +42,16 @@
 %% == Options ==
 %%
 %% <ul>
-%%   <li>`port' — TCP port (default 9090).</li>
-%%   <li>`ip' — bind address (default `{127,0,0,1}').</li>
-%%   <li>`auth' — authentication provider config.</li>
-%%   <li>`session_enabled' — `true' (default) to use
+%%   <li>`port': TCP port (default 9090).</li>
+%%   <li>`ip': bind address (default `{127,0,0,1}').</li>
+%%   <li>`auth': authentication provider config.</li>
+%%   <li>`session_enabled': `true' (default) to use
 %%       `Mcp-Session-Id' sessions.</li>
-%%   <li>`ssl' — TLS options (`certfile', `keyfile',
+%%   <li>`ssl': TLS options (`certfile', `keyfile',
 %%       optional `cacertfile'). A TLS bind serves HTTP/1.1 and
 %%       HTTP/2 on the same port via ALPN.</li>
-%%   <li>`allowed_origins' — `[binary()] | any'.</li>
-%%   <li>`allow_missing_origin' — accept requests with no `Origin'
+%%   <li>`allowed_origins': `[binary()] | any'.</li>
+%%   <li>`allow_missing_origin': accept requests with no `Origin'
 %%       header. Defaults to `true' on loopback, `false' otherwise.</li>
 %%   <li>`subscription_keepalive_ms': how often a quiet
 %%       `subscriptions/listen' stream emits an SSE comment so

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -135,12 +135,12 @@ handle(Request) ->
 %%
 %% Returns one of:
 %% <ul>
-%%   <li>`map()' — a JSON-RPC response envelope ready to encode.</li>
+%%   <li>`map()': a JSON-RPC response envelope ready to encode.</li>
 %%   <li>`[map()]': one envelope per request element of a batch, on
 %%       the revisions that accept batches.</li>
 %%   <li>`no_response': for inbound notifications, and for a batch of
 %%       nothing but notifications and responses.</li>
-%%   <li>`{async, AsyncPlan}' — for `tools/call'. The transport
+%%   <li>`{async: AsyncPlan}', for `tools/call'. The transport
 %%       spawns the worker via `(maps:get(spawn, AsyncPlan))(Ctx)'
 %%       and waits on its mailbox for a `tool_result' / `tool_error' /
 %%       `tool_failed' / `tool_validation_failed' / `cancelled'
@@ -1715,7 +1715,7 @@ handle_request(<<"logging/setLevel">>, Params, Id, Ctx) ->
                 <<"Missing required parameter: level">>
             );
         {_, undefined} ->
-            %% Stdio / no session — accept but no per-session storage.
+            %% Stdio / no session, accept but no per-session storage.
             case barrel_mcp_session:log_level_priority(Level) of
                 error ->
                     error_response(

--- a/src/barrel_mcp_registry.erl
+++ b/src/barrel_mcp_registry.erl
@@ -292,8 +292,8 @@ run_completion(Key, Value, Ctx) ->
 
 %% @doc Execute a tool handler asynchronously. Spawns a worker that
 %% calls `Mod:Fun(Args, Ctx)' (when arity 2 is exported) or
-%% `Mod:Fun(Args)' otherwise. `Ctx' carries `tool_name' — the name the
-%% tool was invoked under — so one handler can serve many registered
+%% `Mod:Fun(Args)' otherwise. `Ctx' carries `tool_name', the name the
+%% tool was invoked under, so one handler can serve many registered
 %% tools (as an MCP gateway does). The worker reports back to
 %% `maps:get(reply_to, Ctx)' as either:
 %% <ul>

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -575,7 +575,7 @@ events_since(SessionId, LastId) ->
 collect_after(Buf, LastId) ->
     case lists:splitwith(fun({Id, _}) -> Id =/= LastId end, Buf) of
         {_, []} ->
-            %% LastId not found — buffer rolled over.
+            %% LastId not found, buffer rolled over.
             truncated;
         {Newer, [_ | _]} ->
             {ok, lists:reverse(Newer)}

--- a/src/barrel_mcp_tasks.erl
+++ b/src/barrel_mcp_tasks.erl
@@ -739,7 +739,7 @@ transition(SessionId, TaskId, Status, Result, Reason) ->
             notify_changed(SessionId, Updated),
             ok;
         {ok, _Terminal} ->
-            %% Already terminal — idempotent.
+            %% Already terminal, idempotent.
             ok;
         {error, not_found} ->
             {error, not_found}

--- a/src/barrel_mcp_uri_template.erl
+++ b/src/barrel_mcp_uri_template.erl
@@ -3,7 +3,7 @@
 %%%
 %%% Used by the server's `resources/read' handler to route a
 %%% concrete URI to a registered `resource_template'. We only
-%%% implement Level 1 (`{var}' simple expansion) — that covers
+%%% implement Level 1 (`{var}' simple expansion), that covers
 %%% every template the spec's reference examples use, and it's
 %%% the level the MCP server registry actually accepts.
 %%%
@@ -57,7 +57,7 @@ expand(Template, Vars) when is_binary(Template), is_map(Vars) ->
     end.
 
 %%====================================================================
-%% Internal — template parser
+%% Internal: template parser
 %%====================================================================
 
 %% Parse a template into a list of `{literal, Bin} | {var, Name}'
@@ -85,7 +85,7 @@ template_for_error(Acc, Rest) ->
     <<Acc/binary, Rest/binary>>.
 
 %%====================================================================
-%% Internal — match
+%% Internal: match
 %%====================================================================
 
 do_match(<<>>, [], Vars) ->
@@ -98,7 +98,7 @@ do_match(Uri, [{literal, Lit} | Rest], Vars) ->
         false -> nomatch
     end;
 do_match(Uri, [{var, Name}], Vars) ->
-    %% Trailing variable — consume the rest. Empty value is
+    %% Trailing variable, consume the rest. Empty value is
     %% allowed only if the template clearly expected an empty
     %% suffix; here we require at least one character.
     case Uri of
@@ -119,7 +119,7 @@ do_match(Uri, [{var, Name}, {literal, NextLit} | Rest], Vars) ->
             nomatch
     end;
 do_match(Uri, [{var, Name1}, {var, Name2} | Rest], Vars) ->
-    %% Two variables in a row with no literal between them —
+    %% Two variables in a row with no literal between them,
     %% ambiguous. RFC 6570 doesn't require us to support this; we
     %% treat the first as everything up to the last separator and
     %% the second as the remainder, but most MCP templates avoid
@@ -149,7 +149,7 @@ starts_with(Bin, Prefix) ->
     end.
 
 %%====================================================================
-%% Internal — expand
+%% Internal: expand
 %%====================================================================
 
 do_expand([], _Vars, Acc) ->

--- a/test/barrel_mcp_agent_SUITE.erl
+++ b/test/barrel_mcp_agent_SUITE.erl
@@ -66,7 +66,7 @@ aggregates_and_routes(_Config) ->
     ok = wait_ready(Beta, 30),
 
     %% Both clients see the same registry, so the aggregator should
-    %% surface the `echo' tool twice — once per ServerId.
+    %% surface the `echo' tool twice, once per ServerId.
     Tools = barrel_mcp_agent:list_tools(),
     Names = [maps:get(<<"name">>, T) || T <- Tools],
     ?assert(lists:member(<<"alpha:echo">>, Names)),

--- a/test/barrel_mcp_auth_hash_tests.erl
+++ b/test/barrel_mcp_auth_hash_tests.erl
@@ -10,7 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 %%====================================================================
-%% basic auth — pbkdf2-sha256
+%% basic auth: pbkdf2-sha256
 %%====================================================================
 
 basic_default_uses_pbkdf2_test() ->
@@ -56,7 +56,7 @@ basic_iterations_are_overridable_test() ->
     ?assertEqual(ok, barrel_mcp_auth_basic:verify_password(<<"x">>, H)).
 
 %%====================================================================
-%% apikey auth — hmac-sha256
+%% apikey auth: hmac-sha256
 %%====================================================================
 
 apikey_legacy_default_test() ->

--- a/test/barrel_mcp_client_auth_oauth_tests.erl
+++ b/test/barrel_mcp_client_auth_oauth_tests.erl
@@ -374,7 +374,7 @@ test_client_credentials_jwt() ->
 
 test_client_credentials_refresh() ->
     %% A 401 in client_credentials mode should re-acquire via the
-    %% same grant — no refresh_token involved.
+    %% same grant, no refresh_token involved.
     Auth = barrel_mcp_client_auth:new(
         {oauth_client_credentials, #{
             allow_insecure_oauth => true,
@@ -481,7 +481,7 @@ test_enterprise_managed_refresh() ->
     ).
 
 test_enterprise_managed_subject_token_expired() ->
-    %% IdP returns invalid_grant — caller learns the typed
+    %% IdP returns invalid_grant, caller learns the typed
     %% subject_token_expired result so it can re-acquire the ID
     %% Token from the IdP.
     Result = barrel_mcp_client_auth:new(

--- a/test/barrel_mcp_client_progress_tests.erl
+++ b/test/barrel_mcp_client_progress_tests.erl
@@ -97,7 +97,7 @@ start_client(Extras) ->
     wait_ready(Pid, 30),
     {ok, Pid}.
 
-%% slow tool handler — gives the test time to inspect the progress
+%% slow tool handler, gives the test time to inspect the progress
 %% map before the response settles.
 slow_handler(_Args) ->
     timer:sleep(200),

--- a/test/barrel_mcp_http_stream_security_SUITE.erl
+++ b/test/barrel_mcp_http_stream_security_SUITE.erl
@@ -639,7 +639,7 @@ bearer_challenge_includes_resource_metadata(Config) ->
 %%====================================================================
 
 %% A GET (open SSE) with no credentials must be rejected by the auth
-%% provider before any session is touched — the session id is not a
+%% provider before any session is touched, the session id is not a
 %% credential. Regression for the GET/DELETE auth-bypass.
 get_sse_requires_auth(Config) ->
     Port = ?config(port, Config),

--- a/test/barrel_mcp_http_stream_tests.erl
+++ b/test/barrel_mcp_http_stream_tests.erl
@@ -74,7 +74,7 @@ test_start_stop() ->
     ok = barrel_mcp:stop_http_stream().
 
 test_post_json() ->
-    %% Sessions disabled — `ping' goes through without one.
+    %% Sessions disabled, `ping' goes through without one.
     {ok, _} = barrel_mcp:start_http_stream(#{
         port => 19091,
         session_enabled => false

--- a/test/barrel_mcp_oauth_enterprise_SUITE.erl
+++ b/test/barrel_mcp_oauth_enterprise_SUITE.erl
@@ -187,7 +187,7 @@ expired_subject_token_blocks_init(_Config) ->
                 resource => McpUrl
             }}
     },
-    %% `start/1' returns asynchronously — the gen_statem accepts
+    %% `start/1' returns asynchronously, the gen_statem accepts
     %% the spec, then fails during the connecting state when the
     %% auth handle init walks the EMA chain. Monitor the pid and
     %% wait for the EXIT.

--- a/test/barrel_mcp_pagination_tests.erl
+++ b/test/barrel_mcp_pagination_tests.erl
@@ -39,6 +39,6 @@ error_propagates_test() ->
     ?assertEqual({error, boom}, barrel_mcp_pagination:walk(Fetch)).
 
 max_pages_guard_test() ->
-    %% Always returns a cursor — would loop forever without the cap.
+    %% Always returns a cursor, would loop forever without the cap.
     Fetch = fun(_) -> {ok, [x], <<"more">>} end,
     ?assertEqual({error, max_pages}, barrel_mcp_pagination:walk(Fetch, 3)).

--- a/test/barrel_mcp_python_interop_SUITE.erl
+++ b/test/barrel_mcp_python_interop_SUITE.erl
@@ -117,7 +117,7 @@ init_per_testcase(_TC, Config) -> Config.
 end_per_testcase(_TC, _Config) -> ok.
 
 %%====================================================================
-%% Direction A — Python client → Erlang server
+%% Direction A: Python client → Erlang server
 %%====================================================================
 
 python_client_against_erlang_server(Config) ->
@@ -163,7 +163,7 @@ legacy_direction_a(Python, Flags) ->
     ok.
 
 %%====================================================================
-%% Direction B — Erlang client → Python server
+%% Direction B: Erlang client → Python server
 %%====================================================================
 
 erlang_client_against_python_server(Config) ->

--- a/test/barrel_mcp_spec_additives_SUITE.erl
+++ b/test/barrel_mcp_spec_additives_SUITE.erl
@@ -335,7 +335,7 @@ long_running_returns_taskid(Config) ->
     ),
     ResultPayload = maps:get(<<"result">>, json:decode(ResultResp)),
     %% The long_tool returned <<"done">>; the result map is whatever
-    %% the registry stored — it may be wrapped further by the
+    %% the registry stored, it may be wrapped further by the
     %% collector. Just assert we got a non-error response.
     ?assert(is_map(ResultPayload) orelse is_binary(ResultPayload)),
     ok = barrel_mcp_registry:unreg(tool, <<"long">>),
@@ -348,7 +348,7 @@ long_running_cancel_signals_worker(Config) ->
         session_enabled => true
     }),
     Self = self(),
-    %% The cooperative tool reads `cancel_observer' from Ctx — but
+    %% The cooperative tool reads `cancel_observer' from Ctx, but
     %% the runtime fills Ctx, not the test. Use a small registered
     %% process that the tool message-passes to after observing the
     %% cancel: we stash Self in a process_dict-style fallback by
@@ -379,7 +379,7 @@ long_running_cancel_signals_worker(Config) ->
     ),
     Result = maps:get(<<"result">>, envelope_of(RB)),
     TaskId = maps:get(<<"taskId">>, maps:get(<<"task">>, Result)),
-    %% Cancel the task — the worker should receive a `{cancel, _}'
+    %% Cancel the task, the worker should receive a `{cancel, _}'
     %% signal in its mailbox (cooperatively observed by our tool).
     {ok, 200, _, _} = hackney:request(
         post,
@@ -398,7 +398,7 @@ long_running_cancel_signals_worker(Config) ->
         [with_body]
     ),
     %% The tool sends us `{observed_cancel, _}' from inside the
-    %% worker — but only if the runtime delivered the cancel. We
+    %% worker, but only if the runtime delivered the cancel. We
     %% can't assert that path without a registered observer hook;
     %% instead, poll the task store until the status is
     %% `cancelled', proving the wire path completed.
@@ -441,7 +441,7 @@ sse_replay_after_reconnect(_Config) ->
      || N <- lists:seq(1, 3)
     ],
 
-    %% Replay events newer than "1" — expect [2, 3] in order.
+    %% Replay events newer than "1", expect [2, 3] in order.
     {ok, Events} = barrel_mcp_session:events_since(SessionId, <<"1">>),
     ?assertEqual(
         [

--- a/test/barrel_mcp_test_http.erl
+++ b/test/barrel_mcp_test_http.erl
@@ -30,7 +30,7 @@
 %% @doc Start a mock server registered as `Name' on `Port'.
 %%
 %% h1 links the listener to whoever calls `h1:start_server', so a
-%% long-lived owner process (registered as `Name') holds it open —
+%% long-lived owner process (registered as `Name') holds it open,
 %% otherwise it would die with the transient caller (e.g. a CT
 %% `init_per_suite' process).
 start(Name, Port, Handler) when is_function(Handler, 1) ->

--- a/test/interop/server.py
+++ b/test/interop/server.py
@@ -1,4 +1,4 @@
-"""Direction B — Python FastMCP server over stdio.
+"""Direction B: Python FastMCP server over stdio.
 
 Spawned by `barrel_mcp_python_interop_SUITE:erlang_client_against_python_server/1`.
 Exposes a tool, a resource, and a prompt so the Erlang client can

--- a/test/snippet_check.escript
+++ b/test/snippet_check.escript
@@ -1,7 +1,7 @@
 #!/usr/bin/env escript
 %%! -noshell
 %%
-%% snippet_check — extract every ```erlang fenced block from the
+%% snippet_check: extract every ```erlang fenced block from the
 %% project's documentation and verify each compiles.
 %%
 %% Usage:
@@ -9,7 +9,7 @@
 %%
 %% Conventions:
 %%   - Fences with info string `erlang' are compiled.
-%%   - Fences with info string `erl' (or any other) are skipped — use
+%%   - Fences with info string `erl' (or any other) are skipped, use
 %%     them for illustrative output, REPL transcripts, or fragments
 %%     that aren't expected to compile in isolation.
 %%   - A snippet that starts with `-module(' is treated as a complete
@@ -47,7 +47,7 @@ main(_) ->
 %%====================================================================
 
 %% New, snippet-tested docs only. Older guides (client.md, http-stream.md,
-%% etc.) remain illustrative — port them over when their snippets are
+%% etc.) remain illustrative, port them over when their snippets are
 %% rewritten to compile standalone.
 collect_doc_files() ->
     Globs = ["guides/building-a-client.md",


### PR DESCRIPTION
Comment and documentation text only: the label form (`x` - description) becomes a colon, mid-sentence dashes become a comma or parentheses. The vendored spec schema and the upstream runner patch keep their own text. Based on #64 so it merges without conflicts; retarget to main after #64 lands.