### PR TITLE
Document the server so a human can modify it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `guides/server-internals.md` (supervision tree, process model,
+  request lifecycle per verb, tool-call modes, session fields, tables)
+  and `guides/glossary.md`. The protocol-versions guide lists every
+  era branch site, the authentication guide has a Principals section,
+  and the ten largest modules open with a section index, their
+  process model and their state record.
 - Tools declare `task_support => forbidden | optional | required`
   (`long_running => true` still means `optional`), listed as
   `execution.taskSupport` in the modern era. A `required` tool refuses

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Track `main` instead of pinning a tag for the latest fixes:
 
 ## Architecture
 
+The process tree, the request lifecycle per transport and the
+tool-call modes are in [Server Internals](guides/server-internals.md);
+the client side is in [Client Internals](guides/internals.md), and
+the vocabulary both use is in the [Glossary](guides/glossary.md).
+
 barrel_mcp uses a supervised gen_statem process to manage the handler registry:
 
 - **Writes** (reg/unreg) go through the gen_statem for atomic operations

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -874,6 +874,44 @@ This stays a standalone exchanger, the library doesn't persist
 the issued credentials. That's a host concern (file, DB, secret
 manager).
 
+## Principals
+
+A principal is who a request is from, as the auth provider states
+it. You need this section when you write a provider, or when you
+change anything that is owned per client: sessions, tasks,
+elicitations.
+
+Derivation: after a provider's `authenticate/2` succeeds,
+`barrel_mcp_auth:with_principal/3` asks the provider for the identity
+through its optional `principal/2` callback, and falls back to
+`barrel_mcp_auth:principal/2`, which derives it from the auth info
+map. The result is stored as `principal` in the auth info every
+handler sees under `_auth`. `barrel_mcp_auth_none` yields
+`anonymous`; every anonymous request is the same principal.
+
+Where it is enforced:
+
+- **Sessions**: a Streamable HTTP session is bound to the principal
+  that initialized it (`barrel_mcp_http_engine:lookup_session/5`),
+  and every later POST, GET, DELETE and replay checks it
+  (`owned_session/2`). The 2024-11-05 pair binds its endpoint the
+  same way (`legacy_sse_open/3`, `legacy_session_of/2`). Another
+  principal holding the id gets the unknown-session 404, so the id
+  is neither an oracle nor a capability on its own.
+- **Server-to-client responses**: a response to `sampling/createMessage`,
+  `elicitation/create` or `roots/list` is delivered only from the
+  session that carried the request
+  (`barrel_mcp_session:deliver_response/3`).
+- **Tasks**: a modern task belongs to its principal, a legacy one to
+  its session (`barrel_mcp_protocol:task_owner/1`); `tasks/get`,
+  `tasks/cancel` and `tasks/result` look up by owner.
+- **Elicitations**: URL-mode elicitation records carry the principal
+  and the session (`barrel_mcp_elicitation`).
+
+If your provider can name a stable identity (a subject claim, a key
+id), return it from `principal/2`; the default derivation is only as
+good as the auth info map it reads.
+
 ## Security Best Practices
 
 1. **Always use TLS** in production

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -129,4 +129,6 @@ For Claude Desktop integration, use the stdio transport:
 - [Features matrix](features.md): what's supported on the wire.
 - [Building a client](building-a-client.md): task-oriented walkthrough for hosting MCP clients.
 - [Client internals](internals.md): architecture and behaviour contracts.
+- [Server internals](server-internals.md): processes, request lifecycle, tool-call modes, sessions; read before changing `src/`.
+- [Glossary](glossary.md): the terms the code and the guides use.
 - [MCP Client (reference)](client.md) - Older API reference, kept for cross-linking

--- a/guides/glossary.md
+++ b/guides/glossary.md
@@ -1,0 +1,129 @@
+# Glossary
+
+The words the code and the other guides use with a fixed meaning.
+Read this when a term in a module header or a comment is unfamiliar;
+each entry names the module that owns the concept, so you can go
+from the word to the code.
+
+- **AS (authorization server)**: the OAuth server that issues tokens
+  for an MCP server. Found from the PRM, validated by
+  `barrel_mcp_client_auth_oauth:discover_authorization_server/2`.
+- **Challenge**: a 401 or 403 the client transport hands to its auth
+  handle (`barrel_mcp_client_auth:challenge/2`) as a map with
+  `status`, `www_authenticate`, `server_url`, `protocol_version` and
+  `dpop_nonce`. The handle answers with a new token or refuses.
+- **Channel**: the process a server-to-client request is written to.
+  For a session it is the `sse_pid` (`barrel_mcp_session:channel/2`);
+  for a request answered on its own response stream it is the
+  request process.
+- **CIMD (Client ID Metadata Document)**: an HTTPS URL used as the
+  OAuth `client_id`, the document at that URL being the client's
+  metadata. One of the three registration mechanisms in
+  `barrel_mcp_client_auth_oauth`, with DCR and pre-registration.
+- **Collector**: the process that owns a task's outcome once the
+  request process has answered with a task handle. Spawned by
+  `barrel_mcp_protocol:spawn_task_collector/3`, it monitors the
+  worker and writes `finish`, `fail` or `cancel` into
+  `barrel_mcp_tasks`.
+- **DCR (Dynamic Client Registration)**: RFC 7591 registration at
+  the AS, done by the OAuth handle when it has no client id and the
+  AS advertises a registration endpoint.
+- **DPoP**: RFC 9449 proof-of-possession. With `dpop => true` the
+  OAuth handle signs a proof JWT for every token request and every
+  MCP request, and sends `Authorization: DPoP <token>` once the AS
+  issued a DPoP-bound token.
+- **EMA (Enterprise-Managed Authorization)**: the token-exchange chain
+  where an identity provider's token is exchanged (RFC 8693) for an
+  assertion the AS accepts (RFC 7523). `{oauth_enterprise, Config}`.
+- **Envelope**: one JSON-RPC 2.0 message as a map: a request, a
+  response or a notification. `barrel_mcp_protocol` encodes and
+  decodes envelopes; nothing else touches the wire shape.
+- **Era**: which of the two protocol families a request belongs to.
+  The **modern** era (2026-07-28 and later) is stateless: each
+  request carries its version, capabilities and identity in `_meta`.
+  The **legacy** or **handshake** era (2025-11-25 and earlier)
+  establishes those with `initialize`. Defined by
+  `barrel_mcp_version:era/1`, decided per request by
+  `barrel_mcp_ctx:from_request/2`. See
+  [Protocol Versions](protocol-versions.md).
+- **Escalate**: what a modern tool call does when the tool has not
+  answered inside the inline window: the request process creates a
+  task, hands the worker to a collector and answers with the task
+  handle (`barrel_mcp_task_relay:escalate/6`).
+- **Federation**: several clients, one per remote server, under
+  `barrel_mcp_client_sup`, addressed by server id through
+  `barrel_mcp_clients`.
+- **Handle (auth)**: the client-side auth state,
+  `barrel_mcp_client_auth:t()`, wrapping a provider module
+  (`barrel_mcp_client_auth_bearer`, `barrel_mcp_client_auth_oauth`)
+  and its opaque state. Threaded through the transport, which calls
+  it for headers, challenges and settlement.
+- **Inline window**: how long a modern tool call waits for its
+  worker before escalating to a task. `task_inline_ms` in the
+  `barrel_mcp` application environment, default 100 ms
+  (`barrel_mcp_task_relay:inline_ms/0`).
+- **`input_required`**: the state of a task, or the `resultType` of
+  a synchronous answer, when the tool asked the client a question
+  and waits for the answer (`barrel_mcp_tasks:await_input/5`). See
+  MRTR.
+- **`Last-Event-ID`**: the header a client sends when it reopens an
+  SSE stream, naming the last event it saw. The engine replays newer
+  events from the session's replay buffer.
+- **`_meta`**: the per-envelope metadata map. In the modern era it
+  carries the protocol version, the client capabilities and the
+  request identity; in both eras it carries progress tokens, task
+  ids and subscription ids. Keys are `?MCP_META_*` in
+  `include/barrel_mcp.hrl`.
+- **MRTR (multi round-trip request)**: a request whose answer is a
+  question back to the client (`resultType: "input_required"`) that
+  the client repeats with the answer and the server's opaque
+  `request_state`. The state is sealed by `barrel_mcp_request_state`
+  so the server keeps nothing between rounds.
+- **Plan**: what `barrel_mcp_protocol:handle/2` returns for a tool
+  call, `{async, Plan}`: a map with the `spawn` closure that starts
+  the worker, the request id, the timeout and the context. The
+  transport drives it (`drive_async_plan/4` or the engine's own
+  path) because only the transport knows how the answer is written.
+- **Principal**: who a request is from, as the auth provider states
+  it (`barrel_mcp_auth:principal/2`, `anonymous` under
+  `barrel_mcp_auth_none`). Sessions, tasks and elicitations are owned
+  by a principal. See [Authentication](authentication.md).
+- **PRM (Protected Resource Metadata)**: RFC 9728, the document an
+  MCP server publishes at `/.well-known/oauth-protected-resource`
+  naming its authorization servers and scopes. Served by the engine
+  from the `resource_metadata` option; fetched by the OAuth handle
+  from a 401.
+- **Relay**: the process a modern tool worker reports to while the
+  request process decides between an inline answer and a task. It
+  forwards to whichever process owns the outcome, and is redirected
+  to the collector on escalation (`barrel_mcp_task_relay`).
+- **Replay buffer**: the last `sse_buffer_max` events (default 256)
+  a session's stream sent, kept in `#mcp_session.sse_buffer` for
+  `Last-Event-ID`.
+- **Request state**: the opaque, HMAC-sealed blob an MRTR carries
+  between rounds (`barrel_mcp_request_state`).
+- **Session**: the legacy-era state a client establishes with
+  `initialize`: version, capabilities, principal, the SSE channel,
+  the replay buffer, pending server-to-client requests, in-flight
+  workers. One `#mcp_session{}` row in `barrel_mcp_session`,
+  identified by `Mcp-Session-Id`. Modern requests have none.
+- **Settled**: the auth handle callback the transport invokes when a
+  request the handle authorized got a 2xx
+  (`barrel_mcp_client_auth:settled/1`), so a handle can commit a new
+  token.
+- **Shell**: the one-child supervisor around each client in the
+  federation (`barrel_mcp_client_shell`). It carries the client's
+  restart budget so one failing server cannot exhaust the others.
+- **Task**: a tool call that outlives its request. Created in
+  `barrel_mcp_tasks`, polled with `tasks/get`, cancelled with
+  `tasks/cancel`. Legacy clients read the result with `tasks/result`;
+  modern ones get it inlined in `tasks/get`.
+- **`taskSupport`**: what a tool declares about tasks: `forbidden`
+  (default), `optional` or `required`. Set with the `task_support`
+  option at registration, read by `barrel_mcp_registry:task_support/1`,
+  advertised on `tools/list` in the modern era.
+- **Worker**: the process running a tool handler. Spawned by
+  `barrel_mcp_registry:run_tool/3` with a `reply_to` in its context,
+  it sends one `{tool_result, ...}`, `{tool_error, ...}`,
+  `{tool_failed, ...}` or `{tool_input_required, ...}` message and
+  ends.

