### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.1] - 2026-08-30
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Add to your `rebar.config`:
 {deps, [
     {barrel_mcp,
         {git, "https://github.com/barrel-platform/barrel_mcp.git",
-              {tag, "v3.0.0"}}}
+              {tag, "v3.0.1"}}}
 ]}.
 ```
 

--- a/src/barrel_mcp.app.src
+++ b/src/barrel_mcp.app.src
@@ -1,6 +1,6 @@
 {application, barrel_mcp, [
     {description, "MCP Protocol Library for Erlang"},
-    {vsn, "3.0.0"},
+    {vsn, "3.0.1"},
     {registered, [
         barrel_mcp_registry,
         barrel_mcp_sup,
@@ -15,7 +15,7 @@
     {applications, [kernel, stdlib, crypto, h1, h2, hackney]},
     {env, [
         {server_name, <<"barrel">>},
-        {server_version, <<"3.0.0">>},
+        {server_version, <<"3.0.1">>},
         %% 30 minutes default
         {session_ttl, 1800000}
     ]},

--- a/src/barrel_mcp_client.erl
+++ b/src/barrel_mcp_client.erl
@@ -1520,7 +1520,7 @@ build_initialize_params(#data{spec = Spec}) ->
         Spec,
         #{
             <<"name">> => <<"barrel_mcp_client">>,
-            <<"version">> => <<"3.0.0">>
+            <<"version">> => <<"3.0.1">>
         }
     ),
     ClientInfo = normalize_keys(ClientInfo0),

--- a/test/barrel_mcp_conformance_client.erl
+++ b/test/barrel_mcp_conformance_client.erl
@@ -47,7 +47,7 @@ run() ->
     Spec = #{
         transport => {http, Url},
         protocol_version => Version,
-        client_info => #{name => <<"barrel_mcp-conformance">>, version => <<"3.0.0">>},
+        client_info => #{name => <<"barrel_mcp-conformance">>, version => <<"3.0.1">>},
         capabilities => #{
             roots => #{listChanged => true},
             sampling => #{},


### PR DESCRIPTION
h1 0.9, h2 0.12, hackney 4.7.4 and the ex_doc reference fix, on top of 3.0.0.