### PR TITLE
Reference private functions without an arity in the docs

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -882,7 +882,7 @@ change anything that is owned per client: sessions, tasks,
 elicitations.
 
 Derivation: after a provider's `authenticate/2` succeeds,
-`barrel_mcp_auth:with_principal/3` asks the provider for the identity
+`barrel_mcp_auth:with_principal` asks the provider for the identity
 through its optional `principal/2` callback, and falls back to
 `barrel_mcp_auth:principal/2`, which derives it from the auth info
 map. The result is stored as `principal` in the auth info every
@@ -892,7 +892,7 @@ handler sees under `_auth`. `barrel_mcp_auth_none` yields
 Where it is enforced:
 
 - **Sessions**: a Streamable HTTP session is bound to the principal
-  that initialized it (`barrel_mcp_http_engine:lookup_session/5`),
+  that initialized it (`barrel_mcp_http_engine:lookup_session`),
   and every later POST, GET, DELETE and replay checks it
   (`owned_session/2`). The 2024-11-05 pair binds its endpoint the
   same way (`legacy_sse_open/3`, `legacy_session_of/2`). Another

--- a/guides/glossary.md
+++ b/guides/glossary.md
@@ -13,7 +13,7 @@ from the word to the code.
   `status`, `www_authenticate`, `server_url`, `protocol_version` and
   `dpop_nonce`. The handle answers with a new token or refuses.
 - **Channel**: the process a server-to-client request is written to.
-  For a session it is the `sse_pid` (`barrel_mcp_session:channel/2`);
+  For a session it is the `sse_pid` (`barrel_mcp_session:channel`);
   for a request answered on its own response stream it is the
   request process.
 - **CIMD (Client ID Metadata Document)**: an HTTPS URL used as the

--- a/guides/protocol-versions.md
+++ b/guides/protocol-versions.md
@@ -189,12 +189,12 @@ re-derives it.
 
 The fork per transport:
 
-- Streamable HTTP: `barrel_mcp_http_engine:stream_post_request/6`,
+- Streamable HTTP: `barrel_mcp_http_engine:stream_post_request`,
   after decode and before any session lookup, so a modern request
   never touches the session machinery.
 - The 2024-11-05 pair: always legacy
   (`legacy_transport_version/2`).
-- stdio: `barrel_mcp_stdio:bind_session/2` attaches the SSE channel
+- stdio: `barrel_mcp_stdio:bind_session` attaches the SSE channel
   to the session for the legacy era only.
 - Client: `barrel_mcp_client` chooses between `server/discover` and
   `initialize` from the requested version.

--- a/guides/server-internals.md
+++ b/guides/server-internals.md
@@ -61,7 +61,7 @@ barrel_mcp_sup                   one_for_one, 5 restarts / 10 s
 Listener names are `barrel_mcp_http_stream_listener` and
 `barrel_mcp_http_simple_listener`. When `barrel_mcp_listener_sup` is
 not running (the library embedded without its application), the
-listener is started unsupervised by `barrel_mcp_listener_sup:supervised_start/3`'s
+listener is started unsupervised by `barrel_mcp_listener_sup:supervised_start`'s
 fallback.
 
 `barrel_mcp_stdio` is not under the tree: `start/0` runs it
@@ -101,7 +101,7 @@ it spawns during a `tools/call`:
 | tool worker | `barrel_mcp_registry:run_tool/3` | `spawn` (no link) | `reply_to` in its Ctx: `{tool_result, ...}`, `{tool_error, ...}`, `{tool_failed, ...}`, `{tool_input_required, ...}` | after one message; killed on disconnect (`settle_disconnect/2`) or when a task cannot be created |
 | task relay | `barrel_mcp_task_relay:start/0` | `spawn_link` from the request process | its `target`: the request process, then the collector | `stop`, or the worker's `DOWN` once forwarded; unlinked before escalation |
 | task collector | `barrel_mcp_protocol:spawn_task_collector/3` | `spawn` | `barrel_mcp_tasks` (`finish`, `fail`, `cancel`) | first terminal message; monitors the worker; `?WORKER_HANDOFF_MS` without a worker fails the task |
-| legacy-SSE driver | `barrel_mcp_http_engine:legacy_answer/3` | `spawn` | `push_legacy/2` onto the session's stream | when `drive_async_plan/4` returns |
+| legacy-SSE driver | `barrel_mcp_http_engine:legacy_answer` | `spawn` | `push_legacy/2` onto the session's stream | when `drive_async_plan/4` returns |
 | stream watcher | `answer_on_stream/3` | `spawn_link` | kills the worker if the SSE stream dies | `done` |
 
 Under stdio the coordinator runs each request in a `spawn_monitor`
@@ -230,10 +230,10 @@ whether the client declared the tasks extension, and on the era:
 
 The rule is written twice, on purpose in two shapes:
 
-- HTTP, `barrel_mcp_http_engine:handle_async_tool_call/7`: the
+- HTTP, `barrel_mcp_http_engine:handle_async_tool_call`: the
   five-clause `case {Support, Enabled}` with the `when Modern` guard,
   because the engine writes the answer itself.
-- Every other transport, `barrel_mcp_protocol:task_plan/2` consumed
+- Every other transport, `barrel_mcp_protocol:task_plan` consumed
   by `drive_async_plan/4`, which picks `drive_inline_then_task/5`
   (modern) or `drive_as_task/4` (legacy).
 
@@ -275,9 +275,9 @@ on `initialize` (Streamable), `legacy_sse_open/3` (2024-11-05 pair),
 | --- | --- |
 | `id`, `created_at`, `client_info` | `create/1` |
 | `last_activity` | `handle_dispatch/6` on every legacy request |
-| `client_capabilities` | `barrel_mcp_protocol:initialize/3` |
+| `client_capabilities` | `barrel_mcp_protocol:initialize` |
 | `protocol_version` | `initialize/3`; `remember_version/2` and `maybe_capture_initialize_version/3` in the engine |
-| `sse_pid` | `stream_get_sse_session/5`, `sse_cleanup/2`, `legacy_sse_open/3`, `barrel_mcp_stdio:bind_session/2` (legacy era only) |
+| `sse_pid` | `stream_get_sse_session/5`, `sse_cleanup/2`, `legacy_sse_open/3`, `barrel_mcp_stdio:bind_session` (legacy era only) |
 | `sse_buffer`, `sse_buffer_max` | `record_sse_event` from the engine's SSE helpers; the max from `lookup_session/5` (`sse_buffer_size`, default 256) |
 | `log_level` | `logging/setLevel` handler |
 | `principal` | `lookup_session/5`, `legacy_sse_open/3` |

--- a/src/barrel_mcp_tasks.erl
+++ b/src/barrel_mcp_tasks.erl
@@ -9,8 +9,8 @@
 %%% enumerate via `tasks/list' (legacy), and abort via `tasks/cancel'.
 %%% State transitions emit `notifications/tasks/status' on the
 %%% session's SSE channel. The mode rule lives in the transports
-%%% (`barrel_mcp_http_engine:handle_async_tool_call/7',
-%%% `barrel_mcp_protocol:task_plan/2'), not here: this module is the
+%%% (`barrel_mcp_http_engine:handle_async_tool_call',
+%%% `barrel_mcp_protocol:task_plan'), not here: this module is the
 %%% table and the lifecycle.
 %%%
 %%% Tasks live in a `protected' ETS table keyed by `TaskId', which is


### PR DESCRIPTION
ex_doc auto-links `module:function/arity` and warns when the target is private. The internals guides name private functions on purpose; dropping the arity keeps the name greppable and the doc build silent.