--- a/guides/protocol-versions.md
+++ b/guides/protocol-versions.md
@@ -170,6 +170,52 @@ retry. See the [Features guide](features.md) for the full shape.
 `-32020` through `-32099` are reserved for the specification. Do not emit a code
 in that range that the spec does not define.
 
+## Where the era is decided
+
+Read this before adding a revision or changing what one era serves.
+The era is one function and one classification, but it is consulted
+in many places; this is the list to walk.
+
+Definition: `barrel_mcp_version:era/1` maps a revision to `modern` or
+`legacy` from `?MCP_MODERN_VERSIONS` and `?MCP_LEGACY_VERSIONS` in
+`include/barrel_mcp.hrl`. Adding a revision starts there.
+
+Classification: `barrel_mcp_ctx:from_request/2` builds the request
+context and decides the era once, from the body's `_meta` and the
+transport's version (`classify/3`, `version_of/3`,
+`capabilities_of/3`). Everything downstream reads
+`barrel_mcp_ctx:era/1` or `barrel_mcp_ctx:is_modern/1`; nothing
+re-derives it.
+
+The fork per transport:
+
+- Streamable HTTP: `barrel_mcp_http_engine:stream_post_request/6`,
+  after decode and before any session lookup, so a modern request
+  never touches the session machinery.
+- The 2024-11-05 pair: always legacy
+  (`legacy_transport_version/2`).
+- stdio: `barrel_mcp_stdio:bind_session/2` attaches the SSE channel
+  to the session for the legacy era only.
+- Client: `barrel_mcp_client` chooses between `server/discover` and
+  `initialize` from the requested version.
+
+Branch sites, by module. Each one behaves differently per era and
+needs a look when an era's rules change:
+
+| module | functions |
+| --- | --- |
+| `barrel_mcp_protocol` | `serves/2` and `serves_in_era/2` (which methods exist), `advertised_versions/0`, `check_version/1`, `resource_not_found_code/1`, `internal_error_code/1`, `with_cache_hints/3`, `finalize/2`, `seal_input_required/6`, `with_tasks_extension/3`, `task_owner/1`, `tasks_enabled/1`, `create_task_result/3`, `cancel_task_response/4`, `with_execution/3`, `drive_async_plan/4`, `read_task_for/3`, the `tasks/get` handler |
+| `barrel_mcp_http_engine` | `stream_post_request/6`, `handle_async_tool_call/7` (the `escalate` mode), `streams_notifications/4`, `cancels_on_disconnect/1`, `request_log_level/1`, `internal_error_code/1`, `start_task_worker/3` |
+| `barrel_mcp_tasks` | `get/2` (defaults to legacy), the `ttl` versus `ttlMs` rendering, `task_to_map` |
+| `barrel_mcp_task_relay` | `escalate/6` renders the task for the caller's era |
+| `barrel_mcp_elicitation` | `with_elicitation_id/3` (modern only) |
+| `barrel_mcp_ctx` | `classify/3`, `validate/1`, `validate_version/1` |
+
+The tests that pin the split: `test/barrel_mcp_dual_era_SUITE.erl`
+(both eras on one listener), `test/barrel_mcp_protocol_tests.erl`
+(initialize per legacy revision), and the conformance runner at each
+revision (`test/barrel_mcp_conformance_SUITE.erl`).
+
 ## Notes
 
 - Nothing was removed in 3.0. Every legacy path still works, and a 2.3.0

--- a/guides/server-internals.md
+++ b/guides/server-internals.md
@@ -1,0 +1,356 @@
+# Server Internals
+
+How the server side of `barrel_mcp` is put together: which process
+runs what, how a request travels from the socket to a tool handler
+and back, and where the decisions that span several modules are
+made. Read this before changing anything under `src/` on the server
+side; the usage guides tell you how to call the library, this one
+tells you how to modify it. The client side has its own page,
+[Client Internals](internals.md), and the words used here are
+defined in the [Glossary](glossary.md).
+
+## 1. Module map
+
+```erl
+barrel_mcp                      public facade: register, start, stop
+  |- barrel_mcp_registry        tools / resources / prompts, tool workers
+  |- barrel_mcp_http_stream     Streamable HTTP listener config
+  |- barrel_mcp_http            simple HTTP (POST only) listener config
+  |- barrel_mcp_stdio           stdio transport (own process tree)
+  `- barrel_mcp_listener_sup    one child per listener
+       `- barrel_mcp_http_listener   h1/h2 acceptors, connections, request processes
+            `- barrel_mcp_http_engine    HTTP verbs, sessions, SSE, auth, CORS, tool calls
+                 `- barrel_mcp_protocol     JSON-RPC envelopes, era gating, method handlers
+                      |- barrel_mcp_ctx            per-request context, era, _meta validation
+                      |- barrel_mcp_registry       handler lookup and execution
+                      |- barrel_mcp_session        legacy sessions, SSE channel, pending requests
+                      |- barrel_mcp_tasks          task table and lifecycle
+                      |- barrel_mcp_task_relay     inline-or-task hand-off (modern era)
+                      |- barrel_mcp_subscriptions  subscriptions/listen filters
+                      |- barrel_mcp_elicitation    URL-mode elicitation records
+                      |- barrel_mcp_request_state  MRTR sealed state
+                      |- barrel_mcp_headers        x-mcp-* header mirroring
+                      |- barrel_mcp_pagination     cursors for */list
+                      `- barrel_mcp_jsonschema     input/output schema validation
+barrel_mcp_auth + barrel_mcp_auth_*   server auth providers (bearer, apikey, basic, custom, none)
+barrel_mcp_version                   the revision registry and the era function
+```
+
+`barrel_mcp_stdio` calls `barrel_mcp_protocol` directly and never
+goes through the engine. The legacy 2024-11-05 HTTP+SSE pair lives
+inside the engine (section 4.6).
+
+## 2. Supervision tree
+
+`barrel_mcp_app:start/2` seeds the MRTR signing key
+(`barrel_mcp_request_state:ensure_key/0`, a `persistent_term`) and
+starts `barrel_mcp_sup`.
+
+```erl
+barrel_mcp_sup                   one_for_one, 5 restarts / 10 s
+  |- barrel_mcp_registry         gen_statem, permanent
+  |- barrel_mcp_session          gen_server, permanent
+  |- barrel_mcp_subscriptions    gen_server, permanent
+  |- barrel_mcp_elicitation      gen_server, permanent
+  |- barrel_mcp_listener_sup     supervisor, one_for_one, 3 / 60 s, no static children
+  |    `- <listener name>        barrel_mcp_http_listener, transient, added at start_http_stream/start_http
+  |- barrel_mcp_tasks            gen_server, permanent
+  `- barrel_mcp_client_sup       supervisor (client side, see Client Internals)
+```
+
+Listener names are `barrel_mcp_http_stream_listener` and
+`barrel_mcp_http_simple_listener`. When `barrel_mcp_listener_sup` is
+not running (the library embedded without its application), the
+listener is started unsupervised by `barrel_mcp_listener_sup:supervised_start/3`'s
+fallback.
+
+`barrel_mcp_stdio` is not under the tree: `start/0` runs it
+unregistered and blocks the caller until it exits, `start_link/0`
+registers it as `barrel_mcp_stdio` for a host supervisor.
+
+### The listener
+
+`barrel_mcp_http_listener` is a `proc_lib` process that traps exits.
+On start it opens the socket, registers under its name, and spawns
+`acceptors` linked acceptor processes (default `max(2, schedulers)`)
+kept in a map. An acceptor that exits abnormally is logged and
+replaced after `?ACCEPT_ERROR_BACKOFF` (50 ms); `acceptors/1` lists
+the live pool.
+
+Each accepted socket gets a connection process (`spawn`, then the
+connection links itself to the listener), counted against
+`max_connections` (default 16384) through an atomics counter that a
+monitor releases on exit. The connection negotiates h1 or h2 and
+spawns one request process per request with
+`spawn_opt([link, monitor])` (`spawn_handler/7`): h1 serves requests
+one at a time, h2 one process per stream. A request process that
+crashes is answered 500 by the connection, except for `shutdown`,
+`{shutdown, _}` and `{noproc, {gen_statem, call, _}}`, which are a
+peer that went away.
+
+When the listener stops it closes the socket and exits `shutdown`,
+which reaches every connection and request over the links.
+
+## 3. Process model of a request
+
+`barrel_mcp_http_engine:handle/6` runs in the request process. What
+it spawns during a `tools/call`:
+
+| process | spawned by | primitive | reports to | ends |
+| --- | --- | --- | --- | --- |
+| tool worker | `barrel_mcp_registry:run_tool/3` | `spawn` (no link) | `reply_to` in its Ctx: `{tool_result, ...}`, `{tool_error, ...}`, `{tool_failed, ...}`, `{tool_input_required, ...}` | after one message; killed on disconnect (`settle_disconnect/2`) or when a task cannot be created |
+| task relay | `barrel_mcp_task_relay:start/0` | `spawn_link` from the request process | its `target`: the request process, then the collector | `stop`, or the worker's `DOWN` once forwarded; unlinked before escalation |
+| task collector | `barrel_mcp_protocol:spawn_task_collector/3` | `spawn` | `barrel_mcp_tasks` (`finish`, `fail`, `cancel`) | first terminal message; monitors the worker; `?WORKER_HANDOFF_MS` without a worker fails the task |
+| legacy-SSE driver | `barrel_mcp_http_engine:legacy_answer/3` | `spawn` | `push_legacy/2` onto the session's stream | when `drive_async_plan/4` returns |
+| stream watcher | `answer_on_stream/3` | `spawn_link` | kills the worker if the SSE stream dies | `done` |
+
+Under stdio the coordinator runs each request in a `spawn_monitor`
+worker (at most `?DEFAULT_MAX_WORKERS`, 8; queue of 64), and that
+worker drives the plan itself, so the tool worker's `reply_to` is the
+stdio worker, or a relay it creates. The reader process sends one
+frame and waits for `stdio_ack` before reading the next; the writer
+serialises `io:format` calls. Either one exiting stops the
+coordinator.
+
+## 4. Request lifecycle per verb
+
+Function names are the hops; every one is in
+`src/barrel_mcp_http_engine.erl` unless a module is given.
+
+### 4.1 Any request
+
+1. `handle/6`: strip the query; serve
+   `/.well-known/oauth-protected-resource` when `resource_metadata`
+   is configured; `validate_origin/2` (403 on failure).
+2. `route/7`: the 2024-11-05 pair's paths (`sse_path`,
+   `sse_message_path`) go to section 4.6; everything else to
+   `dispatch/6` keyed on the engine `mode` (`stream` or `simple`)
+   and the verb.
+
+### 4.2 Streamable POST, modern era
+
+1. `stream_post/4`: `Accept` check (406), authentication
+   (`with_auth_info/4`), body decode; a batch goes to
+   `stream_post_batch/6`.
+2. `stream_post_request/6`: a JSON-RPC response goes to
+   `handle_inbound_response/6`; otherwise the era fork:
+   `barrel_mcp_ctx:era(barrel_mcp_ctx:from_request(Request, Extra))`.
+3. `handle_modern_request/6`: `validate_metadata_headers/2` (the
+   `Mcp-*` headers must agree with the body, else 400
+   `?MCP_HEADER_MISMATCH`).
+4. `dispatch_modern_request/6`: `barrel_mcp_protocol:handle/2` with
+   `auth_info`, `streaming => true`, `transport_version`. No session
+   is looked up or minted.
+5. In the protocol: `handle/2` → `dispatch/4` (`serves/2`: does this
+   era have the method) → `dispatch_versioned/4`
+   (`barrel_mcp_ctx:validate_version/1`, `check_version/1`) →
+   `dispatch_valid/4` (`barrel_mcp_ctx:validate/1`, then
+   `handle_request/4`, `with_cache_hints/3`, `finalize/2`).
+6. `handle_request(<<"tools/call">>, ...)` → `tool_call_plan/4`
+   returns `{async, Plan}`.
+7. Back in the engine, `dispatch_modern_request/6` matches
+   `{async, Plan}` → `handle_async_tool_call/7`, which computes the
+   mode (section 5), spawns the worker with `reply_to =>
+   reply_target(Relay, self())`, then `wait_for_tool/4` (inline) or
+   `wait_inline_or_escalate/6` (escalate).
+8. The answer is a JSON body, or an SSE response stream when the
+   client's `Accept` asks for one (`stream_sse_response/5`). A
+   `{subscribe, Sub}` return opens a subscription stream
+   (`handle_subscription/4`, `subscription_loop/3`).
+
+### 4.3 Streamable POST, legacy era
+
+Steps 1 and 2 as above, then:
+
+3. `handle_inbound_request/6` → `lookup_session/5`: `initialize`
+   without a header mints a session and records the principal; any
+   other request must name a session the same principal owns
+   (`owned_session/2`), else 404.
+4. `handle_dispatch/6`: `validate_protocol_version/3`, activity
+   update, `barrel_mcp_protocol:handle/2` with `session_id`.
+5. Same protocol path as 4.2 step 5; `initialize/3` records the
+   negotiated version and capabilities on the session.
+6. `{async, Plan}` → `handle_async_tool_call/7`; the legacy mode is
+   `task` (immediate task, `handle_long_running_call/10`) or
+   `inline`; the worker is recorded in the session's in-flight table
+   so a `notifications/cancelled` or a DELETE can kill it.
+7. The answer goes back on the POST's own SSE stream
+   (`stream_sse_response/5`); server-to-client requests raised while
+   it runs go on the same stream when the client has no standalone
+   GET open, else on the GET.
+
+### 4.4 GET (standalone stream, legacy era only)
+
+`dispatch/6` answers 405 when sessions are off. Otherwise
+`stream_get_sse/3` → `stream_get_sse_authed/4` (header required, 400)
+→ `stream_get_sse_session/5` (`owned_session/2`, 404) →
+`replay_sse_events/3` for `Last-Event-ID` → `set_sse_pid` → `sse_loop/2`
+until `session_terminated`, `mcp_disconnect` or a failed write, then
+`sse_cleanup/2`.
+
+### 4.5 DELETE
+
+`stream_delete/3` → `stream_delete_authed/4` → `owned_session/2` →
+`barrel_mcp_session:delete/1` (204). Deleting a session fails its
+pending server-to-client requests and signals its SSE loop.
+
+### 4.6 The 2024-11-05 HTTP+SSE pair
+
+`legacy_sse_open/3`: mint a session bound to the principal, start the
+stream, send the `endpoint` event carrying the session id, `sse_loop/2`;
+the session is deleted when the loop ends. `legacy_sse_post/5`:
+`legacy_session_of/2` checks the `sessionId` query parameter against
+the principal (404 either way), `legacy_dispatch/6` handles the
+message, the answer is pushed onto the stream and the POST gets 202.
+An `{async, Plan}` here is driven by a spawned driver
+(`legacy_answer/3`, `answer_on_stream/3`).
+
+### 4.7 stdio
+
+`barrel_mcp_stdio` classifies each frame (`Classification` section),
+queues or starts a worker (`start_worker/3`), and the worker calls
+`barrel_mcp_protocol:handle/2` then `settle_result/2`, which drives an
+`{async, Plan}` with `barrel_mcp_protocol:drive_async_plan/4`. The
+mode decision for stdio is therefore the protocol's (section 5).
+
+## 5. Tool-call modes
+
+A registered tool declares `task_support` (`forbidden` by default,
+`optional`, `required`; `long_running => true` is the old spelling of
+`optional`). Whether a call becomes a task depends on that, on
+whether the client declared the tasks extension, and on the era:
+
+| `task_support` | extension declared | era | mode |
+| --- | --- | --- | --- |
+| `forbidden` | any | any | `inline`: run to completion, answer in place |
+| `optional` | no | any | `inline` |
+| `required` | no | any | `refuse`: `-32021` naming the extension |
+| `optional` or `required` | yes | legacy | `task`: create the task first, answer with the handle |
+| `optional` or `required` | yes | modern | `escalate`: run inline for `task_inline_ms`, then task |
+
+The rule is written twice, on purpose in two shapes:
+
+- HTTP, `barrel_mcp_http_engine:handle_async_tool_call/7`: the
+  five-clause `case {Support, Enabled}` with the `when Modern` guard,
+  because the engine writes the answer itself.
+- Every other transport, `barrel_mcp_protocol:task_plan/2` consumed
+  by `drive_async_plan/4`, which picks `drive_inline_then_task/5`
+  (modern) or `drive_as_task/4` (legacy).
+
+Change one and change the other; `barrel_mcp_tasks_tests` pins both.
+
+### The relay
+
+In `escalate` mode the worker does not report to the request process
+but to a relay, so the outcome can be handed to a task after the
+window without a race:
+
+1. Request process: `Relay = barrel_mcp_task_relay:start()` (linked),
+   spawn the worker with `reply_to => Relay`, `worker(Relay, Pid)`.
+2. Relay forwards every worker message to its owner while the owner
+   waits `inline_ms()`.
+3. Outcome inside the window: `stop(Relay)`, answer in place.
+4. Window over: `hold(Relay)`; the relay acknowledges with
+   `relay_held` and starts holding messages. A relay that already
+   ended counts as held (its forwarded messages are in the mailbox),
+   so the owner re-checks its mailbox with a zero timeout.
+5. Still nothing: `unlink(Relay)`, `escalate/6` creates the task
+   (`barrel_mcp_tasks:create/3`, before the response is written, so
+   `tasks/get` resolves at once), spawns a collector, sends
+   `{redirect, Collector}`; the relay replays what it held to the
+   collector and forwards from then on. The answer is the
+   `CreateTaskResult` for the era.
+6. The relay exits when the worker is down and everything is
+   forwarded; a worker gone before it was watched (`noproc`) counts
+   as normal.
+
+## 6. Session
+
+One `#mcp_session{}` row per legacy session in the
+`barrel_mcp_sessions` table, created at three sites: `lookup_session/5`
+on `initialize` (Streamable), `legacy_sse_open/3` (2024-11-05 pair),
+`barrel_mcp_stdio:init/1` (one per stdio process).
+
+| field | written by |
+| --- | --- |
+| `id`, `created_at`, `client_info` | `create/1` |
+| `last_activity` | `handle_dispatch/6` on every legacy request |
+| `client_capabilities` | `barrel_mcp_protocol:initialize/3` |
+| `protocol_version` | `initialize/3`; `remember_version/2` and `maybe_capture_initialize_version/3` in the engine |
+| `sse_pid` | `stream_get_sse_session/5`, `sse_cleanup/2`, `legacy_sse_open/3`, `barrel_mcp_stdio:bind_session/2` (legacy era only) |
+| `sse_buffer`, `sse_buffer_max` | `record_sse_event` from the engine's SSE helpers; the max from `lookup_session/5` (`sse_buffer_size`, default 256) |
+| `log_level` | `logging/setLevel` handler |
+| `principal` | `lookup_session/5`, `legacy_sse_open/3` |
+
+Beside the row, `barrel_mcp_session` keeps three more tables keyed by
+session: resource subscriptions, pending server-to-client requests
+(`#pending{}`, matched on `{SessionId, Id}` at delivery), and
+in-flight tool workers (`{SessionId, RequestId}` → worker and
+waiter). `delete/1` fails the pending rows, kills the in-flight
+workers and signals the SSE loop. Expired sessions are swept on a
+timer.
+
+Ownership: a session belongs to the principal that initialized it.
+`owned_session/2` answers `unknown_session` for another principal,
+which every verb reports as the 404 an unknown id gets.
+
+## 7. Registered processes and tables
+
+| table | owner | options | key → value |
+| --- | --- | --- | --- |
+| `barrel_mcp_registry_table` | `barrel_mcp_registry` | public, set | `{Type, Name}` → handler map |
+| `barrel_mcp_sessions` | `barrel_mcp_session` | protected | `SessionId` → `#mcp_session{}` |
+| `barrel_mcp_resource_subs` | `barrel_mcp_session` | protected | `{SessionId, Uri}` |
+| `barrel_mcp_pending_requests` | `barrel_mcp_session` | protected | `RequestId` → `#pending{}` |
+| `barrel_mcp_inflight` | `barrel_mcp_session` | protected | `{SessionId, RequestId}` → `#in_flight{}` |
+| `barrel_mcp_subscriptions_table` | `barrel_mcp_subscriptions` | protected | `{Pid, SubId}` → filter |
+| `barrel_mcp_elicitations` | `barrel_mcp_elicitation` | protected | `Id` → `#elicitation{}` |
+| `barrel_mcp_tasks_table` | `barrel_mcp_tasks` | protected | `TaskId` → `#task{}` |
+
+Protected tables are read directly by request processes and written
+only through their owner's `gen_server` calls; that is why the
+`barrel_mcp_session` API is a long list of small calls.
+
+`persistent_term` holds the registry snapshot (`{Handlers,
+ParamHeaders}`, rebuilt on every registration), the MRTR signing key,
+the dummy hash `barrel_mcp_auth_basic` compares against for unknown
+users, and the JSON Schema metaschema.
+
+Registered names: the four gen_servers and the registry above,
+`barrel_mcp_sup`, `barrel_mcp_listener_sup`, `barrel_mcp_client_sup`,
+each listener under its name, and `barrel_mcp_stdio` when started
+with `start_link/0`.
+
+## 8. Where to look
+
+| want to read | file |
+| --- | --- |
+| HTTP verbs, sessions on the wire, SSE, CORS, Origin | `src/barrel_mcp_http_engine.erl` |
+| JSON-RPC envelopes, era gating, one handler per method | `src/barrel_mcp_protocol.erl` |
+| Per-request context and `_meta` validation | `src/barrel_mcp_ctx.erl` |
+| Tool / resource / prompt registration and workers | `src/barrel_mcp_registry.erl` |
+| Session rows, pending requests, in-flight workers | `src/barrel_mcp_session.erl` |
+| Task table, TTL, `input_required` | `src/barrel_mcp_tasks.erl` |
+| Inline-or-task hand-off | `src/barrel_mcp_task_relay.erl` |
+| Acceptors, connections, h1/h2 | `src/barrel_mcp_http_listener.erl` |
+| stdio framing and worker pool | `src/barrel_mcp_stdio.erl` |
+| Server auth providers and principals | `src/barrel_mcp_auth.erl`, `src/barrel_mcp_auth_*.erl` |
+| Revisions and the era function | `src/barrel_mcp_version.erl`, `include/barrel_mcp.hrl` |
+
+Tests are grouped by feature, not by module. The ones that pin each
+area:
+
+| area | tests |
+| --- | --- |
+| tool-call modes, tasks, MRTR | `test/barrel_mcp_tasks_tests.erl`, `test/barrel_mcp_mrtr_SUITE.erl`, `test/barrel_mcp_async_tools_SUITE.erl` |
+| relay | `test/barrel_mcp_task_relay_tests.erl` |
+| envelopes, dispatch, initialize | `test/barrel_mcp_protocol_tests.erl`, `test/barrel_mcp_protocol_envelope_tests.erl` |
+| eras on one listener | `test/barrel_mcp_dual_era_SUITE.erl` |
+| session ownership, Origin, headers, response codes | `test/barrel_mcp_http_stream_security_SUITE.erl` |
+| cancellation, replay, spec additions | `test/barrel_mcp_spec_additives_SUITE.erl` |
+| subscriptions | `test/barrel_mcp_subscriptions_SUITE.erl` |
+| listener and embedding | `test/barrel_mcp_http_engine_embed_tests.erl`, `test/barrel_mcp_http_stream_tests.erl` |
+| auth providers, principals | `test/barrel_mcp_auth_tests.erl`, `test/barrel_mcp_principal_tests.erl` |
+| stdio | `test/barrel_mcp_stdio_SUITE.erl` |
+| the official runner, both modes | `test/barrel_mcp_conformance_SUITE.erl` |
+| the Python SDK, both eras | `test/barrel_mcp_python_interop_SUITE.erl` |

--- a/guides/tools-resources-prompts.md
+++ b/guides/tools-resources-prompts.md
@@ -266,25 +266,34 @@ Notes:
 
 ### Long-running tools (tasks)
 
-Set `long_running => true` on `reg_tool/4` and the tool returns
-immediately to the client with a `taskId`. The handler keeps
-running in the background and the runtime stores its eventual
-outcome on the task. Clients track progress via `tasks/get`,
-`tasks/list`, or `notifications/tasks/status`.
-
-This now applies over stdio too. Before 3.0 only the HTTP transport
-honoured `long_running`; stdio drove every tool synchronously and
-blocked up to 60 seconds.
+Set `task_support` on `reg_tool/4` to say whether a call may become a
+task: `forbidden` (the default), `optional`, or `required`.
+`long_running => true` is the older spelling of `optional`.
 
 ```erlang
 barrel_mcp:reg_tool(<<"render_video">>, my_tools, render_video, #{
-    long_running => true,
+    task_support => optional,
     description => <<"Render a video on the GPU farm">>
 }).
 ```
 
-The same handler shape (arity 1 or arity 2) applies. Long-running
-handlers may emit progress just like any other tool.
+What the client then sees depends on its era and on whether it
+declared the tasks extension:
+
+- A legacy client that negotiated tasks gets a `taskId` at once; the
+  handler keeps running and the runtime stores its outcome on the
+  task. It tracks progress with `tasks/get`, `tasks/list` or
+  `notifications/tasks/status`.
+- A modern client that declared the extension gets the result in
+  place when the handler answers within `task_inline_ms` (application
+  environment, default 100 ms), and a task handle otherwise.
+- A client that did not declare the extension gets the tool run
+  synchronously for `optional`, and error `-32021` for `required`.
+
+The full mode table, and where each transport decides it, is in
+[Server Internals](server-internals.md#5-tool-call-modes). The same
+handler shape (arity 1 or arity 2) applies, over stdio too, and
+task-backed handlers may emit progress like any other tool.
 
 ### Schema validation
 

--- a/rebar.config
+++ b/rebar.config
@@ -61,6 +61,7 @@
         {"guides/getting-started.md", #{title => "Getting Started"}},
         {"guides/building-a-client.md", #{title => "Building a Client"}},
         {"guides/internals.md", #{title => "Client Internals"}},
+        {"guides/server-internals.md", #{title => "Server Internals"}},
         {"guides/features.md", #{title => "Features"}},
         {"guides/http-stream.md", #{title => "Streamable HTTP Transport"}},
         {"guides/stdio.md", #{title => "stdio Transport"}},
@@ -70,6 +71,7 @@
         {"guides/tools-resources-prompts.md", #{title => "Tools, Resources & Prompts"}},
         {"guides/client.md", #{title => "MCP Client (reference)"}},
         {"docs/pending-features.md", #{title => "Pending Features"}},
+        {"guides/glossary.md", #{title => "Glossary"}},
         {"CHANGELOG.md", #{title => "Changelog"}},
         {"LICENSE", #{title => "License"}}
     ]},

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -30,6 +30,22 @@
 %%% an LLM provider (Anthropic, OpenAI, Hermes-style local model) into
 %%% this loop is the host's job, `barrel_mcp' itself stays a pure
 %%% MCP library.
+%%%
+%%% == Sections, in file order ==
+%%%
+%%% <ul>
+%%%   <li>Public API: connect, the verbs, subscriptions, close.</li>
+%%%   <li>gen_statem: the four states above and the common event
+%%%       handling.</li>
+%%%   <li>Inbound message routing, tool definitions and header
+%%%       bindings, subscriptions, multi round-trip requests.</li>
+%%%   <li>Initialize handling: `server/discover' probe or
+%%%       `initialize' handshake by requested version.</li>
+%%%   <li>Transport plumbing, helpers, ping cadence, termination.</li>
+%%% </ul>
+%%%
+%%% The state record is documented field by field in the Client
+%%% Internals guide, section 7.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_client).

--- a/src/barrel_mcp_client_auth_oauth.erl
+++ b/src/barrel_mcp_client_auth_oauth.erl
@@ -81,6 +81,42 @@
 %%% Security"). `allow_insecure_oauth => true' lifts that for a
 %%% plaintext test server. It is noncompliant and never a production
 %%% setting.
+%%%
+%%% == Sections, in file order ==
+%%%
+%%% <ul>
+%%%   <li>Behaviour callbacks: `init/1', `headers/1', `refresh/2',
+%%%       `challenge/2', `settled/1', `request_headers/3'.</li>
+%%%   <li>Discovery: `WWW-Authenticate' parsing, PRM, AS metadata,
+%%%       the HTTPS policy `secure_url/2'.</li>
+%%%   <li>PKCE, authorization URL, token endpoint.</li>
+%%%   <li>Choosing a registration mechanism, Client ID Metadata
+%%%       Documents, binding a client to an authorization server.</li>
+%%%   <li>The authorization-code flow driven from a challenge:
+%%%       `prm_flow', `ensure_client', `run_authorization',
+%%%       `exchange', `step_up'; the non-interactive grants and DPoP
+%%%       proofs sit with it.</li>
+%%%   <li>HTTP helpers and encoders.</li>
+%%% </ul>
+%%%
+%%% == The handle record ==
+%%%
+%%% `#h{}' is the whole state. The fields that steer behaviour:
+%%% `mode' (which grant), `phase' (`flow' runs the authorization-code
+%%% flow from a 401, `token' only refreshes what the host supplied),
+%%% `tea_method' (how the client authenticates at the token
+%%% endpoint, persisted with the client), `want_refresh' (ask for
+%%% `offline_access' when the AS lists it), `insecure' (the plaintext
+%%% policy), `dpop' (proof key and the AS and RS nonces),
+%%% `token_type' (`dpop' switches the `Authorization' scheme). `prm',
+%%% `as_metadata' and `client' are the discovered documents;
+%%% `requested_scope' and `granted_scope' drive step-up on 403.
+%%%
+%%% == Processes ==
+%%%
+%%% The handle is a value; the transport calls it. `challenge/2' does
+%%% network I/O and may block on the host's `authorize' fun, which is
+%%% why `barrel_mcp_client_http' runs it in a worker.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_client_auth_oauth).

--- a/src/barrel_mcp_client_http.erl
+++ b/src/barrel_mcp_client_http.erl
@@ -23,6 +23,35 @@
 %%% Each parsed SSE event's `data:' payload is forwarded to the owning
 %%% client as `{mcp_in, self(), Json}'. The owner sees the same shape
 %%% as it does from the stdio transport.
+%%%
+%%% == Sections, in file order ==
+%%%
+%%% <ul>
+%%%   <li>Transport API and public helpers.</li>
+%%%   <li>gen_server: `init', the info handlers for hackney, the auth
+%%%       worker and resume timers.</li>
+%%%   <li>POST request lifecycle: `start_post/3', response parsing,
+%%%       `finalize_request', the challenge path, SEP-1699
+%%%       resumption.</li>
+%%%   <li>SSE GET stream, SSE parsing, header helpers, DELETE on close.</li>
+%%% </ul>
+%%%
+%%% == State ==
+%%%
+%%% `#state{}': `requests' maps each in-flight POST's hackney ref to a
+%%% `#req{}' (attempts, last event id, resumes); `challenged' holds
+%%% the requests waiting on the single auth flow in `auth_flow';
+%%% `sse_mode' and `legacy_sse' record how the server delivers
+%%% unsolicited traffic (a GET, a `subscriptions/listen' POST, or the
+%%% 2024-11-05 endpoint); `resumes' keeps resumption timers so a
+%%% cancel can drop one; `tool_headers' caches the `x-mcp-header'
+%%% bindings from `tools/list'. Each field carries its reason inline.
+%%%
+%%% == Processes ==
+%%%
+%%% One gen_server per connection, owned by the client. hackney
+%%% delivers asynchronously; the auth flow runs in a `spawn_monitor'
+%%% worker so a person's consent step never blocks the transport.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_client_http).

--- a/src/barrel_mcp_ctx.erl
+++ b/src/barrel_mcp_ctx.erl
@@ -166,12 +166,6 @@ capabilities_of(legacy, _Meta, Extra) ->
 %% Validation
 %%====================================================================
 
-%% @doc Check that a modern request carries the `_meta' fields the spec
-%% marks required, and that the optional ones it does carry are usable.
-%% A failure is malformed params and the caller must reject it with
-%% `?JSONRPC_INVALID_PARAMS' (HTTP 400).
-%%
-%% Legacy requests carry no such requirement and always pass.
 %% @doc Check the stated revision on its own, before anything is judged
 %% against it. A peer naming a revision we do not speak may legitimately
 %% carry a `_meta' shape we would misjudge, so the version error has to
@@ -189,6 +183,12 @@ validate_version(#{era := modern, meta := Meta}) ->
         {ok, _} -> {error, {invalid_meta, ?MCP_META_PROTOCOL_VERSION}}
     end.
 
+%% @doc Check that a modern request carries the `_meta' fields the spec
+%% marks required, and that the optional ones it does carry are usable.
+%% A failure is malformed params and the caller must reject it with
+%% `?JSONRPC_INVALID_PARAMS' (HTTP 400).
+%%
+%% Legacy requests carry no such requirement and always pass.
 -spec validate(ctx()) ->
     ok | {error, {missing_meta, binary()}} | {error, {invalid_meta, binary()}}.
 validate(#{era := legacy}) ->

--- a/src/barrel_mcp_http_engine.erl
+++ b/src/barrel_mcp_http_engine.erl
@@ -39,6 +39,38 @@
 %%% long-lived GET SSE stream it blocks in a receive loop until the
 %%% session is terminated or the binding signals a client disconnect
 %%% by sending the calling process the message `mcp_disconnect'.
+%%%
+%%% == Sections, in file order ==
+%%%
+%%% <ul>
+%%%   <li>Entry point and method dispatch: `handle/6', `route/7',
+%%%       `dispatch/6' keyed on the engine mode and the verb.</li>
+%%%   <li>Simple transport: POST only, no sessions.</li>
+%%%   <li>Streamable POST: `stream_post/4', the era fork in
+%%%       `stream_post_request/6', batches, inbound responses.</li>
+%%%   <li>Modern requests: header and body agreement, stateless
+%%%       dispatch, SSE response streams, `subscriptions/listen'.</li>
+%%%   <li>Async tool calls: `handle_async_tool_call/7' decides the
+%%%       tool-call mode for HTTP (inline, task, escalate, refuse) and
+%%%       waits for the worker; the legacy immediate-task path is
+%%%       `handle_long_running_call/10'.</li>
+%%%   <li>Session resolution: `lookup_session/5', `owned_session/2',
+%%%       version negotiation.</li>
+%%%   <li>GET and DELETE: the standalone stream with replay, and
+%%%       session termination.</li>
+%%%   <li>The 2024-11-05 HTTP+SSE pair.</li>
+%%%   <li>SSE, validation, authentication, CORS, Origin and bind
+%%%       helpers, the session manager bootstrap, plumbing.</li>
+%%% </ul>
+%%%
+%%% == Processes ==
+%%%
+%%% `handle/6' runs in the request process the listener spawned. A
+%%% tool worker is spawned by the registry with this process (or a
+%%% relay) as `reply_to'; a task collector, a relay and, on the
+%%% legacy pair, a driver and a stream watcher are the other
+%%% processes this module starts. The Server Internals guide lists
+%%% them with who links or monitors whom.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_http_engine).
@@ -85,6 +117,9 @@
 %% Entry point
 %%====================================================================
 
+%% @doc Serve one HTTP request. Runs in the caller's process and, for
+%% an SSE response, blocks in it until the stream ends. Every binding
+%% (the built-in listener, an embedder's adapter) enters here.
 -spec handle(
     binary(),
     binary(),
@@ -2177,7 +2212,8 @@ extract_headers(Headers, AuthConfig) ->
         Names
     ).
 
-%% The user-facing `resource_metadata' option processing.
+%% @doc Normalise the `resource_metadata' option into the document the
+%% engine serves and the URL it advertises. Shared by both listeners.
 -spec normalize_resource_metadata(map() | undefined) -> map() | undefined.
 normalize_resource_metadata(undefined) ->
     undefined;
@@ -2209,6 +2245,8 @@ derive_prm_url(Resource) when is_binary(Resource) ->
             <<Resource/binary, "/.well-known/oauth-protected-resource">>
     end.
 
+%% @doc Put the PRM URL into the auth config so the bearer challenge
+%% can name it (RFC 9728 `resource_metadata').
 -spec inject_resource_metadata_url(map(), map() | undefined) -> map().
 inject_resource_metadata_url(AuthConfig, undefined) ->
     AuthConfig;
@@ -2267,6 +2305,8 @@ cors_headers(Headers, Config, Extra) ->
 %% Origin validation + bind helpers
 %%====================================================================
 
+%% @doc Decide the `Origin' allow-list from the bind address: a
+%% loopback bind may default, a public one must list its origins.
 -spec resolve_allowed_origins(boolean(), any | undefined | [binary()]) ->
     {ok, any | [term()]} | {error, allowed_origins_required}.
 resolve_allowed_origins(_Loopback, any) ->
@@ -2299,6 +2339,8 @@ parse_origin(Bin) when is_binary(Bin) ->
             #{scheme => undefined, host => Bin, port => any}
     end.
 
+%% @doc Whether a bind address is loopback, in any of the shapes the
+%% listener options accept.
 -spec is_loopback(inet:ip_address() | string() | binary()) -> boolean().
 is_loopback({127, _, _, _}) -> true;
 is_loopback({0, 0, 0, 0, 0, 0, 0, 1}) -> true;
@@ -2343,6 +2385,8 @@ origin_matches(_, _) ->
 %% Session manager bootstrap
 %%====================================================================
 
+%% @doc Start `barrel_mcp_session' when the library is embedded
+%% without its application, so sessions work under a host supervisor.
 -spec ensure_session_manager() -> ok | {ok, pid()} | {error, term()}.
 ensure_session_manager() ->
     case whereis(barrel_mcp_session) of

--- a/src/barrel_mcp_jsonschema.erl
+++ b/src/barrel_mcp_jsonschema.erl
@@ -25,6 +25,22 @@
 %%%
 %%% Depth, subschema count and reference expansions are capped, so a
 %%% hostile schema cannot spend the caller's stack or time.
+%%%
+%%% == Sections, in file order ==
+%%%
+%%% <ul>
+%%%   <li>Compilation: identifiers, anchors, references, the registry.</li>
+%%%   <li>Validation: the entry point and the per-schema walk with
+%%%       annotations.</li>
+%%%   <li>Assertions: the leaf keywords (`type', `enum', bounds,
+%%%       patterns, `format' as annotation).</li>
+%%%   <li>Applicators: `properties', `items', `allOf' and friends.</li>
+%%%   <li>`unevaluated*': the keywords that read the annotations the
+%%%       walk collected.</li>
+%%%   <li>URIs and pointers, and the dialect's own metaschema.</li>
+%%% </ul>
+%%%
+%%% Pure functions throughout; nothing here spawns or stores.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_jsonschema).

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -1,7 +1,47 @@
 %%%-------------------------------------------------------------------
-%%% @doc MCP protocol implementation over JSON-RPC 2.0.
+%%% @doc The MCP protocol core: JSON-RPC envelopes in, envelopes out.
 %%%
-%%% Handles encoding/decoding and routing of MCP methods.
+%%% This module owns what every transport shares: decoding a request,
+%%% deciding which era it belongs to and whether that era has the
+%%% method, validating `_meta', running the method handler, and
+%%% rendering the answer for that era. It owns nothing about the
+%%% wire: no sockets, no headers, no sessions on the wire, no SSE. A
+%%% transport (`barrel_mcp_http_engine', `barrel_mcp_stdio') calls
+%%% {@link handle/2} with a protocol state map and writes whatever
+%%% comes back.
+%%%
+%%% == What handle/2 returns ==
+%%%
+%%% A response map to encode, `no_response' for a notification,
+%%% `{async, Plan}' for a `tools/call' (the transport drives the plan,
+%%% see {@link drive_async_plan/4}, because only it knows how to
+%%% stream the answer), `{subscribe, Sub}' for `subscriptions/listen',
+%%% or a list for a batch.
+%%%
+%%% == Sections, in file order ==
+%%%
+%%% <ul>
+%%%   <li>API: `handle/1,2', `decode/1', the response constructors.</li>
+%%%   <li>Batches: the legacy batch envelope and its per-era refusal.</li>
+%%%   <li>Era dispatch: `dispatch/4' → `dispatch_versioned/4' →
+%%%       `dispatch_valid/4'; `serves/2' says which methods an era
+%%%       has; `finalize/2' decorates a result for its era.</li>
+%%%   <li>Tasks: the task collector, `task_plan/2' (the mode rule for
+%%%       every transport but Streamable HTTP), `create_task_result/3'.</li>
+%%%   <li>Multi round-trip requests: `input_required' rounds and the
+%%%       sealed `request_state'.</li>
+%%%   <li>Request handlers: one `handle_request/4' clause per method.</li>
+%%%   <li>Notification handlers.</li>
+%%%   <li>Internal functions, cursor pagination, envelope helpers.</li>
+%%% </ul>
+%%%
+%%% == Processes ==
+%%%
+%%% Everything here runs in the caller's process (a request process
+%%% under HTTP, a worker under stdio) except the task collector,
+%%% which `spawn_task_collector/3' starts to outlive the request. See
+%%% the Server Internals guide for the process model and the hop
+%%% list of a request.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_protocol).

--- a/src/barrel_mcp_protocol.erl
+++ b/src/barrel_mcp_protocol.erl
@@ -763,7 +763,7 @@ tool_call_plan(Params, Id, Ctx, Mrtr) ->
 %% Both Python SDK generations turn every exception in the tool-call
 %% handler into a CallToolResult with isError, never a protocol error
 %% (v2 mcp/server/mcpserver/server.py:424, v1 lowlevel/server.py:472),
-%% and an unknown tool raises ToolError("Unknown tool: <name>") into
+%% and an unknown tool raises ToolError("Unknown tool: ...") into
 %% that same branch (tools/tool_manager.py:72). That is what clients on
 %% the wire expect and what the official conformance runner asserts.
 %%

--- a/src/barrel_mcp_registry.erl
+++ b/src/barrel_mcp_registry.erl
@@ -43,6 +43,26 @@
 %%%
 %%% If not configured, the registry becomes ready immediately after init.
 %%%
+%%% == Running a tool ==
+%%%
+%%% {@link run_tool/3} spawns the handler in a fresh process (no link,
+%%% no monitor) with `reply_to' in its context, and that process sends
+%%% exactly one outcome message: `{tool_result, ...}',
+%%% `{tool_error, ...}', `{tool_failed, ...}',
+%%% `{tool_validation_failed, ...}' or `{tool_input_required, ...}'.
+%%% Who receives it (the request process, a relay, a collector) is
+%%% the transport's decision; see the Server Internals guide.
+%%% {@link task_support/1} is what that decision reads.
+%%%
+%%% == Sections, in file order ==
+%%%
+%%% <ul>
+%%%   <li>API: readiness, `reg/4,5', `unreg/2', `run/3,4',
+%%%       `run_tool/3', `find/2', `all/0,1', `task_support/1'.</li>
+%%%   <li>gen_statem callbacks: the two states.</li>
+%%%   <li>Internal functions: the ETS table, the persistent_term
+%%%       snapshot, option parsing, handler invocation.</li>
+%%% </ul>
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_registry).

--- a/src/barrel_mcp_session.erl
+++ b/src/barrel_mcp_session.erl
@@ -1,11 +1,39 @@
 %%%-------------------------------------------------------------------
 %%% @author Benoit Chesneau
 %%% @copyright 2024-2026 Benoit Chesneau
-%%% @doc MCP Session Management.
+%%% @doc Legacy-era sessions and everything that hangs off them.
 %%%
-%%% Provides ETS-based session management for MCP Streamable HTTP transport.
-%%% Sessions track client connections, protocol versions, and activity.
+%%% A session is what a handshake-era client establishes with
+%%% `initialize': its id, negotiated version, capabilities, principal,
+%%% the process holding its SSE stream, the replay buffer for
+%%% `Last-Event-ID', the server-to-client requests waiting for an
+%%% answer, and the tool workers in flight. Modern (2026-07-28)
+%%% requests are stateless and never create one; stdio creates one
+%%% per process.
 %%%
+%%% == Tables ==
+%%%
+%%% Four `protected' ETS tables owned by this gen_server: sessions,
+%%% resource subscriptions, pending requests, in-flight workers.
+%%% Request processes read them directly and write through the calls
+%%% below, which is why the API is many small functions. A pending
+%%% request is matched on `{SessionId, Id}' at delivery, so a
+%%% response posted on another session cannot answer it.
+%%%
+%%% == Sections, in file order ==
+%%%
+%%% <ul>
+%%%   <li>API: create / get / delete, the setters, the SSE channel,
+%%%       `sampling_create_message/3', `elicit_create/3',
+%%%       `roots_list/2' and `deliver_response/3', in-flight
+%%%       bookkeeping, `broadcast_list_changed/1'.</li>
+%%%   <li>gen_server callbacks: every write, the expiry sweep.</li>
+%%%   <li>Internal functions: `ask_client/5' (one server-to-client
+%%%       request and its wait), table bootstrap.</li>
+%%% </ul>
+%%%
+%%% The writer of each `#mcp_session{}' field is listed in the Server
+%%% Internals guide.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_session).

--- a/src/barrel_mcp_stdio.erl
+++ b/src/barrel_mcp_stdio.erl
@@ -45,9 +45,6 @@
 %%% (macOS), `%APPDATA%\Claude\claude_desktop_config.json' (Windows) or
 %%% `~/.config/claude/claude_desktop_config.json' (Linux).
 %%%
-%%% @see barrel_mcp
-%%% @see barrel_mcp_protocol
-%%%
 %%% == Sections, in file order ==
 %%%
 %%% <ul>
@@ -68,6 +65,9 @@
 %%% worker cap; `notifications', `notifying', `outbound' and
 %%% `dropped' bound the outbound notification buffer so a flood of
 %%% progress cannot exhaust memory.
+%%%
+%%% @see barrel_mcp
+%%% @see barrel_mcp_protocol
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_stdio).

--- a/src/barrel_mcp_stdio.erl
+++ b/src/barrel_mcp_stdio.erl
@@ -47,6 +47,27 @@
 %%%
 %%% @see barrel_mcp
 %%% @see barrel_mcp_protocol
+%%%
+%%% == Sections, in file order ==
+%%%
+%%% <ul>
+%%%   <li>API and the coordinator's gen_server callbacks.</li>
+%%%   <li>Classification: what kind of frame arrived and whether it
+%%%       runs now, queues, or is answered in place.</li>
+%%%   <li>Requests: the worker pool, `run_request/5',
+%%%       `settle_result/2' (drives an `{async, Plan}' in the worker).</li>
+%%%   <li>Subscriptions, cancellation, notifications with bounded
+%%%       buffering, the reader, the writer, helpers.</li>
+%%% </ul>
+%%%
+%%% == State ==
+%%%
+%%% `#state{}': `requests' indexed by id, with `by_mref' and `by_tag'
+%%% as secondary indexes on the worker monitor and its result tag;
+%%% `pending' and the `queued' / `running' counters implement the
+%%% worker cap; `notifications', `notifying', `outbound' and
+%%% `dropped' bound the outbound notification buffer so a flood of
+%%% progress cannot exhaust memory.
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_stdio).

--- a/src/barrel_mcp_tasks.erl
+++ b/src/barrel_mcp_tasks.erl
@@ -209,8 +209,6 @@ list(SessionId, _Opts) ->
 cancel(SessionId, TaskId) ->
     gen_server:call(?MODULE, {cancel, SessionId, TaskId}).
 
-%% @doc Record the worker pid (and optional originating request id)
-%% on a running task so a later `tasks/cancel' can stop it.
 %% @doc Attach the worker to a task created before it, so cancel and
 %% expiry can reach the process; carries the request id for MRTR
 %% resumption.

--- a/src/barrel_mcp_tasks.erl
+++ b/src/barrel_mcp_tasks.erl
@@ -1,12 +1,17 @@
 %%%-------------------------------------------------------------------
 %%% @doc Long-running operation registry (MCP tasks).
 %%%
-%%% Tools registered with `long_running => true' return immediately
-%%% with a `taskId' instead of synchronously producing a result. The
-%%% worker continues in the background; clients poll via
-%%% `tasks/get', enumerate via `tasks/list', and abort via
-%%% `tasks/cancel'. State transitions emit
-%%% `notifications/tasks/status' on the session's SSE channel.
+%%% Tools registered with `task_support => optional | required'
+%%% (`long_running => true' is the old spelling of `optional') can
+%%% answer with a `taskId' instead of a result: at once for a legacy
+%%% client, after the inline window for a modern one. The worker
+%%% continues in the background; clients poll via `tasks/get',
+%%% enumerate via `tasks/list' (legacy), and abort via `tasks/cancel'.
+%%% State transitions emit `notifications/tasks/status' on the
+%%% session's SSE channel. The mode rule lives in the transports
+%%% (`barrel_mcp_http_engine:handle_async_tool_call/7',
+%%% `barrel_mcp_protocol:task_plan/2'), not here: this module is the
+%%% table and the lifecycle.
 %%%
 %%% Tasks live in a `protected' ETS table keyed by `TaskId', which is
 %%% crypto-random and so unique on its own. Who owns a task is a field
@@ -21,6 +26,17 @@
 %%%
 %%% A periodic sweep evicts terminal tasks (success / error /
 %%% cancelled) older than `?TASK_TTL'.
+%%%
+%%% == Sections, in file order ==
+%%%
+%%% <ul>
+%%%   <li>Public API: create, get, list, finish, fail, cancel,
+%%%       `set_worker/3', `await_input/5' for `input_required'.</li>
+%%%   <li>gen_server: every transition, the sweep, generation fencing
+%%%       so a late worker cannot revive an expired task.</li>
+%%%   <li>Internal: rendering per era (`ttl' versus `ttlMs'), the
+%%%       error object, expiry.</li>
+%%% </ul>
 %%% @end
 %%%-------------------------------------------------------------------
 -module(barrel_mcp_tasks).
@@ -132,6 +148,7 @@
 %% Public API
 %%====================================================================
 
+%% @doc Start the task table owner, registered as `barrel_mcp_tasks'.
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
@@ -169,6 +186,8 @@ lookup(Owner, TaskId) ->
         _ -> {error, not_found}
     end.
 
+%% @doc Every task an owner holds, rendered for the legacy era
+%% (`tasks/list' exists only there).
 -spec list(SessionId :: binary() | undefined, map()) -> {ok, [map()]}.
 list(SessionId, _Opts) ->
     Tasks = ets:foldl(
@@ -192,6 +211,9 @@ cancel(SessionId, TaskId) ->
 
 %% @doc Record the worker pid (and optional originating request id)
 %% on a running task so a later `tasks/cancel' can stop it.
+%% @doc Attach the worker to a task created before it, so cancel and
+%% expiry can reach the process; carries the request id for MRTR
+%% resumption.
 -spec set_worker(
     binary() | undefined,
     binary(),


### PR DESCRIPTION
Documentation only, no behaviour change.

- `guides/server-internals.md`: module map, supervision tree, process model of a request, request lifecycle per verb and era as hop lists, the tool-call mode table and the relay exchange, session fields with their writers, ETS tables and registered names, where to look and which tests pin each area.
- `guides/glossary.md`: the terms the code uses, each pointing at its module.
- The protocol-versions guide lists every era branch site by module; the authentication guide gains a Principals section; the tools guide documents `task_support` and the modes.
- The ten largest modules open with a section index, their process model and their state record; every export has a `@doc`.
- ex_doc extras, README and getting-started link the new pages. Two pre-existing edoc errors that made `rebar3 ex_doc` fail on main are fixed.

Checks: fmt, compile, lint, xref, dialyzer, eunit 577, CT 212 (19 skipped), doc snippet suite, `rebar3 ex_doc`.